### PR TITLE
chore(app): dual-ABI cache for better-sqlite3 with fast copy swap

### DIFF
--- a/app/desktop/scripts/ensureDevNative.mjs
+++ b/app/desktop/scripts/ensureDevNative.mjs
@@ -1,31 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { ensureElectronAbi } from "../../scripts/native-abi.mjs";
 
 const desktopRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const require = createRequire(join(desktopRoot, "package.json"));
 
-function run(script) {
-  const result = spawnSync("pnpm", ["run", script], { cwd: desktopRoot, stdio: "inherit" });
-  if (result.status !== 0) process.exit(result.status ?? 1);
-}
-
-// ELECTRON_RUN_AS_NODE boots Electron's embedded Node, so the probe exercises
-// the exact ABI the app will load — a plain `node -e` probe would pass on a
-// Node-ABI binary that Electron then crashes on.
-const probe = spawnSync(require("electron"), ["-e", "new (require('better-sqlite3'))(':memory:').close()"], {
-  cwd: desktopRoot,
-  env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
-  stdio: "pipe",
-});
-if (probe.status !== 0) {
-  console.log("[ensureDevNative] better-sqlite3 is not built for Electron — rebuilding");
-  run("rebuild-native");
-} else {
-  console.log("[ensureDevNative] better-sqlite3 OK for Electron ABI, skipping rebuild");
-}
+ensureElectronAbi(desktopRoot, "ensureDevNative");
 
 const bridgeRoot = join(desktopRoot, "native", "sparkle-bridge");
 const bridgeReady =
