### PR TITLE
fix(desktop): bundle Codex OAuth auth

### DIFF
--- a/app/desktop/package.json
+++ b/app/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist-main/main.mjs",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && node scripts/verifyBundledCodexAuth.mjs",
     "rebuild-native": "electron-rebuild -v 43.1.0 --force -w better-sqlite3",
     "build:native": "cd native/sparkle-bridge && npm ci && npm run build",
     "predev": "node scripts/ensureDevNative.mjs",
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit",
     "generate-icon": "bash scripts/generate-icon.sh",
     "prepackage": "pnpm --filter @trade/web build && (test -f ../web/dist/index.html || (echo 'web/dist/index.html missing after build' && exit 1))",
-    "package": "tsdown && pnpm rebuild-native && pnpm build:native && electron-builder --mac dmg zip --arm64"
+    "package": "tsdown && node scripts/verifyBundledCodexAuth.mjs && pnpm rebuild-native && pnpm build:native && electron-builder --mac dmg zip --arm64"
   },
   "dependencies": {
     "better-sqlite3": "^12.11.1",

--- a/app/desktop/scripts/verifyBundledCodexAuth.mjs
+++ b/app/desktop/scripts/verifyBundledCodexAuth.mjs
@@ -1,0 +1,61 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const desktopDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const distDir = join(desktopDir, "dist-main");
+const entries = await readdir(distDir);
+
+let runtimeChunk;
+for (const entry of entries) {
+  if (!entry.endsWith(".mjs")) continue;
+  const filePath = join(distDir, entry);
+  const source = await readFile(filePath, "utf8");
+  if (source.includes("function initModelsRuntime(")) {
+    runtimeChunk = filePath;
+    break;
+  }
+}
+
+if (!runtimeChunk) {
+  throw new Error("桌面构建产物中找不到 modelsRuntime");
+}
+
+const runtimeModule = await import(pathToFileURL(runtimeChunk).href);
+const initModelsRuntime = Object.values(runtimeModule).find(
+  (value) => typeof value === "function" && value.name === "initModelsRuntime",
+);
+
+if (typeof initModelsRuntime !== "function") {
+  throw new Error("桌面构建产物没有导出 initModelsRuntime");
+}
+
+const accessToken = "bundled-codex-auth-smoke-token";
+const credentials = {
+  async read(provider) {
+    if (provider !== "openai-codex") return undefined;
+    return {
+      type: "oauth",
+      access: accessToken,
+      refresh: "bundled-codex-auth-smoke-refresh",
+      expires: Date.now() + 60_000,
+    };
+  },
+  async modify() {
+    return undefined;
+  },
+  async delete() {},
+};
+
+const models = initModelsRuntime(credentials);
+const model = models.getModels("openai-codex")[0];
+if (!model) {
+  throw new Error("桌面构建产物中没有 OpenAI Codex 模型");
+}
+
+const auth = await models.getAuth(model);
+if (auth?.auth.apiKey !== accessToken) {
+  throw new Error("桌面构建产物无法从 Codex OAuth 凭据生成请求认证");
+}
+
+console.log("桌面构建产物的 Codex OAuth 验证通过");

--- a/app/packages/core/src/ai/modelsRuntime.ts
+++ b/app/packages/core/src/ai/modelsRuntime.ts
@@ -1,6 +1,8 @@
-import type { AuthContext, CredentialStore } from "@earendil-works/pi-ai";
+import type { AuthContext, CredentialStore, MutableModels } from "@earendil-works/pi-ai";
+import { openaiCodexOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
-import type { MutableModels } from "@earendil-works/pi-ai";
+
+const CODEX_PROVIDER = "openai-codex";
 
 export const SINGLE_KEY_PROVIDERS: ReadonlySet<string> = new Set([
   "anthropic",
@@ -29,11 +31,46 @@ const isolatedAuthContext: AuthContext = {
 
 let singleton: MutableModels | null = null;
 
+function installStaticCodexOAuth(models: MutableModels): void {
+  const provider = models.getProvider(CODEX_PROVIDER);
+  const oauth = provider?.auth.oauth;
+  if (!provider || !oauth) {
+    throw new Error("modelsRuntime: openai-codex OAuth provider is unavailable");
+  }
+
+  // pi-ai 的内置 provider 会通过运行时动态 import 加载 OAuth 实现；桌面主进程
+  // 合并为单个构建产物后没有对应文件。应用只复用 codex CLI 登录态，因此在这里
+  // 静态绑定实际请求需要的凭据转换与刷新逻辑。
+  models.setProvider({
+    ...provider,
+    auth: {
+      ...provider.auth,
+      oauth: {
+        name: oauth.name,
+        async login() {
+          throw new Error("OpenAI Codex 登录由 codex CLI 管理，请先在终端完成登录");
+        },
+        async refresh(credential) {
+          return {
+            ...(await openaiCodexOAuthProvider.refreshToken(credential)),
+            type: "oauth" as const,
+          };
+        },
+        async toAuth(credential) {
+          return { apiKey: openaiCodexOAuthProvider.getApiKey(credential) };
+        },
+      },
+    },
+  });
+}
+
 export function initModelsRuntime(credentials: CredentialStore): MutableModels {
   if (singleton) {
     throw new Error("modelsRuntime: already initialized; call setModelsRuntimeForTests(null) first in tests");
   }
-  singleton = builtinModels({ credentials, authContext: isolatedAuthContext });
+  const models = builtinModels({ credentials, authContext: isolatedAuthContext });
+  installStaticCodexOAuth(models);
+  singleton = models;
   return singleton;
 }
 


### PR DESCRIPTION
## 修改内容

- 为 OpenAI Codex OAuth 凭据转换和令牌刷新注册可打包的静态实现
- 桌面构建与打包后自动运行 Codex OAuth 构建产物验证
- 防止分发版因缺少动态加载模块而出现 `OAuth auth derivation failed`

## 根因

设置页只需要读取 `~/.codex/auth.json`，所以能够显示“已登录”；真正发起请求时，`pi-ai` 会动态加载 `openai-codex.js`。该文件没有进入桌面分发包，导致认证转换在请求前失败。

## 验证

- Core 类型检查通过
- Desktop 类型检查通过
- Core：617 项测试通过，1 项跳过
- Desktop：206 项测试通过
- Desktop 构建及新增 OAuth 产物验证通过
- 使用 Electron 运行时直接验证生成的 0.6.0 `app.asar`，Codex `getAuth()` 成功