### PR TITLE
feat(bench): abstain rate, winner R, difficulty tiers, agreement matrix

### DIFF
--- a/app/packages/bench/src/report/render.ts
+++ b/app/packages/bench/src/report/render.ts
@@ -1,9 +1,10 @@
 import type { RunConfig } from "../schema/runConfig.js";
 import type { ReportSummary } from "../schema/reportSummary.js";
+import type { AgreementMatrix, AgreementPair, DifficultyTiers, QuestionDifficultyEntry } from "../score/analysis.js";
 import type { CellVerdict } from "../score/cell.js";
 import type { ModelAggregate } from "../score/aggregate.js";
 import type { Scores } from "../schema/scores.js";
-import { escapeCell, fmtCostUsd, fmtCount, fmtDurationMs, fmtRate, fmtScore } from "./format.js";
+import { DASH, escapeCell, fmtCostUsd, fmtCount, fmtDurationMs, fmtRate, fmtScore } from "./format.js";
 import { renderTable } from "./table.js";
 
 export interface ReportConfigSnapshot {
@@ -77,6 +78,8 @@ function renderLeaderboard(models: ModelAggregate[]): string[] {
     "效率分",
     "胜率",
     "期望收益",
+    "赢单平均盈亏比",
+    "观望率",
     "观望正确率",
     "抗噪分",
     "一致性",
@@ -94,6 +97,8 @@ function renderLeaderboard(models: ModelAggregate[]): string[] {
     fmtScore(m.efficiency),
     fmtRate(m.winRate),
     fmtScore(m.expectancy),
+    fmtScore(m.avgWinnerR),
+    fmtRate(m.abstainRate),
     fmtRate(m.neutralAccuracy),
     fmtScore(m.noiseDelta),
     fmtScore(m.consistency),
@@ -133,6 +138,60 @@ function renderLayeredBoard(models: ModelAggregate[]): string[] {
     ...renderSplitTable("按市场状态", models, "regimes", REGIME_LABEL),
     ...renderSplitTable("按模式", models, "modes", MODE_LABEL),
   ];
+}
+
+function renderDifficultyList(title: string, entries: QuestionDifficultyEntry[]): string[] {
+  const lines = [`### ${title}`, ""];
+  if (entries.length === 0) {
+    lines.push("无数据。", "");
+    return lines;
+  }
+  for (const entry of entries) {
+    const nLabel = entry.nModels === 1 ? "n=1" : `n=${entry.nModels}`;
+    lines.push(`- ${escapeCell(entry.questionId)}：${nLabel}，均分 ${fmtScore(entry.meanScore)}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function renderDifficultyTiers(tiers: DifficultyTiers): string[] {
+  return [
+    "## 题目难度分级",
+    "",
+    ...renderDifficultyList("全对题", tiers.allCorrect),
+    ...renderDifficultyList("全错题", tiers.allWrong),
+    ...renderDifficultyList("分歧题", tiers.split),
+    "> 全错题可能是陷阱题，也可能是出题本身有问题，需要人工复核，不要直接当作模型判断力差的证据。",
+  ];
+}
+
+function formatAgreementCell(pair: AgreementPair | undefined): string {
+  if (!pair) return DASH;
+  const suffix = pair.sharedCount < 20 ? ` (${pair.sharedCount})` : "";
+  if (pair.sharedCount < 5 || pair.agreementRate == null) return `${DASH}${suffix}`;
+  return `${fmtRate(pair.agreementRate)}${suffix}`;
+}
+
+function renderAgreementMatrix(matrix: AgreementMatrix): string[] {
+  const lines = ["## 模型同质化矩阵", ""];
+  if (matrix.models.length < 2) {
+    lines.push("参与比较的模型不足两个，无法计算。");
+    return lines;
+  }
+
+  const pairMap = new Map<string, AgreementPair>();
+  for (const pair of matrix.pairs) pairMap.set(`${pair.a}|${pair.b}`, pair);
+
+  const headers = ["model", ...matrix.models.map(escapeCell)];
+  const rows = matrix.models.map((rowModel) => [
+    modelCell(rowModel),
+    ...matrix.models.map((colModel) => {
+      if (rowModel === colModel) return DASH;
+      const key = rowModel < colModel ? `${rowModel}|${colModel}` : `${colModel}|${rowModel}`;
+      return formatAgreementCell(pairMap.get(key));
+    }),
+  ]);
+  return [...lines, ...renderTable(headers, rows)];
 }
 
 function sortCellsForDrilldown(cells: CellVerdict[]): CellVerdict[] {
@@ -178,7 +237,14 @@ function renderDrilldown(cells: CellVerdict[]): string[] {
 }
 
 function buildSummary(scores: Scores, models: ModelAggregate[], generatedAt: string): ReportSummary {
-  const ranking = models.map((m) => ({ model: m.model, total: m.total, judgment: m.judgment, efficiency: m.efficiency }));
+  const ranking = models.map((m) => ({
+    model: m.model,
+    total: m.total,
+    judgment: m.judgment,
+    efficiency: m.efficiency,
+    abstainRate: m.abstainRate,
+    avgWinnerR: m.avgWinnerR,
+  }));
   const buyHold = scores.models.find((m) => m.model === "baseline/buy-hold");
   const modelsBeatingBuyHold = buyHold
     ? models
@@ -210,6 +276,10 @@ export function renderReport(
     ...renderLeaderboard(models),
     "",
     ...renderLayeredBoard(models),
+    "",
+    ...renderDifficultyTiers(scores.analysis.difficultyTiers),
+    "",
+    ...renderAgreementMatrix(scores.analysis.agreementMatrix),
     "",
     ...renderDrilldown(scores.cells),
   ];

--- a/app/packages/bench/src/schema/reportSummary.ts
+++ b/app/packages/bench/src/schema/reportSummary.ts
@@ -6,6 +6,8 @@ const rankingEntrySchema = Type.Object(
     total: Type.Number(),
     judgment: Type.Number(),
     efficiency: Type.Union([Type.Number(), Type.Null()]),
+    abstainRate: Type.Number(),
+    avgWinnerR: Type.Union([Type.Number(), Type.Null()]),
   },
   { additionalProperties: false },
 );

--- a/app/packages/bench/src/schema/scores.ts
+++ b/app/packages/bench/src/schema/scores.ts
@@ -55,6 +55,7 @@ const judgmentSummarySchema = Type.Object(
     expectancyNorm: Type.Number(),
     neutralAccuracy: Type.Number(),
     judgment: Type.Number(),
+    abstainRate: Type.Number(),
   },
   { additionalProperties: false },
 );
@@ -68,6 +69,7 @@ const modelAggregateSchema = Type.Object(
     expectancyNorm: Type.Number(),
     neutralAccuracy: Type.Number(),
     judgment: Type.Number(),
+    abstainRate: Type.Number(),
     noFillRate: Type.Number(),
     formatViolationRate: Type.Number(),
     timeoutRate: Type.Number(),
@@ -84,9 +86,54 @@ const modelAggregateSchema = Type.Object(
     ),
     noiseDelta: Type.Union([Type.Number(), Type.Null()]),
     consistency: Type.Number(),
+    avgWinnerR: Type.Union([Type.Number(), Type.Null()]),
     modes: Type.Record(Type.String(), judgmentSummarySchema),
     layers: Type.Record(Type.String(), judgmentSummarySchema),
     regimes: Type.Record(Type.String(), judgmentSummarySchema),
+  },
+  { additionalProperties: false },
+);
+
+const questionDifficultyEntrySchema = Type.Object(
+  {
+    questionId: Type.String(),
+    nModels: Type.Number(),
+    meanScore: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const difficultyTiersSchema = Type.Object(
+  {
+    allCorrect: Type.Array(questionDifficultyEntrySchema),
+    allWrong: Type.Array(questionDifficultyEntrySchema),
+    split: Type.Array(questionDifficultyEntrySchema),
+  },
+  { additionalProperties: false },
+);
+
+const agreementPairSchema = Type.Object(
+  {
+    a: Type.String(),
+    b: Type.String(),
+    sharedCount: Type.Number(),
+    agreementRate: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const agreementMatrixSchema = Type.Object(
+  {
+    models: Type.Array(Type.String()),
+    pairs: Type.Array(agreementPairSchema),
+  },
+  { additionalProperties: false },
+);
+
+const analysisSchema = Type.Object(
+  {
+    difficultyTiers: difficultyTiersSchema,
+    agreementMatrix: agreementMatrixSchema,
   },
   { additionalProperties: false },
 );
@@ -98,6 +145,7 @@ export const scoresSchema = Type.Object(
     weights: weightsSchema,
     cells: Type.Array(cellVerdictSchema),
     models: Type.Array(modelAggregateSchema),
+    analysis: analysisSchema,
   },
   { additionalProperties: false },
 );

--- a/app/packages/bench/src/score/aggregate.ts
+++ b/app/packages/bench/src/score/aggregate.ts
@@ -9,6 +9,7 @@ export interface JudgmentSummary {
   expectancyNorm: number;
   neutralAccuracy: number;
   judgment: number;
+  abstainRate: number;
 }
 
 export interface ToolCallStats {
@@ -32,6 +33,7 @@ export interface ModelAggregate extends JudgmentSummary {
   toolCalls: ToolCallStats;
   noiseDelta: number | null;
   consistency: number;
+  avgWinnerR: number | null;
   modes: Record<string, JudgmentSummary>;
   layers: Record<string, JudgmentSummary>;
   regimes: Record<string, JudgmentSummary>;
@@ -108,11 +110,19 @@ export function judgmentSummary(cells: CellVerdict[], neutralFallback: number): 
   const expectancyNorm = clamp((expectancy + 1) / 3, 0, 1);
   const neutralAccuracy = neutralTotal > 0 ? neutralCorrect / neutralTotal : neutralFallback;
   const judgment = 0.4 * winRate + 0.4 * expectancyNorm + 0.2 * neutralAccuracy;
+  const scored = cells.filter((c) => c.outcome !== "api_error");
+  const abstainRate = scored.length > 0 ? neutralTotal / scored.length : 0;
 
-  return { cellCount: cells.length, winRate, expectancy, expectancyNorm, neutralAccuracy, judgment };
+  return { cellCount: cells.length, winRate, expectancy, expectancyNorm, neutralAccuracy, judgment, abstainRate };
 }
 
-function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+function avgWinnerROf(cells: CellVerdict[]): number | null {
+  const wins = cells.filter((c) => c.outcome === "win");
+  if (wins.length === 0) return null;
+  return wins.reduce((acc, c) => acc + (c.score ?? 0), 0) / wins.length;
+}
+
+export function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
   const map = new Map<string, T[]>();
   for (const item of items) {
     const bucket = map.get(key(item));
@@ -174,7 +184,7 @@ interface ModelDraft {
   rawNeutral: number | null;
 }
 
-function isReferenceModel(model: string): boolean {
+export function isReferenceModel(model: string): boolean {
   return model.startsWith("baseline/") || model.startsWith("gold/");
 }
 
@@ -236,6 +246,7 @@ export function aggregate(cells: CellVerdict[], weights: RunConfig["weights"]): 
       },
       noiseDelta: noiseDeltaOf(draft.cells, neutralMedian),
       consistency: consistencyOf(draft.cells),
+      avgWinnerR: avgWinnerROf(draft.cells),
       modes: summarizeGroups(draft.cells, (c) => c.mode, neutralMedian),
       layers: summarizeGroups(draft.cells, (c) => c.layer, neutralMedian),
       regimes: summarizeGroups(draft.cells, (c) => c.regime, neutralMedian),

--- a/app/packages/bench/src/score/analysis.ts
+++ b/app/packages/bench/src/score/analysis.ts
@@ -1,0 +1,148 @@
+import { groupBy, isReferenceModel } from "./aggregate.js";
+import type { CellVerdict } from "./cell.js";
+
+export interface QuestionDifficultyEntry {
+  questionId: string;
+  nModels: number;
+  meanScore: number | null;
+}
+
+export interface DifficultyTiers {
+  allCorrect: QuestionDifficultyEntry[];
+  allWrong: QuestionDifficultyEntry[];
+  split: QuestionDifficultyEntry[];
+}
+
+export interface AgreementPair {
+  a: string;
+  b: string;
+  sharedCount: number;
+  agreementRate: number | null;
+}
+
+export interface AgreementMatrix {
+  models: string[];
+  pairs: AgreementPair[];
+}
+
+export interface Analysis {
+  difficultyTiers: DifficultyTiers;
+  agreementMatrix: AgreementMatrix;
+}
+
+function competitorCellsOf(cells: CellVerdict[]): CellVerdict[] {
+  return cells.filter((c) => !isReferenceModel(c.model));
+}
+
+function modelQuestionCorrect(cells: CellVerdict[]): boolean | null {
+  const answered = cells.filter((c) => c.outcome !== "api_error");
+  if (answered.length === 0) return null;
+  const correctFlags = answered.map((c) =>
+    c.direction === "neutral" ? c.outcome === "neutral_correct" : c.score != null && c.score > 0,
+  );
+  const correctCount = correctFlags.filter(Boolean).length;
+  return correctCount * 2 > correctFlags.length;
+}
+
+export function difficultyTiersOf(cells: CellVerdict[]): DifficultyTiers {
+  const byQuestion = groupBy(competitorCellsOf(cells), (c) => c.questionId);
+  const allCorrect: QuestionDifficultyEntry[] = [];
+  const allWrong: QuestionDifficultyEntry[] = [];
+  const split: QuestionDifficultyEntry[] = [];
+
+  for (const [questionId, qCells] of byQuestion) {
+    const byModel = groupBy(qCells, (c) => c.model);
+    const verdicts: boolean[] = [];
+    for (const modelCells of byModel.values()) {
+      const verdict = modelQuestionCorrect(modelCells);
+      if (verdict != null) verdicts.push(verdict);
+    }
+    if (verdicts.length === 0) continue;
+
+    const scores = qCells.map((c) => c.score).filter((s): s is number => s != null);
+    const meanScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+    const entry: QuestionDifficultyEntry = { questionId, nModels: verdicts.length, meanScore };
+
+    if (verdicts.every((v) => v)) allCorrect.push(entry);
+    else if (verdicts.every((v) => !v)) allWrong.push(entry);
+    else split.push(entry);
+  }
+
+  const byId = (a: QuestionDifficultyEntry, b: QuestionDifficultyEntry) => a.questionId.localeCompare(b.questionId);
+  return {
+    allCorrect: allCorrect.sort(byId),
+    allWrong: allWrong.sort(byId),
+    split: split.sort(byId),
+  };
+}
+
+type MajorityDirection = "long" | "short" | "neutral" | "tie";
+
+function majorityDirection(cells: CellVerdict[]): MajorityDirection | null {
+  const directions = cells.map((c) => c.direction).filter((d): d is "long" | "short" | "neutral" => d != null);
+  if (directions.length === 0) return null;
+
+  const counts = new Map<string, number>();
+  for (const direction of directions) counts.set(direction, (counts.get(direction) ?? 0) + 1);
+
+  let best: string | null = null;
+  let bestCount = 0;
+  let tie = false;
+  for (const [direction, count] of counts) {
+    if (count > bestCount) {
+      best = direction;
+      bestCount = count;
+      tie = false;
+    } else if (count === bestCount) {
+      tie = true;
+    }
+  }
+  return tie ? "tie" : (best as MajorityDirection);
+}
+
+export function agreementMatrixOf(cells: CellVerdict[]): AgreementMatrix {
+  const competitorCells = competitorCellsOf(cells);
+  const models = [...new Set(competitorCells.map((c) => c.model))].sort();
+
+  const unitsByModel = new Map<string, Map<string, MajorityDirection>>();
+  for (const model of models) {
+    const modelCells = competitorCells.filter((c) => c.model === model);
+    const byUnit = groupBy(modelCells, (c) => `${c.questionId}|${c.mode}`);
+    const units = new Map<string, MajorityDirection>();
+    for (const [unit, unitCells] of byUnit) {
+      const direction = majorityDirection(unitCells);
+      if (direction != null) units.set(unit, direction);
+    }
+    unitsByModel.set(model, units);
+  }
+
+  const pairs: AgreementPair[] = [];
+  for (let i = 0; i < models.length; i++) {
+    for (let j = i + 1; j < models.length; j++) {
+      const a = models[i];
+      const b = models[j];
+      const unitsA = unitsByModel.get(a) ?? new Map();
+      const unitsB = unitsByModel.get(b) ?? new Map();
+      const sharedUnits = [...unitsA.keys()].filter((unit) => unitsB.has(unit));
+      const sharedCount = sharedUnits.length;
+
+      let agreementRate: number | null = null;
+      if (sharedCount >= 5) {
+        const agreeCount = sharedUnits.filter((unit) => {
+          const da = unitsA.get(unit);
+          const db = unitsB.get(unit);
+          return da !== "tie" && db !== "tie" && da === db;
+        }).length;
+        agreementRate = agreeCount / sharedCount;
+      }
+
+      pairs.push({ a, b, sharedCount, agreementRate });
+    }
+  }
+
+  return { models, pairs };
+}
+
+export function computeAnalysis(cells: CellVerdict[]): Analysis {
+  return { difficultyTiers: difficultyTiersOf(cells), agreementMatrix: agreementMatrixOf(cells) };
+}

--- a/app/packages/bench/src/score/score.ts
+++ b/app/packages/bench/src/score/score.ts
@@ -6,6 +6,7 @@ import type { Question } from "../schema/question.js";
 import { RUN_CONFIG_DEFAULTS, type RunConfig } from "../schema/runConfig.js";
 import { type Scores, scoresSchema } from "../schema/scores.js";
 import { aggregate } from "./aggregate.js";
+import { computeAnalysis } from "./analysis.js";
 import { scoreCell } from "./cell.js";
 import { loadPredictions } from "./predictions.js";
 
@@ -53,7 +54,8 @@ export async function runScore(options: RunScoreOptions): Promise<Scores> {
   }
 
   const models = aggregate(cells, weights);
-  const scores: Scores = { runId: options.runId, datasetVersion: options.datasetVersion, weights, cells, models };
+  const analysis = computeAnalysis(cells);
+  const scores: Scores = { runId: options.runId, datasetVersion: options.datasetVersion, weights, cells, models, analysis };
 
   if (!Value.Check(scoresSchema, scores)) {
     const first = Value.Errors(scoresSchema, scores)[0];

--- a/app/packages/bench/test/report/render.test.ts
+++ b/app/packages/bench/test/report/render.test.ts
@@ -2,6 +2,8 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { renderReport } from "../../src/report/render.js";
 import { aggregate } from "../../src/score/aggregate.js";
+import { computeAnalysis } from "../../src/score/analysis.js";
+import type { CellVerdict } from "../../src/score/cell.js";
 import { reportSummarySchema } from "../../src/schema/reportSummary.js";
 import { RUN_CONFIG_DEFAULTS } from "../../src/schema/runConfig.js";
 import type { Scores } from "../../src/schema/scores.js";
@@ -9,6 +11,11 @@ import { mkCell } from "../score/helpers.js";
 
 const WEIGHTS = RUN_CONFIG_DEFAULTS.weights;
 const FIXED_NOW = () => new Date("2026-07-17T12:00:00Z");
+
+function buildScoresFrom(runId: string, datasetVersion: string, cells: CellVerdict[]): Scores {
+  const models = aggregate(cells, WEIGHTS);
+  return { runId, datasetVersion, weights: WEIGHTS, cells, models, analysis: computeAnalysis(cells) };
+}
 
 function buildScores(): Scores {
   const cells = [
@@ -96,8 +103,7 @@ function buildScores(): Scores {
       r: 1,
     }),
   ];
-  const models = aggregate(cells, WEIGHTS);
-  return { runId: "run-test-01", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+  return buildScoresFrom("run-test-01", "v1", cells);
 }
 
 describe("renderReport", () => {
@@ -131,11 +137,18 @@ describe("renderReport", () => {
     expect(markdown).toContain("- 重复次数：1");
   });
 
-  it("renders 总榜 with 15 columns and rank order desc by total", () => {
+  it("renders 总榜 with 17 columns and rank order desc by total", () => {
     const headerIdx = lines.findIndex((l) => l.startsWith("| 排名 |"));
     expect(headerIdx).toBeGreaterThan(-1);
-    const headerCells = lines[headerIdx].split("|").filter((c) => c.trim().length > 0);
-    expect(headerCells).toHaveLength(15);
+    const headerCells = lines[headerIdx]
+      .split("|")
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+    expect(headerCells).toHaveLength(17);
+    expect(headerCells[6]).toBe("期望收益");
+    expect(headerCells[7]).toBe("赢单平均盈亏比");
+    expect(headerCells[8]).toBe("观望率");
+    expect(headerCells[9]).toBe("观望正确率");
 
     const dataRows = lines.slice(headerIdx + 2, headerIdx + 2 + scores.models.length);
     const totals = dataRows.map((row) => Number(row.split("|")[3].trim()));
@@ -157,6 +170,20 @@ describe("renderReport", () => {
     expect(markdown).toContain("下跌段");
     expect(markdown).toContain("盲盘");
     expect(markdown).toContain("实盘");
+  });
+
+  it("renders 题目难度分级 with all three tier lists", () => {
+    expect(markdown).toContain("## 题目难度分级");
+    expect(markdown).toContain("### 全对题");
+    expect(markdown).toContain("### 全错题");
+    expect(markdown).toContain("### 分歧题");
+    expect(markdown).toContain("人工复核");
+  });
+
+  it("renders 模型同质化矩阵 as a GFM table", () => {
+    expect(markdown).toContain("## 模型同质化矩阵");
+    const headerIdx2 = lines.findIndex((l) => l.startsWith("| model |") && l.includes("openai/gpt-5"));
+    expect(headerIdx2).toBeGreaterThan(-1);
   });
 
   it("renders 单题钻取 with one subsection per question and a trace link", () => {
@@ -209,13 +236,19 @@ describe("renderReport", () => {
     expect(summary.baselineComparison.modelsBeatingBuyHold).toContain("anthropic/claude");
     expect(summary.baselineComparison.modelsBeatingBuyHold).not.toContain("baseline/buy-hold");
   });
+
+  it("summary ranking entries carry abstainRate and avgWinnerR", () => {
+    for (const entry of summary.ranking) {
+      expect(typeof entry.abstainRate).toBe("number");
+      expect(entry.avgWinnerR === null || typeof entry.avgWinnerR === "number").toBe(true);
+    }
+  });
 });
 
 describe("renderReport trace links", () => {
   it("renders — instead of a dead link when a cell has no stored traceRef", () => {
     const cells = [mkCell({ model: "baseline/buy-hold", questionId: "q1", outcome: "loss", score: -1, r: 1, traceRef: null })];
-    const models = aggregate(cells, WEIGHTS);
-    const scores: Scores = { runId: "run-tr", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-tr", "v1", cells);
     const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
     const lines = markdown.split("\n");
     const idx = lines.indexOf("### q1");
@@ -228,8 +261,7 @@ describe("renderReport trace links", () => {
 
   it("uses the cell's stored traceRef verbatim for the drilldown link", () => {
     const cells = [mkCell({ model: "x/y", questionId: "q1", outcome: "win", score: 1, r: 1, traceRef: "custom/path.trace.jsonl" })];
-    const models = aggregate(cells, WEIGHTS);
-    const scores: Scores = { runId: "run-tr2", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-tr2", "v1", cells);
     const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
     expect(markdown).toContain("[trace](custom/path.trace.jsonl)");
   });
@@ -238,8 +270,7 @@ describe("renderReport trace links", () => {
 describe("renderReport escaping and determinism", () => {
   it("escapes raw pipes in model names", () => {
     const cells = [mkCell({ model: "weird|model", questionId: "q1", outcome: "win", score: 1, r: 1 })];
-    const models = aggregate(cells, WEIGHTS);
-    const scores: Scores = { runId: "run-escape", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-escape", "v1", cells);
     const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
     expect(markdown).toContain("weird\\|model");
   });
@@ -249,8 +280,7 @@ describe("renderReport escaping and determinism", () => {
       mkCell({ model: "zeta", questionId: "q1", outcome: "win", score: 1, r: 1 }),
       mkCell({ model: "alpha", questionId: "q1", outcome: "win", score: 1, r: 1 }),
     ];
-    const models = aggregate(cells, WEIGHTS);
-    const scores: Scores = { runId: "run-tie", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-tie", "v1", cells);
     const { summary } = renderReport(scores, {}, { now: FIXED_NOW });
     expect(summary.ranking.map((r) => r.model)).toEqual(["alpha", "zeta"]);
   });
@@ -262,22 +292,54 @@ describe("renderReport single-mode run", () => {
       mkCell({ model: "solo/model", questionId: "q1", mode: "blind", outcome: "win", score: 1, r: 1 }),
       mkCell({ model: "solo/model", questionId: "q2", mode: "blind", outcome: "loss", score: -1, r: 1 }),
     ];
-    const models = aggregate(cells, WEIGHTS);
-    expect(models[0].noiseDelta).toBeNull();
-    const scores: Scores = { runId: "run-solo", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-solo", "v1", cells);
+    expect(scores.models[0].noiseDelta).toBeNull();
     const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
     const headerIdx = markdown.split("\n").findIndex((l) => l.startsWith("| 排名 |"));
     const row = markdown.split("\n")[headerIdx + 2];
     const cellsInRow = row.split("|").map((c) => c.trim());
-    expect(cellsInRow[9]).toBe("—");
+    expect(cellsInRow[11]).toBe("—");
   });
 
   it("renders — for repeat when config is missing", () => {
     const cells = [mkCell({ model: "solo/model", questionId: "q1", outcome: "win", score: 1, r: 1 })];
-    const models = aggregate(cells, WEIGHTS);
-    const scores: Scores = { runId: "run-noconfig", datasetVersion: "v1", weights: WEIGHTS, cells, models };
+    const scores = buildScoresFrom("run-noconfig", "v1", cells);
     const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
     expect(markdown).toContain("- 重复次数：—");
     expect(markdown).toContain("- Git SHA：—");
+  });
+});
+
+describe("renderReport difficulty tiers and agreement matrix rendering", () => {
+  it("labels n=1 tiers clearly and renders — for a matrix with fewer than two models", () => {
+    const cells = [mkCell({ model: "solo/model", questionId: "q1", outcome: "win", score: 1, r: 1 })];
+    const scores = buildScoresFrom("run-tier-solo", "v1", cells);
+    const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
+    expect(markdown).toContain("n=1");
+    expect(markdown).toContain("参与比较的模型不足两个");
+  });
+
+  it("escapes pipes in question ids inside the difficulty lists", () => {
+    const cells = [mkCell({ model: "solo/model", questionId: "weird|q", outcome: "win", score: 1, r: 1 })];
+    const scores = buildScoresFrom("run-tier-escape", "v1", cells);
+    const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
+    expect(markdown).toContain("weird\\|q");
+  });
+
+  it("renders a pairwise agreement matrix with shared counts suppressed below 5", () => {
+    const cells: CellVerdict[] = [];
+    for (let i = 0; i < 3; i++) {
+      cells.push(
+        mkCell({ model: "a", questionId: `q${i}`, mode: "blind", direction: "long", outcome: "win", score: 1, r: 1 }),
+        mkCell({ model: "b", questionId: `q${i}`, mode: "blind", direction: "long", outcome: "win", score: 1, r: 1 }),
+      );
+    }
+    const scores = buildScoresFrom("run-matrix", "v1", cells);
+    const { markdown } = renderReport(scores, {}, { now: FIXED_NOW });
+    const lines = markdown.split("\n");
+    const sectionStart = lines.indexOf("## 模型同质化矩阵");
+    const rowA = lines.slice(sectionStart).find((l) => l.startsWith("| a |"));
+    expect(rowA).toBeDefined();
+    expect(rowA).toContain("— (3)");
   });
 });

--- a/app/packages/bench/test/score/aggregate.test.ts
+++ b/app/packages/bench/test/score/aggregate.test.ts
@@ -165,6 +165,76 @@ describe("aggregate reference models", () => {
   });
 });
 
+describe("abstainRate", () => {
+  it("counts neutral cells over all scored cells, excluding api_error", () => {
+    const cells = [
+      mkCell({ outcome: "win", score: 1 }),
+      mkCell({ outcome: "loss", score: -1 }),
+      mkCell({ outcome: "neutral_correct", direction: "neutral", score: null }),
+      mkCell({ outcome: "neutral_wrong", direction: "neutral", score: null }),
+      mkCell({
+        outcome: "api_error",
+        direction: null,
+        entry: null,
+        stop: null,
+        target: null,
+        score: null,
+        r: null,
+      }),
+    ];
+    const s = judgmentSummary(cells, 0);
+    expect(s.abstainRate).toBeCloseTo(2 / 4, 10);
+  });
+
+  it("is 0 when a model never abstains", () => {
+    const s = judgmentSummary([mkCell({ outcome: "win", score: 1 }), mkCell({ outcome: "loss", score: -1 })], 0);
+    expect(s.abstainRate).toBe(0);
+  });
+
+  it("is 0 when there are no scored cells at all", () => {
+    const s = judgmentSummary(
+      [
+        mkCell({
+          outcome: "api_error",
+          direction: null,
+          entry: null,
+          stop: null,
+          target: null,
+          score: null,
+          r: null,
+        }),
+      ],
+      0,
+    );
+    expect(s.abstainRate).toBe(0);
+  });
+});
+
+describe("avgWinnerR", () => {
+  it("is null when a model has zero wins", () => {
+    const [m] = aggregate([mkCell({ outcome: "loss", score: -1 })], WEIGHTS);
+    expect(m.avgWinnerR).toBeNull();
+  });
+
+  it("equals the single winning score when there is exactly one win", () => {
+    const [m] = aggregate([mkCell({ outcome: "win", score: 2.5 }), mkCell({ outcome: "loss", score: -1 })], WEIGHTS);
+    expect(m.avgWinnerR).toBeCloseTo(2.5, 10);
+  });
+
+  it("averages score over wins only, ignoring losses and neutrals", () => {
+    const [m] = aggregate(
+      [
+        mkCell({ outcome: "win", score: 2 }),
+        mkCell({ outcome: "win", score: 4 }),
+        mkCell({ outcome: "loss", score: -1 }),
+        mkCell({ outcome: "neutral_correct", direction: "neutral", score: null }),
+      ],
+      WEIGHTS,
+    );
+    expect(m.avgWinnerR).toBeCloseTo(3, 10);
+  });
+});
+
 describe("aggregate neutral median substitution", () => {
   it("a model with no neutral cells inherits the run median neutralAccuracy", () => {
     const cells = [

--- a/app/packages/bench/test/score/analysis.test.ts
+++ b/app/packages/bench/test/score/analysis.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { agreementMatrixOf, difficultyTiersOf } from "../../src/score/analysis.js";
+import type { CellVerdict } from "../../src/score/cell.js";
+import { mkCell } from "./helpers.js";
+
+describe("difficultyTiersOf", () => {
+  it("classifies a 3-model x 4-question grid into all-correct, all-wrong, split, and n=1", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q-all-correct", outcome: "win", score: 1 }),
+      mkCell({ model: "b", questionId: "q-all-correct", outcome: "win", score: 2 }),
+      mkCell({ model: "c", questionId: "q-all-correct", outcome: "win", score: 1 }),
+
+      mkCell({ model: "a", questionId: "q-all-wrong", outcome: "loss", score: -1 }),
+      mkCell({ model: "b", questionId: "q-all-wrong", outcome: "loss", score: -1 }),
+      mkCell({ model: "c", questionId: "q-all-wrong", outcome: "loss", score: -1 }),
+
+      mkCell({ model: "a", questionId: "q-split", outcome: "win", score: 1 }),
+      mkCell({ model: "b", questionId: "q-split", outcome: "loss", score: -1 }),
+      mkCell({ model: "c", questionId: "q-split", outcome: "loss", score: -1 }),
+
+      mkCell({ model: "a", questionId: "q-solo-correct", outcome: "win", score: 3 }),
+
+      mkCell({
+        model: "baseline/buy-hold",
+        questionId: "q-all-correct",
+        outcome: "loss",
+        score: -1,
+      }),
+    ];
+
+    const tiers = difficultyTiersOf(cells);
+
+    expect(tiers.allCorrect.map((e) => e.questionId)).toEqual(["q-all-correct", "q-solo-correct"]);
+    expect(tiers.allWrong.map((e) => e.questionId)).toEqual(["q-all-wrong"]);
+    expect(tiers.split.map((e) => e.questionId)).toEqual(["q-split"]);
+
+    const allCorrect = tiers.allCorrect.find((e) => e.questionId === "q-all-correct")!;
+    expect(allCorrect.nModels).toBe(3);
+    expect(allCorrect.meanScore).toBeCloseTo((1 + 2 + 1) / 3, 10);
+
+    const solo = tiers.allCorrect.find((e) => e.questionId === "q-solo-correct")!;
+    expect(solo.nModels).toBe(1);
+  });
+
+  it("treats a fully api_error model as not having answered, so it doesn't count", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q1", outcome: "win", score: 1 }),
+      mkCell({
+        model: "b",
+        questionId: "q1",
+        outcome: "api_error",
+        direction: null,
+        entry: null,
+        stop: null,
+        target: null,
+        score: null,
+        r: null,
+      }),
+    ];
+    const tiers = difficultyTiersOf(cells);
+    const entry = tiers.allCorrect.find((e) => e.questionId === "q1");
+    expect(entry?.nModels).toBe(1);
+  });
+
+  it("treats a neutral_wrong verdict as incorrect and neutral_correct as correct", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q1", direction: "neutral", outcome: "neutral_correct", score: null, r: null }),
+      mkCell({ model: "b", questionId: "q1", direction: "neutral", outcome: "neutral_wrong", score: null, r: null }),
+    ];
+    const tiers = difficultyTiersOf(cells);
+    expect(tiers.split.map((e) => e.questionId)).toEqual(["q1"]);
+  });
+});
+
+describe("agreementMatrixOf", () => {
+  it("computes a pinned agreement rate for two models over 6 shared questions", () => {
+    const cells: CellVerdict[] = [];
+    const agreeIds = ["q1", "q2", "q3", "q4"];
+    const disagreeIds = ["q5", "q6"];
+    for (const id of agreeIds) {
+      cells.push(
+        mkCell({ model: "a", questionId: id, mode: "blind", direction: "long" }),
+        mkCell({ model: "b", questionId: id, mode: "blind", direction: "long" }),
+      );
+    }
+    for (const id of disagreeIds) {
+      cells.push(
+        mkCell({ model: "a", questionId: id, mode: "blind", direction: "long" }),
+        mkCell({ model: "b", questionId: id, mode: "blind", direction: "short" }),
+      );
+    }
+    const matrix = agreementMatrixOf(cells);
+    expect(matrix.models).toEqual(["a", "b"]);
+    const pair = matrix.pairs.find((p) => p.a === "a" && p.b === "b")!;
+    expect(pair.sharedCount).toBe(6);
+    expect(pair.agreementRate).toBeCloseTo(4 / 6, 10);
+  });
+
+  it("combines reps by majority direction and counts a tie as disagreement", () => {
+    const cells: CellVerdict[] = [];
+    for (let i = 0; i < 5; i++) {
+      cells.push(mkCell({ model: "a", questionId: `q${i}`, mode: "blind", rep: 0, direction: "long" }));
+      cells.push(mkCell({ model: "b", questionId: `q${i}`, mode: "blind", rep: 0, direction: "long" }));
+    }
+    cells.push(mkCell({ model: "a", questionId: "q-tie", mode: "blind", rep: 0, direction: "long" }));
+    cells.push(mkCell({ model: "a", questionId: "q-tie", mode: "blind", rep: 1, direction: "short" }));
+    cells.push(mkCell({ model: "b", questionId: "q-tie", mode: "blind", rep: 0, direction: "long" }));
+
+    const matrix = agreementMatrixOf(cells);
+    const pair = matrix.pairs.find((p) => p.a === "a" && p.b === "b")!;
+    expect(pair.sharedCount).toBe(6);
+    expect(pair.agreementRate).toBeCloseTo(5 / 6, 10);
+  });
+
+  it("suppresses the agreement rate (nulls it) below 5 shared questions", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q1", mode: "blind", direction: "long" }),
+      mkCell({ model: "b", questionId: "q1", mode: "blind", direction: "long" }),
+      mkCell({ model: "a", questionId: "q2", mode: "blind", direction: "long" }),
+      mkCell({ model: "b", questionId: "q2", mode: "blind", direction: "long" }),
+    ];
+    const matrix = agreementMatrixOf(cells);
+    const pair = matrix.pairs.find((p) => p.a === "a" && p.b === "b")!;
+    expect(pair.sharedCount).toBe(2);
+    expect(pair.agreementRate).toBeNull();
+  });
+
+  it("excludes baseline and gold rows from the matrix", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q1", mode: "blind", direction: "long" }),
+      mkCell({ model: "baseline/buy-hold", questionId: "q1", mode: "blind", direction: "long" }),
+      mkCell({ model: "gold/hindsight", questionId: "q1", mode: "blind", direction: "long" }),
+    ];
+    const matrix = agreementMatrixOf(cells);
+    expect(matrix.models).toEqual(["a"]);
+    expect(matrix.pairs).toHaveLength(0);
+  });
+
+  it("only compares the same mode: blind and live cells for the same question don't count as shared", () => {
+    const cells: CellVerdict[] = [
+      mkCell({ model: "a", questionId: "q1", mode: "blind", direction: "long" }),
+      mkCell({ model: "b", questionId: "q1", mode: "live", direction: "long" }),
+    ];
+    const matrix = agreementMatrixOf(cells);
+    const pair = matrix.pairs.find((p) => p.a === "a" && p.b === "b")!;
+    expect(pair.sharedCount).toBe(0);
+    expect(pair.agreementRate).toBeNull();
+  });
+});


### PR DESCRIPTION
矩阵测试的报告增强：总榜新增观望率与赢单平均盈亏比两列；新增题目难度分级（全对/全错/分歧，附人工复核提示）与模型同质化矩阵（两两方向一致率）两个分析段落。scores.json 增加 analysis 块，旧答卷可直接重判出新指标。228 测试全绿。