@@ -33,7 +14,10 @@ const bridgeReady =
   existsSync(join(bridgeRoot, "vendor", "Sparkle.framework"));
 if (!bridgeReady) {
   console.log("[ensureDevNative] sparkle-bridge addon missing — building");
-  run("build:native");
+  const result = spawnSync("pnpm", ["run", "build:native"], { cwd: desktopRoot, stdio: "inherit" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
 } else {
-  console.log("[ensureDevNative] sparkle-bridge addon present, skipping build (run `pnpm build:native` after changing its sources)");
+  console.log(
+    "[ensureDevNative] sparkle-bridge addon present, skipping build (run `pnpm build:native` after changing its sources)",
+  );
 }

--- a/app/packages/core/scripts/ensureNativeAbi.mjs
+++ b/app/packages/core/scripts/ensureNativeAbi.mjs
@@ -1,42 +1,4 @@
-import { execFileSync, spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { assertNoElectronDev, ensureNodeAbi } from "../../../scripts/native-abi.mjs";
 
-const require = createRequire(import.meta.url);
-
-function packageRoot(entryFile) {
-  let dir = dirname(entryFile);
-  while (!require("node:fs").existsSync(join(dir, "package.json"))) {
-    dir = dirname(dir);
-  }
-  return dir;
-}
-
-// The probe runs in a child process: loading an Electron-ABI binary into Node
-// doesn't always throw a catchable NODE_MODULE_VERSION error — macOS can
-// SIGKILL the process outright, which would take this guard down with it.
-function probe() {
-  return spawnSync(process.execPath, ["-e", "new (require('better-sqlite3'))(':memory:').close()"], {
-    cwd: dirname(fileURLToPath(import.meta.url)),
-    stdio: "pipe",
-  });
-}
-
-const first = probe();
-if (first.status !== 0) {
-  const entry = require.resolve("better-sqlite3");
-  const root = packageRoot(entry);
-  const requireFromRoot = createRequire(join(root, "package.json"));
-  console.log(
-    `[ensureNativeAbi] better-sqlite3 unusable under Node (status=${first.status ?? first.signal}, likely left by an Electron rebuild) — reinstalling for Node at ${root}`,
-  );
-  execFileSync(requireFromRoot.resolve("prebuild-install/bin.js"), [], { cwd: root, stdio: "inherit" });
-
-  const second = probe();
-  if (second.status !== 0) {
-    console.error(`[ensureNativeAbi] better-sqlite3 still unusable after reinstall (status=${second.status ?? second.signal})`);
-    console.error(String(second.stderr));
-    process.exit(1);
-  }
-}
+assertNoElectronDev("ensureNativeAbi");
+ensureNodeAbi("ensureNativeAbi");

--- a/app/scripts/native-abi.mjs
+++ b/app/scripts/native-abi.mjs
@@ -10,7 +10,7 @@ const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 // better-sqlite3); every workspace copy dedupes to the same .pnpm directory.
 const coreRequire = createRequire(join(appRoot, "packages", "core", "package.json"));
 
-const CACHE_DIR = join(homedir(), ".cache", "kansoku-native-abi");
+const CACHE_DIR = join(appRoot, "node_modules", ".abi-cache");
 
 function binaryPath() {
   let dir = dirname(coreRequire.resolve("better-sqlite3"));

--- a/app/scripts/native-abi.mjs
+++ b/app/scripts/native-abi.mjs
@@ -1,0 +1,141 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+// Resolved through packages/core (the root package.json does not depend on
+// better-sqlite3); every workspace copy dedupes to the same .pnpm directory.
+const coreRequire = createRequire(join(appRoot, "packages", "core", "package.json"));
+
+const CACHE_DIR = join(homedir(), ".cache", "kansoku-native-abi");
+
+function binaryPath() {
+  let dir = dirname(coreRequire.resolve("better-sqlite3"));
+  while (!existsSync(join(dir, "package.json"))) dir = dirname(dir);
+  return { root: dir, binary: join(dir, "build", "Release", "better_sqlite3.node") };
+}
+
+function pkgVersion(root) {
+  return coreRequire(join(root, "package.json")).version;
+}
+
+function cachePath(root, abiTag) {
+  return join(CACHE_DIR, `better-sqlite3@${pkgVersion(root)}-${platform()}-${process.arch}-${abiTag}.node`);
+}
+
+// macOS caches code signatures by inode — a swapped-in binary with a stale
+// ad-hoc signature gets SIGKILLed even when its content is valid.
+function codesign(binary) {
+  if (platform() !== "darwin") return;
+  spawnSync("codesign", ["-s", "-", "-f", binary], { stdio: "pipe" });
+}
+
+function storeCache(binary, cacheFile) {
+  mkdirSync(CACHE_DIR, { recursive: true });
+  copyFileSync(binary, cacheFile);
+}
+
+function restoreCache(cacheFile, binary) {
+  copyFileSync(cacheFile, binary);
+  codesign(binary);
+}
+
+export function assertNoElectronDev(label) {
+  const ps = spawnSync("ps", ["ax", "-o", "command"], { stdio: "pipe" });
+  const running = String(ps.stdout)
+    .split("\n")
+    .some((line) => line.includes("Electron.app/Contents/MacOS/Electron") && line.includes(appRoot));
+  if (running) {
+    console.error(
+      `[${label}] refusing to switch better-sqlite3 to the Node ABI: an Electron dev instance from this repo is running and would break on its next db access. Stop \`pnpm dev:desktop\` first.`,
+    );
+    process.exit(1);
+  }
+}
+
+// probe runs in a child process: loading a wrong-ABI binary into this process
+// doesn't always throw a catchable error — macOS can SIGKILL outright.
+function probeNode() {
+  // cwd must resolve better-sqlite3 — the app root's package.json does not
+  // depend on it, so probe from packages/core instead.
+  return spawnSync(process.execPath, ["-e", "new (require('better-sqlite3'))(':memory:').close()"], {
+    cwd: join(appRoot, "packages", "core"),
+    stdio: "pipe",
+  });
+}
+
+function probeElectron(desktopRoot, electronBin) {
+  return spawnSync(electronBin, ["-e", "new (require('better-sqlite3'))(':memory:').close()"], {
+    cwd: desktopRoot,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    stdio: "pipe",
+  });
+}
+
+function ensure({ label, abiTag, probe, slowRebuild }) {
+  const { root, binary } = binaryPath();
+  const cacheFile = cachePath(root, abiTag);
+
+  if (probe().status === 0) {
+    if (!existsSync(cacheFile)) storeCache(binary, cacheFile);
+    console.log(`[${label}] better-sqlite3 OK (${abiTag})`);
+    return;
+  }
+
+  if (existsSync(cacheFile)) {
+    console.log(`[${label}] switching better-sqlite3 to ${abiTag} from local cache`);
+    restoreCache(cacheFile, binary);
+    if (probe().status === 0) return;
+    console.log(`[${label}] cached binary rejected — falling back to a rebuild`);
+    rmSync(cacheFile, { force: true });
+  }
+
+  console.log(`[${label}] rebuilding better-sqlite3 for ${abiTag}`);
+  slowRebuild(root);
+  const result = probe();
+  if (result.status !== 0) {
+    console.error(`[${label}] better-sqlite3 still unusable after rebuild (status=${result.status ?? result.signal})`);
+    console.error(String(result.stderr));
+    process.exit(1);
+  }
+  storeCache(binary, cacheFile);
+}
+
+export function ensureNodeAbi(label) {
+  ensure({
+    label,
+    abiTag: `node-abi${process.versions.modules}`,
+    probe: () => probeNode(),
+    slowRebuild: (root) => {
+      const requireFromRoot = createRequire(join(root, "package.json"));
+      const bin = requireFromRoot.resolve("prebuild-install/bin.js");
+      try {
+        execFileSync(bin, [], { cwd: root, stdio: "inherit" });
+      } catch {
+        // prebuild-install reuses poisoned entries from ~/.npm/_prebuilds;
+        // clear them and force a fresh download before giving up.
+        rmSync(join(homedir(), ".npm", "_prebuilds"), { recursive: true, force: true });
+        execFileSync(bin, ["--force"], { cwd: root, stdio: "inherit" });
+      }
+      codesign(binaryPath().binary);
+    },
+  });
+}
+
+export function ensureElectronAbi(desktopRoot, label) {
+  const desktopRequire = createRequire(join(desktopRoot, "package.json"));
+  const electronBin = desktopRequire("electron");
+  const electronVersion = desktopRequire("electron/package.json").version;
+  ensure({
+    label,
+    abiTag: `electron${electronVersion}`,
+    probe: () => probeElectron(desktopRoot, electronBin),
+    slowRebuild: () => {
+      const result = spawnSync("pnpm", ["run", "rebuild-native"], { cwd: desktopRoot, stdio: "inherit" });
+      if (result.status !== 0) process.exit(result.status ?? 1);
+    },
+  });
+}


### PR DESCRIPTION
Root cause of the ABI tug-of-war: one node_modules, one native binary, two host ABIs (system Node 137 vs Electron 43's 148 — matching Node versions does not help, Electron numbers its ABI independently).

This does not eliminate the exclusivity (only migrating to node:sqlite would), but makes switching free and safe:

- `app/scripts/native-abi.mjs`: one cached binary per (version, platform, arch, ABI) under `app/node_modules/.abi-cache`; switches are file copy + ad-hoc re-codesign (~0.3s, offline). Rebuild/prebuild paths remain as cache-miss fallbacks, with the poisoned `~/.npm/_prebuilds` retry hardening.
- core/pro `pretest` refuses to switch to the Node ABI while an Electron dev instance from this repo is running (it used to silently break the running app).

Verified locally: both ABIs cached, sub-second round-trip swaps, guard exits 1 with a live Electron process. The pro-side pretest wrapper is committed in kansoku-pro.