### PR TITLE
fix(core): 移植 episode 模式的上下文字段(kansoku-pro#4 的前置)

### DIFF
--- a/app/packages/core/src/ai/messages/analystMessagesEngine.ts
+++ b/app/packages/core/src/ai/messages/analystMessagesEngine.ts
@@ -30,8 +30,10 @@ export interface AnalystInitialContext {
 
 export interface AnalystStepContext {
   chartId: string | null;
+  dataAsOf?: string;
   journalWritten: boolean;
   loadedSkillIds: string[];
+  marketDate?: string;
   submitted: boolean;
 }
 
@@ -72,6 +74,8 @@ class AnalystRunStateProvider extends BaseVirtualTailProvider {
       `  <submitted>${state.submitted}</submitted>`,
       `  <chart_id>${escapeXml(state.chartId ?? "")}</chart_id>`,
       `  <loaded_skills>${state.loadedSkillIds.map(escapeXml).join(",")}</loaded_skills>`,
+      ...(state.marketDate ? [`  <market_date>${escapeXml(state.marketDate)}</market_date>`] : []),
+      ...(state.dataAsOf ? [`  <data_as_of>${escapeXml(state.dataAsOf)}</data_as_of>`] : []),
       "</analyst_run_state>",
     ].join("\n");
   }

--- a/app/packages/core/src/ai/messages/sharedProviders.ts
+++ b/app/packages/core/src/ai/messages/sharedProviders.ts
@@ -79,7 +79,7 @@ export class ActivatedSkillsProvider extends BaseFirstUserContentProvider {
 
   constructor(
     private readonly skills: SkillContext[],
-    private readonly runtimeAdapter: string,
+    private readonly runtimeAdapter?: string,
   ) {
     super();
   }
@@ -99,12 +99,10 @@ export class ActivatedSkillsProvider extends BaseFirstUserContentProvider {
         "  </skill>",
       );
     }
-    lines.push(
-      "</activated_skills>",
-      "<runtime_adapter>",
-      this.runtimeAdapter,
-      "</runtime_adapter>",
-    );
+    lines.push("</activated_skills>");
+    if (this.runtimeAdapter?.trim()) {
+      lines.push("<runtime_adapter>", this.runtimeAdapter, "</runtime_adapter>");
+    }
     return lines.join("\n");
   }
 }

--- a/app/packages/core/test/analystMessagesEngine.test.ts
+++ b/app/packages/core/test/analystMessagesEngine.test.ts
@@ -108,11 +108,15 @@ describe("AnalystMessagesEngine", () => {
     const before = await engine.process(raw);
     step.journalWritten = true;
     step.loadedSkillIds = ["twitter-reader"];
+    step.marketDate = "2026-07-15";
+    step.dataAsOf = "2026-07-15T15:30:00.000Z";
     const after = await engine.process(raw);
 
     expect(textOf(before.messages.at(-1)!)).toContain("<journal_written>false</journal_written>");
     expect(textOf(after.messages.at(-1)!)).toContain("<journal_written>true</journal_written>");
     expect(textOf(after.messages.at(-1)!)).toContain("twitter-reader");
+    expect(textOf(after.messages.at(-1)!)).toContain("<market_date>2026-07-15</market_date>");
+    expect(textOf(after.messages.at(-1)!)).toContain("<data_as_of>2026-07-15T15:30:00.000Z</data_as_of>");
     expect(textOf(after.messages.at(-1)!)).not.toContain("<journal_written>false</journal_written>");
     expect(raw).toEqual([{ role: "user", content: "分析", timestamp: 1 }]);
   });


### PR DESCRIPTION
kansoku-pro a031bc6(#3,episode 数据集)给 analystMessagesEngine/sharedProviders 加了 dataAsOf/marketDate 可选字段与 runtime_adapter 可选化,但这两个文件已随 #34 搬进公开 core,该 delta 在搬迁基线之后落在 pro main 上,搬迁时未能带上。本 PR 把 delta 移植到 core 副本(含测试断言),否则 kansoku-pro#4 rebase 后其 episode bench 对着缺字段的 core 类型编译失败。core 798 测试全绿;pro 侧 rebase 分支对着本改动 typecheck+329 测试+build 全绿。**需先于 kansoku-pro#4 合并。**