### PR TITLE
fix: stabilize AI analysis state and routing

### DIFF
--- a/app/desktop/src/ipc/symbolsIpc.ts
+++ b/app/desktop/src/ipc/symbolsIpc.ts
@@ -57,6 +57,11 @@ export class SymbolsIpc extends IpcService implements WrapEnvelope<SymbolsApi> {
   }
 
   @IpcMethod()
+  reassessStatus(input: Parameters<SymbolsApi["reassessStatus"]>[0]) {
+    return toEnvelope("symbols.reassessStatus", () => symbolsService.reassessStatus(input));
+  }
+
+  @IpcMethod()
   note(input: Parameters<SymbolsApi["note"]>[0]) {
     return toEnvelope("symbols.note", () => symbolsService.note(input));
   }

--- a/app/packages/core/src/ai/analyst.ts
+++ b/app/packages/core/src/ai/analyst.ts
@@ -164,7 +164,19 @@ export interface StartResult {
 }
 
 const analystRunLock = createRunLock();
+const analystRunStartedAt = new Map<string, string>();
 const lastEscalationStart = new Map<string, number>();
+
+export interface AnalystRunStatus {
+  running: boolean;
+  startedAt?: string;
+}
+
+export function analystRunStatus(symbol: string): AnalystRunStatus {
+  if (!analystRunLock.isLocked(symbol)) return { running: false };
+  const startedAt = analystRunStartedAt.get(symbol);
+  return { running: true, ...(startedAt ? { startedAt } : {}) };
+}
 
 export function escalationOnCooldown(symbol: string, now: number): boolean {
   for (const [key, ts] of lastEscalationStart) {
@@ -358,6 +370,11 @@ export function runAnalyst({ symbol, origin, deps }: RunAnalystInput): StartResu
 
   if (origin === "escalation") lastEscalationStart.set(symbol, now);
 
-  const done = executeAnalystRun(symbol, { ...deps, origin }).finally(() => analystRunLock.release(symbol));
+  analystRunStartedAt.set(symbol, new Date(now).toISOString());
+
+  const done = executeAnalystRun(symbol, { ...deps, origin }).finally(() => {
+    analystRunStartedAt.delete(symbol);
+    analystRunLock.release(symbol);
+  });
   return { started: true, done };
 }

--- a/app/packages/core/src/contract/symbols.ts
+++ b/app/packages/core/src/contract/symbols.ts
@@ -27,6 +27,7 @@ export interface NoteResult {
 }
 
 export type ReassessResult = { started: boolean; reason?: string };
+export type ReassessStatus = { running: boolean; startedAt?: string };
 
 export type DeepDiveStartResult = { started: true } | { started: false; reason: "busy" | "disabled" };
 
@@ -46,6 +47,7 @@ export interface SymbolsApi {
   journal(input: { sym: string }): Promise<JournalListRow[]>;
   journalEntry(input: { sym: string; name: string }): Promise<JournalEntry>;
   reassess(input: { sym: string }): Promise<ReassessResult>;
+  reassessStatus(input: { sym: string }): Promise<ReassessStatus>;
   note(input: { sym: string }): Promise<NoteResult>;
   deepDive(input: { sym: string }): Promise<DeepDiveStartResult>;
   deepDiveStatus(input: { sym: string }): Promise<DeepDiveState>;
@@ -63,6 +65,7 @@ export const symbolsRoutes = defineRoutes<SymbolsApi>("symbols", {
   journal: { method: "GET", path: "/:sym/journal" },
   journalEntry: { method: "GET", path: "/:sym/journal/:name" },
   reassess: { method: "POST", path: "/:sym/reassess" },
+  reassessStatus: { method: "GET", path: "/:sym/reassess/status" },
   note: { method: "GET", path: "/:sym/note", raw: "body" },
   deepDive: { method: "POST", path: "/:sym/deep-dive", raw: "body" },
   deepDiveStatus: { method: "GET", path: "/:sym/deep-dive/status", raw: "body" },

--- a/app/packages/core/src/modules/symbols/symbols.service.ts
+++ b/app/packages/core/src/modules/symbols/symbols.service.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import type { IntradayPrediction, RawBar, SymbolAnalysisRow } from "../../../../../shared/types.js";
-import { runAnalyst } from "../../ai/analyst.js";
+import { analystRunStatus, runAnalyst } from "../../ai/analyst.js";
 import { listCommentDates, listComments } from "../../ai/comments.js";
 import { deepDiveState, startDeepDive } from "../../ai/deepDive.js";
 import { aiConfig } from "../../ai/models.js";
@@ -164,6 +164,10 @@ export const symbolsService: SymbolsApi = {
     const result = runAnalyst({ symbol: sym, origin: "manual", deps: { model } });
     void result.done?.catch(() => {});
     return { started: result.started, ...(result.reason ? { reason: result.reason } : {}) };
+  },
+
+  async reassessStatus(input) {
+    return analystRunStatus(normalizeSymbol(input.sym));
   },
 
   async note(input) {

--- a/app/packages/core/test/analyst.test.ts
+++ b/app/packages/core/test/analyst.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { CockpitComment } from "../../../shared/types.js";
 import type { AiAgentFactory, AiAgentHandle } from "../src/ai/agentSession.js";
 import {
+  analystRunStatus,
   type AnalystDeps,
   buildAnalystSystemPrompt,
   buildJournalTool,
@@ -289,6 +290,29 @@ describe("buildJournalTool", () => {
 });
 
 describe("runAnalyst gating", () => {
+  it("exposes the active run until the analyst finishes", async () => {
+    const symbol = "STATUS.US";
+    const startedAt = "2026-07-14T02:03:04.000Z";
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { deps } = harness(async () => wait);
+
+    const run = runAnalyst({
+      symbol,
+      origin: "manual",
+      deps: { ...deps, now: () => Date.parse(startedAt) },
+    });
+
+    expect(run.started).toBe(true);
+    expect(analystRunStatus(symbol)).toEqual({ running: true, startedAt });
+
+    release();
+    await run.done;
+    expect(analystRunStatus(symbol)).toEqual({ running: false });
+  });
+
   it("blocks a second run for the same symbol while one is in flight", async () => {
     const symbol = "LOCK.US";
     const { deps } = harness(async () => {}, { hang: true });

--- a/app/server/src/modules/symbols/symbols.controller.ts
+++ b/app/server/src/modules/symbols/symbols.controller.ts
@@ -65,6 +65,12 @@ export class SymbolsController {
     return { ok: true, data };
   }
 
+  @Get("/:sym/reassess/status")
+  async getReassessStatus(@Param("sym") sym: string) {
+    const data = await symbolsService.reassessStatus({ sym });
+    return { ok: true, data };
+  }
+
   @Get("/:sym/note")
   async getNote(@Param("sym") sym: string) {
     return symbolsService.note({ sym });

--- a/app/server/test/analyst-route.test.ts
+++ b/app/server/test/analyst-route.test.ts
@@ -1,17 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const models = vi.hoisted(() => ({ aiConfig: vi.fn() }));
-const analyst = vi.hoisted(() => ({ runAnalyst: vi.fn() }));
+const analyst = vi.hoisted(() => ({ runAnalyst: vi.fn(), analystRunStatus: vi.fn() }));
 
 vi.mock("../../packages/core/src/ai/models.js", () => models);
 vi.mock("../../packages/core/src/ai/analyst.js", () => analyst);
 
 const { tsukiRequest } = await import("./helpers.js");
 
-describe("POST /:sym/reassess", () => {
+describe("analyst routes", () => {
   beforeEach(() => {
     models.aiConfig.mockReset();
     analyst.runAnalyst.mockReset();
+    analyst.analystRunStatus.mockReset();
   });
 
   it("returns started:false when the analyst layer is disabled", async () => {
@@ -37,5 +38,18 @@ describe("POST /:sym/reassess", () => {
     analyst.runAnalyst.mockReturnValue({ started: false, reason: "already running" });
     const res = await tsukiRequest("/api/symbols/MU/reassess", { method: "POST" });
     expect(await res.json()).toEqual({ ok: true, data: { started: false, reason: "already running" } });
+  });
+
+  it("returns the live run state for a normalized symbol", async () => {
+    analyst.analystRunStatus.mockReturnValue({ running: true, startedAt: "2026-07-14T02:03:04.000Z" });
+
+    const res = await tsukiRequest("/api/symbols/mu/reassess/status");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      data: { running: true, startedAt: "2026-07-14T02:03:04.000Z" },
+    });
+    expect(analyst.analystRunStatus).toHaveBeenCalledWith("MU.US");
   });
 });

--- a/app/web/src/PageRouter.tsx
+++ b/app/web/src/PageRouter.tsx
@@ -7,7 +7,7 @@ import { Home } from "./pages/Home";
 import { LogsPage } from "./pages/logViewer/LogsPage";
 import { SettingsPage } from "./pages/settings/SettingsPage";
 import { SymbolCockpit } from "./pages/SymbolCockpit";
-import { navigate, useRoute } from "./router";
+import { navigate, routePathname, useRoute } from "./router";
 import { ErrorBox } from "./ui";
 
 function Redirect({ to }: { to: string }) {
@@ -36,17 +36,18 @@ function ChartRedirect({ id }: { id: string }) {
 
 export function Router() {
   const route = useRoute();
+  const pathname = routePathname(route);
 
-  if (route === "/overview" || route === "/charts") {
+  if (pathname === "/overview" || pathname === "/charts") {
     return <Redirect to="/" />;
   }
-  const chartMatch = route.match(/^\/charts\/(.+)$/);
+  const chartMatch = pathname.match(/^\/charts\/(.+)$/);
   if (chartMatch) {
     return <ChartRedirect id={decodeURIComponent(chartMatch[1])} />;
   }
-  const symbolMatch = route.match(/^\/symbol\/(.+)$/);
+  const symbolMatch = pathname.match(/^\/symbol\/(.+)$/);
   if (symbolMatch) return <SymbolCockpit sym={decodeURIComponent(symbolMatch[1])} />;
-  if (route === "/settings") return <SettingsPage />;
-  if (route === "/logs") return <LogsPage />;
+  if (pathname === "/settings") return <SettingsPage />;
+  if (pathname === "/logs") return <LogsPage />;
   return <Home />;
 }

--- a/app/web/src/apiHooks.ts
+++ b/app/web/src/apiHooks.ts
@@ -14,6 +14,10 @@ export interface QueryState<T> {
   reload: () => void;
 }
 
+export interface QueryOptions {
+  cache?: boolean;
+}
+
 interface QueryInternalState<T> extends Omit<QueryState<T>, "reload"> {
   key: string | null;
 }
@@ -25,8 +29,8 @@ const failureFrom = (error: unknown): QueryFailure => ({
 
 const queryCache = new Map<string, unknown>();
 
-const initialState = <T>(key: string | null): QueryInternalState<T> => {
-  const cached = key !== null && queryCache.has(key);
+const initialState = <T>(key: string | null, useCache: boolean): QueryInternalState<T> => {
+  const cached = useCache && key !== null && queryCache.has(key);
   return {
     key,
     data: cached ? (queryCache.get(key!) as T) : null,
@@ -36,8 +40,9 @@ const initialState = <T>(key: string | null): QueryInternalState<T> => {
   };
 };
 
-export function useQuery<T>(key: string | null, fetch: () => Promise<T>): QueryState<T> {
-  const [state, setState] = useState<QueryInternalState<T>>(() => initialState<T>(key));
+export function useQuery<T>(key: string | null, fetch: () => Promise<T>, options: QueryOptions = {}): QueryState<T> {
+  const useCache = options.cache !== false;
+  const [state, setState] = useState<QueryInternalState<T>>(() => initialState<T>(key, useCache));
   const [version, setVersion] = useState(0);
   const reload = useCallback(() => setVersion((v) => v + 1), []);
   const fetchRef = useRef(fetch);
@@ -46,13 +51,13 @@ export function useQuery<T>(key: string | null, fetch: () => Promise<T>): QueryS
   useEffect(() => {
     let active = true;
 
-    setState(initialState<T>(key));
+    setState(initialState<T>(key, useCache));
     if (!key) return;
 
     fetchRef
       .current()
       .then((data) => {
-        queryCache.set(key, data);
+        if (useCache) queryCache.set(key, data);
         if (active) setState({ key, data, error: null, failure: null, loading: false });
       })
       .catch((error: unknown) => {
@@ -64,15 +69,21 @@ export function useQuery<T>(key: string | null, fetch: () => Promise<T>): QueryS
     return () => {
       active = false;
     };
-  }, [key, version]);
+  }, [key, useCache, version]);
 
-  const visibleState = state.key === key ? state : initialState<T>(key);
+  const visibleState = state.key === key ? state : initialState<T>(key, useCache);
   const { key: _key, ...queryState } = visibleState;
   return { ...queryState, reload };
 }
 
-export function usePollingQuery<T>(key: string | null, fetch: () => Promise<T>, ms: number): QueryState<T> {
-  const [state, setState] = useState<QueryInternalState<T>>(() => initialState<T>(key));
+export function usePollingQuery<T>(
+  key: string | null,
+  fetch: () => Promise<T>,
+  ms: number,
+  options: QueryOptions = {},
+): QueryState<T> {
+  const useCache = options.cache !== false;
+  const [state, setState] = useState<QueryInternalState<T>>(() => initialState<T>(key, useCache));
   const [version, setVersion] = useState(0);
   const reload = useCallback(() => setVersion((v) => v + 1), []);
   const fetchRef = useRef(fetch);
@@ -82,7 +93,7 @@ export function usePollingQuery<T>(key: string | null, fetch: () => Promise<T>, 
     let active = true;
     let inFlight = false;
 
-    setState(initialState<T>(key));
+    setState(initialState<T>(key, useCache));
     if (!key) return;
 
     const load = () => {
@@ -92,7 +103,7 @@ export function usePollingQuery<T>(key: string | null, fetch: () => Promise<T>, 
       fetchRef
         .current()
         .then((data) => {
-          queryCache.set(key, data);
+          if (useCache) queryCache.set(key, data);
           if (active) setState({ key, data, error: null, failure: null, loading: false });
         })
         .catch((error: unknown) => {
@@ -111,9 +122,9 @@ export function usePollingQuery<T>(key: string | null, fetch: () => Promise<T>, 
       active = false;
       window.clearInterval(timer);
     };
-  }, [key, ms, version]);
+  }, [key, ms, useCache, version]);
 
-  const visibleState = state.key === key ? state : initialState<T>(key);
+  const visibleState = state.key === key ? state : initialState<T>(key, useCache);
   const { key: _key, ...queryState } = visibleState;
   return { ...queryState, reload };
 }

--- a/app/web/src/client/http.test.ts
+++ b/app/web/src/client/http.test.ts
@@ -59,6 +59,19 @@ describe("createHttpClient", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/api/ai/providers/lobehub/account");
   });
 
+  it("reads the current AI analysis run state from the symbol status route", async () => {
+    const fetchMock = vi.fn(async (_url?: string, _init?: RequestInit) =>
+      jsonResponse({ ok: true, data: { running: true, startedAt: "2026-07-14T02:03:04.000Z" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createHttpClient(allRoutes);
+
+    const status = await client.symbols.reassessStatus({ sym: "MU" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/symbols/MU/reassess/status");
+    expect(status).toEqual({ running: true, startedAt: "2026-07-14T02:03:04.000Z" });
+  });
+
   it("reassembles {data, meta} for withMeta routes", async () => {
     const fetchMock = vi.fn(async (_url?: string, _init?: RequestInit) => jsonResponse({ ok: true, data: { id: "x" }, meta: { created: true } }));
     vi.stubGlobal("fetch", fetchMock);

--- a/app/web/src/pages/cockpit/GenerateAnalysis.tsx
+++ b/app/web/src/pages/cockpit/GenerateAnalysis.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import type { ReassessStatus } from "../../../../packages/core/src/contract/symbols.js";
 import type { ChartDoc } from "../../../../shared/types";
 import { usePollingQuery } from "../../apiHooks";
 import { client } from "../../client";
@@ -6,28 +7,35 @@ import { Button, Spinner } from "../../ui";
 import { REASON_TEXT, useReassessSymbol } from "./useReassessSymbol";
 
 const POLL_MS = 5_000;
-const TIMEOUT_MS = 10 * 60_000;
 
 export function GenerateAnalysis({ sym }: { sym: string }) {
-  const [running, setRunning] = useState(false);
+  const [optimisticStartedAt, setOptimisticStartedAt] = useState<number | null>(null);
   const [hint, setHint] = useState<string | null>(null);
-  const startedAtRef = useRef(0);
   const { pending, reassess } = useReassessSymbol(sym);
+  const statusKey = `symbols.reassessStatus:${sym}`;
+  const { data: status, loading: statusLoading, reload: reloadStatus } = usePollingQuery<ReassessStatus>(
+    statusKey,
+    () => client.symbols.reassessStatus({ sym }),
+    POLL_MS,
+    { cache: false },
+  );
+  const running = Boolean(status?.running || optimisticStartedAt);
   const latestKey = running ? `symbols.latest:${sym}` : null;
   const { data: latestDoc } = usePollingQuery<ChartDoc>(latestKey, () => client.symbols.latest({ sym }), POLL_MS);
 
   useEffect(() => {
-    if (!running) return;
-    const timer = window.setTimeout(() => {
-      setRunning(false);
-      setHint("等待超时——分析可能失败了，稍后刷新页面看看");
-    }, Math.max(0, TIMEOUT_MS - (Date.now() - startedAtRef.current)));
-    return () => window.clearTimeout(timer);
-  }, [running]);
+    setOptimisticStartedAt(null);
+    setHint(null);
+  }, [sym]);
+
+  useEffect(() => {
+    if (!status) return;
+    setOptimisticStartedAt(null);
+  }, [status]);
 
   useEffect(() => {
     if (!latestDoc) return;
-    setRunning(false);
+    setOptimisticStartedAt(null);
   }, [latestDoc]);
 
   const start = async () => {
@@ -38,19 +46,26 @@ export function GenerateAnalysis({ sym }: { sym: string }) {
       return;
     }
     if (result.data.started) {
-      startedAtRef.current = Date.now();
-      setRunning(true);
+      setOptimisticStartedAt(Date.now());
+      reloadStatus();
     } else {
       const reason = result.data.reason ?? "";
-      setHint(REASON_TEXT[reason] ?? (reason || "未能启动分析"));
+      if (reason === "already running") {
+        setOptimisticStartedAt(Date.now());
+        reloadStatus();
+      } else {
+        setHint(REASON_TEXT[reason] ?? (reason || "未能启动分析"));
+      }
     }
   };
 
+  const checking = statusLoading && !status && !optimisticStartedAt;
+
   return (
     <div className="ai-reassess">
-      <Button onClick={start} disabled={pending || running}>
-        {running && <Spinner />}
-        {running ? "AI 分析中，完成后自动打开…" : "AI 生成分析"}
+      <Button onClick={start} disabled={pending || running || checking}>
+        {(running || checking) && <Spinner />}
+        {checking ? "正在确认分析状态…" : running ? "AI 分析中，完成后自动打开…" : "AI 生成分析"}
       </Button>
       {hint && <span className="ai-hint">{hint}</span>}
     </div>

--- a/app/web/src/router.test.ts
+++ b/app/web/src/router.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __setActiveRouteStore, createMemoryRouteStore, navigate } from "./router.js";
+import { __setActiveRouteStore, createMemoryRouteStore, navigate, routePathname } from "./router.js";
 
 afterEach(() => {
   __setActiveRouteStore(null);
@@ -44,6 +44,16 @@ describe("createMemoryRouteStore", () => {
     unsubscribe();
     store.push("/a");
     expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("routePathname", () => {
+  it("keeps analysis query parameters out of the symbol route", () => {
+    expect(routePathname("/symbol/DRAM.US?analysis=2026-07-13-dram-intraday")).toBe("/symbol/DRAM.US");
+  });
+
+  it("preserves percent-encoded question marks inside path segments", () => {
+    expect(routePathname("/charts/chart%3Fid?view=compact")).toBe("/charts/chart%3Fid");
   });
 });
 

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -77,6 +77,12 @@ export function useRoute(): string {
   return route;
 }
 
+export function routePathname(route: string): string {
+  const queryIndex = route.indexOf("?");
+  const pathname = queryIndex === -1 ? route : route.slice(0, queryIndex);
+  return pathname || "/";
+}
+
 export function navigate(route: string, options: { replace?: boolean } = {}): void {
   const store = currentStore();
   if (route === store.getRoute()) return;


### PR DESCRIPTION
## 修改内容

- 新增 AI 分析运行状态查询接口，并同时接入服务端与桌面端 IPC。
- 前端轮询真实运行状态，页面刷新后仍能继续显示分析进度。
- 允许状态查询跳过本地缓存，避免展示过期结果。
- 路由匹配只读取 pathname，防止 `?analysis=...` 被误当作股票代码。
- 增加运行状态、HTTP 路由与查询参数路由的回归测试。

## 根因

AI 分析进度此前只保存在当前 React 组件状态中，刷新页面后会丢失。同时，页面路由使用包含查询参数的完整字符串匹配 `/symbol/:sym`，导致历史分析链接把 `?analysis=...` 一并传给股票代码校验。

## 影响

分析任务运行期间刷新页面后，界面能够从服务端恢复真实状态；打开固定历史分析的链接时，股票代码保持为纯 ticker，不再触发 `invalid symbol`。

## 验证

- `cd app && pnpm test`：1,199 项通过，1 项跳过。
- `cd app && pnpm typecheck`：通过。
- `cd app/web && pnpm build`：通过。
- `git diff --check`：通过。