### PR TITLE
feat(bench): record and report trade reasons

### DIFF
--- a/app/packages/bench/README.md
+++ b/app/packages/bench/README.md
@@ -118,6 +118,8 @@ pnpm --filter @kansoku/bench cli generate-episode-dataset \
   --source-cache-dir ~/.cache/kansoku/bench/sources
 ```
 
+Episode runner 要求模型在每次交易决策中提交结构化理由：`submit_prediction.decision_reason` 记录入场或观望理由，`advance_trade.reason` 记录持有、改单、撤单或主动退出理由。每条理由由一个主类别和一段简短、可审计的依据组成；缺少理由的调用会被拒绝。Episode HTML 报告及 `episode-report-summary.json` 会按“模型 × 原因类别”统计理由覆盖率、动作分布、入场/成交、胜率、平均净 R 和累计净 R。历史结果中的理由字段保持可选，因此旧 JSONL 仍可读取，但不会被计入理由覆盖。
+
 ## 评分口径速览
 
 - **判断分**（权重默认 0.8）= 0.4×胜率 + 0.4×期望收益归一值 + 0.2×观望正确率。胜率只算「出手」的题（观望不计入分母）；期望收益以止损距离为单位（赢记 +实际盈亏比、输记 −1、超时按收盘价相对入场价的比例截断在 [−1, 盈亏比] 之间），归一到 [0,1] 再加权；观望正确率 = 观望题里事后确实没有像样行情的比例，一个模型如果从不观望，这一项会退化用「全场观望正确率的中位数」兜底。

--- a/app/packages/bench/src/episode/engine.ts
+++ b/app/packages/bench/src/episode/engine.ts
@@ -8,6 +8,7 @@ import type {
 } from "../schema/episode.js";
 import type { Question } from "../schema/question.js";
 import type { Submission } from "../schema/submission.js";
+import type { EpisodeTradeReason } from "../schema/tradeReason.js";
 
 export type EpisodePhase = "flat" | "pending" | "open" | "terminal";
 export type EpisodeEvent =
@@ -33,6 +34,7 @@ export interface PendingOrderState {
   stop: number;
   target: number;
   waitedBars: number;
+  entryReason: EpisodeTradeReason;
 }
 
 export interface PositionState {
@@ -49,6 +51,7 @@ export interface PositionState {
   holdingBars: number;
   mfeR: number;
   maeR: number;
+  entryReason: EpisodeTradeReason;
 }
 
 export interface EpisodeState {
@@ -208,6 +211,7 @@ function validateDirectionalSubmission(
   tradeId: number,
   decisionBar: number,
   decisionTime: string,
+  entryReason: EpisodeTradeReason,
 ): PendingOrderState {
   if (submission.direction === "neutral") throw new Error("neutral submission has no order");
   const plan = submission.entry_plan;
@@ -231,6 +235,16 @@ function validateDirectionalSubmission(
     stop,
     target,
     waitedBars: 0,
+    entryReason,
+  };
+}
+
+function submissionReason(submission: Submission): EpisodeTradeReason {
+  if (submission.decision_reason) return submission.decision_reason;
+  const summary = submission.entry_plan?.rationale?.trim() || submission.comment.trim();
+  return {
+    category: submission.direction === "neutral" ? "no_setup" : "other",
+    summary: summary || "未提供明确的交易理由。",
   };
 }
 
@@ -264,6 +278,7 @@ export function submitEpisode(
   const decisionBar = state.cursor + 1;
   const decisionTime = currentAsOf(question, state.cursor);
   const plan = submission.entry_plan;
+  const reason = submissionReason(submission);
   const recorded = withAction(
     state,
     question,
@@ -271,6 +286,7 @@ export function submitEpisode(
       type: "submit",
       direction: submission.direction,
       ...(plan ? { entry: plan.entry, stop: plan.stop, ...(plan.target1 == null ? {} : { target: plan.target1 }) } : {}),
+      reason,
     },
     replayBar(question, state.cursor + 1),
     submission.direction === "neutral" ? null : state.nextTradeId,
@@ -292,6 +308,7 @@ export function submitEpisode(
     state.nextTradeId,
     decisionBar,
     decisionTime,
+    reason,
   );
   const submitted: EpisodeState = {
     ...recorded,
@@ -447,6 +464,7 @@ function closePosition(
     mfeR: position.mfeR,
     maeR: position.maeR,
     holdingBars: position.holdingBars,
+    entryReason: position.entryReason,
   };
   return {
     ...state,
@@ -569,6 +587,7 @@ export function advanceEpisode(
           holdingBars: 0,
           mfeR: 0,
           maeR: 0,
+          entryReason: order.entryReason,
         },
       };
       fillTiming = fill.timing;

--- a/app/packages/bench/src/episode/report.ts
+++ b/app/packages/bench/src/episode/report.ts
@@ -1,6 +1,7 @@
 import type { RawBar } from "../../../../shared/types.js";
-import type { EpisodeAnswer, EpisodeClosedTrade } from "../schema/episode.js";
+import type { EpisodeActionRecord, EpisodeAnswer, EpisodeClosedTrade } from "../schema/episode.js";
 import type { Question } from "../schema/question.js";
+import type { EpisodeTradeReason, EpisodeTradeReasonCategory } from "../schema/tradeReason.js";
 import type { EpisodeDataAudit } from "./audit.js";
 import { buildEpisodeQuestionViewAtCursor } from "./view.js";
 
@@ -86,7 +87,32 @@ export interface EpisodeReportSummary {
   averageToolCalls: number | null;
   averageTokens: number | null;
   averageDecisionBars: number | null;
+  reasonCoverage: number | null;
+  reasonedActions: number;
+  decisionActions: number;
+  reasonCoverageByModel: EpisodeReasonCoverage[];
+  reasonStats: EpisodeReasonStat[];
   dataAuditPassed: boolean | null;
+}
+
+export interface EpisodeReasonStat {
+  model: string;
+  category: EpisodeTradeReasonCategory;
+  actions: number;
+  actionBreakdown: Record<string, number>;
+  entries: number;
+  trades: number;
+  wins: number;
+  winRate: number | null;
+  averageNetR: number | null;
+  totalNetR: number;
+}
+
+export interface EpisodeReasonCoverage {
+  model: string;
+  reasonedActions: number;
+  decisionActions: number;
+  coverage: number | null;
 }
 
 interface ReportRow {
@@ -193,6 +219,31 @@ const TERMINATION_LABELS: Record<string, string> = {
 
 const DIRECTION_LABELS: Record<string, string> = { long: "做多", short: "做空", neutral: "观望" };
 const MODE_LABELS: Record<string, string> = { blind: "盲盘", live: "实盘" };
+const REASON_LABELS: Record<EpisodeTradeReasonCategory, string> = {
+  trend_following: "趋势跟随",
+  breakout: "突破",
+  pullback: "回调入场",
+  mean_reversion: "均值回归",
+  support_resistance: "支撑阻力",
+  momentum: "动量",
+  volume_flow: "量价与资金流",
+  volatility: "波动率",
+  news_event: "新闻事件",
+  fundamental: "基本面",
+  risk_management: "风险管理",
+  thesis_invalidated: "逻辑失效",
+  profit_protection: "利润保护",
+  time_horizon: "时间窗口",
+  no_setup: "无有效机会",
+  other: "其他",
+};
+const ACTION_LABELS: Record<string, string> = {
+  submit: "提交",
+  hold: "持有",
+  amend: "改单",
+  cancel: "撤单",
+  exit_next_open: "主动退出",
+};
 const EVENT_LABELS: Record<string, string> = {
   observed: "已公开下一根",
   decision_due: "决策窗口即将截止",
@@ -367,6 +418,20 @@ function inferBarAfter(line: EpisodeReportTraceLine, before: number): number {
   return before;
 }
 
+function traceReason(args: Record<string, unknown>): EpisodeTradeReason | null {
+  const candidate = (args.decision_reason ?? args.reason) as Record<string, unknown> | undefined;
+  if (!candidate || typeof candidate !== "object") return null;
+  if (typeof candidate.category !== "string" || typeof candidate.summary !== "string") return null;
+  return candidate as EpisodeTradeReason;
+}
+
+function reasonDetail(args: Record<string, unknown>): string | null {
+  const reason = traceReason(args);
+  if (!reason) return null;
+  const label = REASON_LABELS[reason.category] ?? reason.category;
+  return `${label}：${reason.summary}`;
+}
+
 function processLabel(line: EpisodeReportTraceLine): { label: string; detail: string; timeframe: ChartTimeframe | null } {
   const name = line.name ?? "unknown_tool";
   const args = line.args ?? {};
@@ -386,11 +451,13 @@ function processLabel(line: EpisodeReportTraceLine): { label: string; detail: st
   }
   if (name === "submit_prediction") {
     const direction = typeof args.direction === "string" ? DIRECTION_LABELS[args.direction] ?? args.direction : "未知方向";
-    return { label: `交易计划 · ${direction}`, detail: eventText ? `引擎事件：${eventText}` : "空仓时提交计划，可在后续重新入场", timeframe: "h1" };
+    const reason = reasonDetail(args);
+    return { label: `交易计划 · ${direction}`, detail: reason ?? (eventText ? `引擎事件：${eventText}` : "空仓时提交计划，可在后续重新入场"), timeframe: "h1" };
   }
   if (name === "advance_trade") {
     const action = typeof args.type === "string" ? args.type.toUpperCase() : "ACTION";
-    return { label: `推进 · ${action}`, detail: eventText ? `引擎事件：${eventText}` : "提交管理动作并公开下一根", timeframe: "h1" };
+    const reason = reasonDetail(args);
+    return { label: `推进 · ${action}`, detail: reason ?? (eventText ? `引擎事件：${eventText}` : "提交管理动作并公开下一根"), timeframe: "h1" };
   }
   return { label: name, detail: "工具调用", timeframe: null };
 }
@@ -597,6 +664,114 @@ function aggregate(rows: ReportRow[]): AggregateMetrics {
     avgToolCalls: mean(rows.map((row) => row.answer.metrics.toolCalls)),
     avgTokens: mean(rows.map((row) => row.answer.metrics.inputTokens + row.answer.metrics.outputTokens)),
     avgDecisionBars: mean(completed.map((row) => decisionBar(row.answer))),
+  };
+}
+
+function actionReason(record: EpisodeActionRecord): EpisodeTradeReason | null {
+  return "reason" in record.action ? record.action.reason ?? null : null;
+}
+
+function isDecisionAction(record: EpisodeActionRecord): boolean {
+  return record.action.type !== "observe";
+}
+
+function tradeEntryReason(row: ReportRow, trade: EpisodeClosedTrade): EpisodeTradeReason | null {
+  if (trade.entryReason) return trade.entryReason;
+  const submitted = row.answer.result?.actions.find((record) =>
+    record.tradeId === trade.tradeId && record.action.type === "submit"
+  );
+  return submitted ? actionReason(submitted) : null;
+}
+
+interface ReasonMetrics {
+  decisionActions: number;
+  reasonedActions: number;
+  coverage: number | null;
+  coverageByModel: EpisodeReasonCoverage[];
+  stats: EpisodeReasonStat[];
+}
+
+function aggregateReasons(rows: ReportRow[]): ReasonMetrics {
+  const completed = rows.filter((row) => row.answer.status === "completed");
+  const actions = completed.flatMap((row) =>
+    (row.answer.result?.actions ?? []).filter(isDecisionAction).map((record) => ({ model: row.answer.model, record }))
+  );
+  const reasoned = actions.flatMap(({ model, record }) => {
+    const reason = actionReason(record);
+    return reason ? [{ model, record, reason }] : [];
+  });
+  const byCategory = new Map<string, EpisodeReasonStat>();
+  const ensure = (model: string, category: EpisodeTradeReasonCategory): EpisodeReasonStat => {
+    const key = `${model}\u0000${category}`;
+    const existing = byCategory.get(key);
+    if (existing) return existing;
+    const created: EpisodeReasonStat = {
+      model,
+      category,
+      actions: 0,
+      actionBreakdown: {},
+      entries: 0,
+      trades: 0,
+      wins: 0,
+      winRate: null,
+      averageNetR: null,
+      totalNetR: 0,
+    };
+    byCategory.set(key, created);
+    return created;
+  };
+
+  for (const { model, record, reason } of reasoned) {
+    const stat = ensure(model, reason.category);
+    stat.actions += 1;
+    stat.actionBreakdown[record.action.type] = (stat.actionBreakdown[record.action.type] ?? 0) + 1;
+    if (record.action.type === "submit" && record.tradeId != null) stat.entries += 1;
+  }
+
+  const netByCategory = new Map<string, number[]>();
+  for (const row of completed) {
+    for (const trade of closedTrades(row.answer)) {
+      const reason = tradeEntryReason(row, trade);
+      if (!reason) continue;
+      const stat = ensure(row.answer.model, reason.category);
+      stat.trades += 1;
+      if (trade.netR > 0) stat.wins += 1;
+      stat.totalNetR += trade.netR;
+      const key = `${row.answer.model}\u0000${reason.category}`;
+      netByCategory.set(key, [...(netByCategory.get(key) ?? []), trade.netR]);
+    }
+  }
+
+  for (const [key, values] of netByCategory) {
+    const stat = byCategory.get(key);
+    if (!stat) continue;
+    stat.winRate = ratio(stat.wins, stat.trades);
+    stat.averageNetR = mean(values);
+  }
+
+  const models = [...new Set(actions.map((entry) => entry.model))].sort();
+  const coverageByModel = models.map((model) => {
+    const modelActions = actions.filter((entry) => entry.model === model).length;
+    const modelReasoned = reasoned.filter((entry) => entry.model === model).length;
+    return {
+      model,
+      reasonedActions: modelReasoned,
+      decisionActions: modelActions,
+      coverage: ratio(modelReasoned, modelActions),
+    };
+  });
+
+  return {
+    decisionActions: actions.length,
+    reasonedActions: reasoned.length,
+    coverage: ratio(reasoned.length, actions.length),
+    coverageByModel,
+    stats: [...byCategory.values()].sort((a, b) =>
+      a.model.localeCompare(b.model)
+      || b.actions - a.actions
+      || b.trades - a.trades
+      || a.category.localeCompare(b.category)
+    ),
   };
 }
 
@@ -807,6 +982,21 @@ function metricCell(label: string, value: string, note: string, tone = "neutral"
   return `<div class="metric ${tone}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong><small>${escapeHtml(note)}</small></div>`;
 }
 
+function renderReasonTable(rows: ReportRow[]): string {
+  const metrics = aggregateReasons(rows);
+  const coverage = metrics.coverage == null ? "—" : fmtPercent(metrics.coverage);
+  if (metrics.stats.length === 0) {
+    return `<section class="panel reason-panel"><div class="panel-title"><h2>交易原因统计</h2><span>理由覆盖 ${metrics.reasonedActions}/${metrics.decisionActions} · ${coverage}</span></div><p class="reason-empty">该运行没有结构化交易理由；历史结果仍可读取，但不进入原因表现统计。</p></section>`;
+  }
+  return `<section class="panel reason-panel"><div class="panel-title"><h2>交易原因统计</h2><span>理由覆盖 ${metrics.reasonedActions}/${metrics.decisionActions} · ${coverage}</span></div>
+    <div class="table-scroll"><table class="compact-table reason-table"><thead><tr><th>模型</th><th>主原因</th><th>动作</th><th>入场 / 成交</th><th>胜率</th><th>AVG NET R</th><th>TOTAL NET R</th></tr></thead><tbody>${metrics.stats.map((stat) => {
+      const breakdown = Object.entries(stat.actionBreakdown)
+        .map(([action, count]) => `${ACTION_LABELS[action] ?? action} ${count}`)
+        .join(" · ");
+      return `<tr><td><strong>${escapeHtml(stat.model)}</strong></td><td><strong>${escapeHtml(REASON_LABELS[stat.category])}</strong><small>${escapeHtml(stat.category)}</small></td><td><strong>${stat.actions}</strong><small>${escapeHtml(breakdown || "—")}</small></td><td>${stat.entries} / ${stat.trades}</td><td>${fmtPercent(stat.winRate)}</td><td class="mono ${valueClass(stat.averageNetR)}">${fmtSigned(stat.averageNetR, 3)}</td><td class="mono ${valueClass(stat.totalNetR)}">${fmtSigned(stat.totalNetR, 3)}</td></tr>`;
+    }).join("")}</tbody></table></div></section>`;
+}
+
 function renderModelTable(rows: ReportRow[]): string {
   const groups = new Map<string, ReportRow[]>();
   for (const row of rows) groups.set(row.answer.model, [...(groups.get(row.answer.model) ?? []), row]);
@@ -936,8 +1126,16 @@ function renderTradeLedger(row: ReportRow): string {
     const entryBar = replayBarIndex(row.question, trade.entry.time);
     const exitBar = replayBarIndex(row.question, trade.exit.time);
     const reason = tradeExitLabel(trade);
-    return `<li><div><strong>T${trade.tradeId} · ${escapeHtml(DIRECTION_LABELS[trade.direction])}</strong><small>B${trade.decisionBar} 决策 · ${entryBar == null ? "—" : `B${entryBar}`} → ${exitBar == null ? "—" : `B${exitBar}`} · ${escapeHtml(reason)}</small></div><div class="trade-prices"><span>E ${fmt(trade.entry.price)}</span><span>S ${fmt(trade.initialStop)}${trade.finalStop === trade.initialStop ? "" : ` → ${fmt(trade.finalStop)}`}</span><span>T ${fmt(trade.target)}</span><span>X ${fmt(trade.exit.price)}</span></div><strong class="${valueClass(trade.netR)}">${fmtSigned(trade.netR, 3)} R</strong></li>`;
+    const entryReason = tradeEntryReason(row, trade);
+    return `<li><div><strong>T${trade.tradeId} · ${escapeHtml(DIRECTION_LABELS[trade.direction])}</strong><small>B${trade.decisionBar} 决策 · ${entryBar == null ? "—" : `B${entryBar}`} → ${exitBar == null ? "—" : `B${exitBar}`} · ${escapeHtml(reason)}</small>${entryReason ? `<small class="trade-reason"><b>${escapeHtml(REASON_LABELS[entryReason.category])}</b>${escapeHtml(entryReason.summary)}</small>` : ""}</div><div class="trade-prices"><span>E ${fmt(trade.entry.price)}</span><span>S ${fmt(trade.initialStop)}${trade.finalStop === trade.initialStop ? "" : ` → ${fmt(trade.finalStop)}`}</span><span>T ${fmt(trade.target)}</span><span>X ${fmt(trade.exit.price)}</span></div><strong class="${valueClass(trade.netR)}">${fmtSigned(trade.netR, 3)} R</strong></li>`;
   }).join("")}</ol></details>`;
+}
+
+function renderActionRecord(record: EpisodeActionRecord): string {
+  const reason = actionReason(record);
+  const label = ACTION_LABELS[record.action.type] ?? record.action.type;
+  const reasonLabel = reason ? REASON_LABELS[reason.category] : "未记录理由";
+  return `<li><span>${String(record.step).padStart(2, "0")}</span><div><strong>${escapeHtml(label)} · ${escapeHtml(reasonLabel)}</strong>${reason ? `<small>${escapeHtml(reason.summary)}</small>` : ""}<em>${escapeHtml(record.effectiveBarTime ?? record.at)}</em></div></li>`;
 }
 
 function renderCaseDetail(row: ReportRow, index: number): string {
@@ -950,12 +1148,13 @@ function renderCaseDetail(row: ReportRow, index: number): string {
   const entryAt = replayBarIndex(row.question, result?.entry?.time);
   const exitAt = replayBarIndex(row.question, result?.exit?.time);
   const trades = closedTrades(answer);
+  const initialReason = answer.initialSubmission?.decision_reason;
   return `<article class="trade-case" id="case-${index}" data-model="${escapeHtml(answer.model)}" data-mode="${escapeHtml(answer.mode)}" data-outcome="${escapeHtml(outcome)}">
     <header class="case-head"><div><h3>${escapeHtml(answer.symbol)}</h3><span>${escapeHtml(answer.questionId)} · ${escapeHtml(answer.model)} · ${escapeHtml(MODE_LABELS[answer.mode] ?? answer.mode)}</span></div><div class="case-result"><span class="status ${valueClass(result?.netR)}">${escapeHtml(TERMINATION_LABELS[outcome] ?? outcome)}</span><strong class="${valueClass(result?.netR)}">${escapeHtml(fmtSigned(result?.netR, 3))} R</strong></div></header>
     <div class="case-layout"><section class="chart-panel"><div class="chart-toolbar"><div><strong>K 线与成交量</strong><span>点击工具节点可回看该 B 编号当时可见的数据</span></div><div class="timeframe-tabs" role="tablist" aria-label="K 线周期"><button type="button" class="active" data-timeframe-tab data-chart="trade-chart-${index}" data-timeframe="h1">1 小时</button><button type="button" data-timeframe-tab data-chart="trade-chart-${index}" data-timeframe="day">日线</button><button type="button" data-timeframe-tab data-chart="trade-chart-${index}" data-timeframe="week">周线</button></div></div><div class="tv-chart" id="trade-chart-${index}" data-chart-id="trade-chart-${index}"><span class="chart-loading">加载图表…</span></div><div class="chart-legend"><span><i class="entry"></i>计划入场</span><span><i class="target"></i>止盈</span><span><i class="stop"></i>止损</span><span><i class="decision"></i>决策位置</span><span class="chart-range" data-chart-range="trade-chart-${index}"></span></div>${renderProcessChain(row, index)}</section>
-      <aside class="trade-sidebar"><section><h4>首次计划</h4><dl class="facts">${fact("方向", DIRECTION_LABELS[answer.initialSubmission?.direction ?? ""] ?? "—")}${fact("首次决策", submittedAt == null ? "—" : `B${submittedAt}`)}${fact("自主观察", `${observationBars(answer)} bars`)}${fact("计划入场", fmt(plan?.entry), "entry-text")}${fact("止损", fmt(plan?.stop), "negative")}${fact("止盈", fmt(plan?.target1), "positive")}${fact("计划盈亏比", `${fmt(row.plannedRr)} R`)}${fact("止损距离", fmtPercent(row.stopDistancePct))}</dl>${plan?.rationale ? `<p class="rationale">${escapeHtml(plan.rationale)}</p>` : ""}</section>
+      <aside class="trade-sidebar"><section><h4>首次计划</h4><dl class="facts">${fact("方向", DIRECTION_LABELS[answer.initialSubmission?.direction ?? ""] ?? "—")}${fact("首次决策", submittedAt == null ? "—" : `B${submittedAt}`)}${fact("自主观察", `${observationBars(answer)} bars`)}${fact("计划入场", fmt(plan?.entry), "entry-text")}${fact("止损", fmt(plan?.stop), "negative")}${fact("止盈", fmt(plan?.target1), "positive")}${fact("计划盈亏比", `${fmt(row.plannedRr)} R`)}${fact("止损距离", fmtPercent(row.stopDistancePct))}</dl>${initialReason ? `<p class="decision-reason"><b>${escapeHtml(REASON_LABELS[initialReason.category])}</b>${escapeHtml(initialReason.summary)}</p>` : plan?.rationale ? `<p class="rationale">${escapeHtml(plan.rationale)}</p>` : ""}</section>
       <section><h4>Episode 结果</h4><dl class="facts">${fact("完整交易", `${trades.length} 笔`)}${fact("盈利 / 亏损", `${result?.winCount ?? trades.filter((trade) => trade.netR > 0).length} / ${result?.lossCount ?? trades.filter((trade) => trade.netR < 0).length}`)}${fact("Gross / Net R", `${fmtSigned(result?.grossR, 3)} / ${fmtSigned(result?.netR, 3)}`, valueClass(result?.netR))}${fact("最大回撤", `${fmt(result?.maxDrawdownR)} R`)}${fact("MFE / MAE", `${fmt(result?.mfeR)} / ${fmt(result?.maeR)}`)}${fact("首次成交 / 末次退出", `${entryAt == null ? "—" : `B${entryAt}`} / ${exitAt == null ? "—" : `B${exitAt}`}`)}${fact("累计持有", `${result?.holdingBars ?? 0} bars`)}${fact("方向命中", row.directionHit == null ? "—" : row.directionHit ? "是" : "否")}</dl></section>
-      ${renderTradeLedger(row)}<details class="actions"><summary>回放动作 <span>${actions.length}</span></summary>${actions.length === 0 ? `<p>没有动作记录</p>` : `<ol>${actions.map((action) => `<li><span>${String(action.step).padStart(2, "0")}</span><strong>${escapeHtml(action.action.type)}</strong><small>${escapeHtml(action.effectiveBarTime ?? action.at)}</small></li>`).join("")}</ol>`}</details></aside></div>
+      ${renderTradeLedger(row)}<details class="actions"><summary>回放动作与理由 <span>${actions.length}</span></summary>${actions.length === 0 ? `<p>没有动作记录</p>` : `<ol>${actions.map(renderActionRecord).join("")}</ol>`}</details></aside></div>
   </article>`;
 }
 
@@ -972,6 +1171,10 @@ const STYLES = String.raw`
 
 const PROCESS_STYLES = String.raw`
   .chart-legend i.decision{background:#7c3aed}.process-panel{border-top:1px solid var(--line);background:#fbfcfd}.process-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:9px 10px;border-bottom:1px solid var(--line)}.process-head>div:first-child strong,.process-head>div:first-child span{display:block}.process-head>div:first-child strong{font-size:11px}.process-head>div:first-child span{margin-top:1px;color:var(--muted);font:9px var(--mono)}.process-head>div:last-child{display:flex;align-items:center;gap:6px}.process-score,.process-reset{height:25px;padding:0 8px;border:1px solid var(--line-strong);border-radius:4px;background:#fff;font:9px inherit}.process-score{display:inline-flex;align-items:center}.process-score.pass{color:var(--green);border-color:#a7d8c7;background:#f0fdf8}.process-score.fail{color:var(--red);border-color:#efb4b4;background:#fff5f5}.process-reset{cursor:pointer;color:var(--text)}.process-reset:hover{background:var(--soft)}.process-rail{display:flex;gap:14px;padding:10px;overflow-x:auto;scrollbar-width:thin}.process-node{position:relative;flex:0 0 154px;min-height:94px;padding:8px 9px;border:1px solid var(--line);border-top:3px solid #94a3b8;border-radius:5px;background:#fff;color:var(--text);text-align:left;cursor:pointer}.process-node::after{content:"";position:absolute;top:42px;left:calc(100% + 1px);width:14px;height:1px;background:var(--line-strong)}.process-node:last-child::after{display:none}.process-node:hover{border-color:#94a3b8;background:#f8fafc}.process-node.active{border-color:#7c3aed;box-shadow:0 0 0 2px #ede9fe;background:#faf9ff}.process-node.data{border-top-color:#2563eb}.process-node.observe{border-top-color:#d97706}.process-node.decision{border-top-color:#7c3aed}.process-node.manage{border-top-color:#059669}.process-node.warning{border-top-color:#dc2626;background:#fffafa}.process-node.warning .process-bar{color:#dc2626}.process-node.error{border-color:var(--red);border-top-color:var(--red)}.process-index{position:absolute;top:6px;right:7px;color:#9aa2ad;font:8px var(--mono)}.process-bar{display:block;color:#7c3aed;font:650 10px var(--mono)}.process-node strong,.process-node small,.process-node em{display:block}.process-node strong{margin-top:5px;font-size:10px}.process-node small{margin-top:2px;color:var(--muted);font-size:8px;line-height:1.3}.process-node em{margin-top:6px;color:#87909b;font:7px var(--mono);font-style:normal}.process-checks{display:flex;align-items:center;gap:14px;min-height:31px;padding:6px 10px;border-top:1px solid var(--line);background:#fff;overflow-x:auto}.process-checks>span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;font-size:8px;color:var(--muted)}.process-checks i{display:grid;place-items:center;width:14px;height:14px;border-radius:50%;font-style:normal}.process-checks .pass i{color:var(--green);background:#e9f9f2}.process-checks .fail i{color:var(--red);background:#fff0f0}.process-checks small{font:7px var(--mono);color:#99a1ab}.process-empty{margin:0;padding:12px;color:var(--muted);font-size:10px}.trade-ledger{padding:0!important;border-bottom:1px solid var(--line)}.trade-ledger>h4,.trade-ledger>p{margin:0;padding:9px 12px}.trade-ledger>p{padding-top:0;color:var(--muted);font-size:9px}.trade-ledger>summary{display:flex;justify-content:space-between;padding:9px 12px;cursor:pointer;font-size:10px;font-weight:650}.trade-ledger>summary span{color:var(--muted)}.trade-ledger ol{list-style:none;margin:0;padding:0 12px 8px}.trade-ledger li{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:5px 8px;padding:7px 0;border-top:1px solid var(--line)}.trade-ledger li>div:first-child strong,.trade-ledger li>div:first-child small{display:block}.trade-ledger li>div:first-child strong{font-size:9px}.trade-ledger li>div:first-child small{color:var(--muted);font:7px var(--mono)}.trade-prices{grid-column:1/-1;display:flex;gap:7px;color:var(--muted);font:7px var(--mono);white-space:nowrap}.trade-ledger li>strong{grid-column:2;grid-row:1;font:650 10px var(--mono)}@media(max-width:680px){.process-head{align-items:flex-start;flex-direction:column}.process-head>div:last-child{width:100%;justify-content:space-between}.process-node{flex-basis:146px}.process-checks{gap:10px}.process-checks small{display:none}}@media print{.process-reset{display:none}.process-rail{flex-wrap:wrap;overflow:visible}.process-node{flex-basis:140px}}
+`;
+
+const REASON_STYLES = String.raw`
+  .reason-panel{margin-bottom:10px}.reason-empty{margin:0;padding:12px;color:var(--muted);font-size:10px}.reason-table{min-width:720px}.decision-reason{margin:8px 0 0;padding-top:8px;border-top:1px solid var(--line);color:var(--muted);font-size:10px}.decision-reason b,.trade-reason b{display:inline-block;margin-right:6px;color:#7c3aed}.trade-ledger li>div:first-child .trade-reason{margin-top:4px;color:var(--text);font:9px/1.45 inherit}.actions li{grid-template-columns:22px minmax(0,1fr);gap:6px;padding:7px 0}.actions li>div strong,.actions li>div small,.actions li>div em{display:block}.actions li>div strong{font-size:9px}.actions li>div small{margin-top:2px;color:var(--text);font:9px/1.4 inherit}.actions li>div em{margin-top:3px;color:var(--muted);font:7px var(--mono);font-style:normal}
 `;
 
 const SCRIPT = String.raw`
@@ -1133,6 +1336,7 @@ export function renderEpisodeReportHtml(input: EpisodeReportInput): { html: stri
   const generatedAt = (input.now ?? (() => new Date()))().toISOString();
   const rows = buildRows(input.answers, input.questions, input.traces);
   const metrics = aggregate(rows);
+  const reasonMetrics = aggregateReasons(rows);
   const runId = input.config.runId ?? "episode-run";
   const audits = input.audits ?? [];
   const auditChecks = audits.flatMap((audit) => audit.checks);
@@ -1172,12 +1376,17 @@ export function renderEpisodeReportHtml(input: EpisodeReportInput): { html: stri
     averageToolCalls: metrics.avgToolCalls,
     averageTokens: metrics.avgTokens,
     averageDecisionBars: metrics.avgDecisionBars,
+    reasonCoverage: reasonMetrics.coverage,
+    reasonedActions: reasonMetrics.reasonedActions,
+    decisionActions: reasonMetrics.decisionActions,
+    reasonCoverageByModel: reasonMetrics.coverageByModel,
+    reasonStats: reasonMetrics.stats,
     dataAuditPassed: auditPassed,
   };
   const charts = rows.map(buildChartPayload).filter((payload): payload is ChartPayload => payload != null);
   const models = input.config.config?.models ?? [...new Set(input.answers.map((answer) => answer.model))];
   const modes = input.config.config?.modes ?? [...new Set(input.answers.map((answer) => answer.mode))];
-  const html = `<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="color-scheme" content="light"/><link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%232563eb'/%3E%3Cpath d='M8 7h4v7l7-7h5l-8 8 9 10h-5l-8-9v9H8z' fill='white'/%3E%3C/svg%3E"/><title>${escapeHtml(runId)} · Episode Bench Report</title><style>${STYLES}${PROCESS_STYLES}</style></head><body><main class="report">
+  const html = `<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="color-scheme" content="light"/><link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%232563eb'/%3E%3Cpath d='M8 7h4v7l7-7h5l-8 8 9 10h-5l-8-9v9H8z' fill='white'/%3E%3C/svg%3E"/><title>${escapeHtml(runId)} · Episode Bench Report</title><style>${STYLES}${PROCESS_STYLES}${REASON_STYLES}</style></head><body><main class="report">
     <header class="report-header"><div class="report-title"><h1>Episode Bench Report</h1><p>${escapeHtml(runId)}</p></div><div class="header-meta"><span class="chip">${escapeHtml(input.config.datasetVersion ?? input.config.config?.datasetVersion ?? "—")}</span><span class="chip">${escapeHtml(models.join(" · "))}</span><span class="chip">${escapeHtml(modes.map((mode) => MODE_LABELS[mode] ?? mode).join(" / "))}</span><span class="chip">${input.config.costBps ?? 0} bps</span><span class="chip audit-state ${auditPassed === true ? "pass" : auditPassed === false ? "fail" : ""}">${auditPassed === true ? "长桥数据已校验" : auditPassed === false ? "数据审计失败" : "未附加数据审计"}</span><span class="generated">${escapeHtml(generatedAt)}</span></div></header>
     <section class="panel summary"><div class="panel-title"><h2>运行总览</h2><span>${metrics.completed}/${metrics.cases} 完成 · ${metrics.trades} 笔完整交易</span></div><div class="metrics">
       ${metricCell("平均净 R / case", `${fmtSigned(metrics.avgNetRPerCase, 3)} R`, `累计 ${fmtSigned(metrics.totalNetR, 3)} R`, valueClass(metrics.avgNetRPerCase))}
@@ -1193,7 +1402,7 @@ export function renderEpisodeReportHtml(input: EpisodeReportInput): { html: stri
       ${metricCell("执行成本", fmtUsd(metrics.avgCostUsd), `${input.config.costBps ?? 0} bps`)}
       ${metricCell("耗时 / 首次决策", `${fmtDuration(metrics.avgDurationMs)} / ${metrics.avgDecisionBars == null ? "—" : `B${fmt(metrics.avgDecisionBars, 1)}`}`, `${fmt(metrics.avgToolCalls, 1)} tools · ${fmt(metrics.avgTokens, 0)} tokens`)}
     </div><div class="config-strip"><div><span>初始 1H</span><strong>${config?.h1 ?? "—"} bars</strong></div><div><span>初始日线</span><strong>${config?.day ?? "—"} bars</strong></div><div><span>初始周线</span><strong>${config?.week ?? "—"} bars</strong></div><div><span>回放窗口</span><strong>${config?.sessions ?? "—"} sessions</strong></div><div><span>回放 1H</span><strong>${config?.bars ?? "—"} bars</strong></div><div><span>首次决策</span><strong>B0 起自主决定</strong></div><div><span>待成交窗口</span><strong>${config?.expiry ?? "—"} bars</strong></div><div><span>强平提醒</span><strong>T-5 → T-1</strong></div><div><span>长桥日 / 周回填</span><strong>${config?.dayRollups ?? "—"} / ${config?.weekRollups ?? "—"}</strong></div></div></section>
-    ${renderModelTable(rows)}${renderCasesTable(rows)}<section class="case-details">${rows.map(renderCaseDetail).join("")}</section>${renderAudit(audits)}
+    ${renderReasonTable(rows)}${renderModelTable(rows)}${renderCasesTable(rows)}<section class="case-details">${rows.map(renderCaseDetail).join("")}</section>${renderAudit(audits)}
     <footer class="footer"><span>KANSOKU BENCH · Git ${escapeHtml(input.config.gitSha ?? "—")}</span><span>图表由 <a href="https://www.tradingview.com/" target="_blank" rel="noreferrer">TradingView Lightweight Charts™</a> 提供 · 行情数据源：长桥</span></footer>
   </main><script src="https://unpkg.com/lightweight-charts@5.2.0/dist/lightweight-charts.standalone.production.js"></script><script>const REPORT_CHARTS=${serializeForScript(charts)};${SCRIPT}</script></body></html>`;
   return { html, summary };

--- a/app/packages/bench/src/schema/episode.ts
+++ b/app/packages/bench/src/schema/episode.ts
@@ -1,20 +1,35 @@
 import { type Static, Type } from "typebox";
 import { submissionSchema } from "./submission.js";
+import { episodeTradeReasonSchema } from "./tradeReason.js";
 
 const nullableNumber = Type.Union([Type.Number(), Type.Null()]);
 
+const requiredReason = { reason: episodeTradeReasonSchema };
+const optionalReason = { reason: Type.Optional(episodeTradeReasonSchema) };
+
+export const episodeSubmissionSchema = Type.Object(
+  {
+    ...submissionSchema.properties,
+    decision_reason: episodeTradeReasonSchema,
+  },
+  { additionalProperties: false },
+);
+
+export type EpisodeSubmission = Static<typeof episodeSubmissionSchema>;
+
 export const episodeTradeActionSchema = Type.Union([
-  Type.Object({ type: Type.Literal("hold") }, { additionalProperties: false }),
+  Type.Object({ type: Type.Literal("hold"), ...requiredReason }, { additionalProperties: false }),
   Type.Object(
     {
       type: Type.Literal("amend"),
       stop: Type.Optional(Type.Number()),
       target: Type.Optional(Type.Number()),
+      ...requiredReason,
     },
     { additionalProperties: false },
   ),
-  Type.Object({ type: Type.Literal("cancel") }, { additionalProperties: false }),
-  Type.Object({ type: Type.Literal("exit_next_open") }, { additionalProperties: false }),
+  Type.Object({ type: Type.Literal("cancel"), ...requiredReason }, { additionalProperties: false }),
+  Type.Object({ type: Type.Literal("exit_next_open"), ...requiredReason }, { additionalProperties: false }),
 ]);
 
 export type EpisodeTradeAction = Static<typeof episodeTradeActionSchema>;
@@ -28,6 +43,7 @@ export const episodeActionSchema = Type.Union([
       entry: Type.Optional(Type.Number()),
       stop: Type.Optional(Type.Number()),
       target: Type.Optional(Type.Number()),
+      ...requiredReason,
     },
     { additionalProperties: false },
   ),
@@ -35,6 +51,37 @@ export const episodeActionSchema = Type.Union([
 ]);
 
 export type EpisodeAction = Static<typeof episodeActionSchema>;
+
+const episodeRecordedTradeActionSchema = Type.Union([
+  Type.Object({ type: Type.Literal("hold"), ...optionalReason }, { additionalProperties: false }),
+  Type.Object(
+    {
+      type: Type.Literal("amend"),
+      stop: Type.Optional(Type.Number()),
+      target: Type.Optional(Type.Number()),
+      ...optionalReason,
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object({ type: Type.Literal("cancel"), ...optionalReason }, { additionalProperties: false }),
+  Type.Object({ type: Type.Literal("exit_next_open"), ...optionalReason }, { additionalProperties: false }),
+]);
+
+const episodeRecordedActionSchema = Type.Union([
+  Type.Object({ type: Type.Literal("observe") }, { additionalProperties: false }),
+  Type.Object(
+    {
+      type: Type.Literal("submit"),
+      direction: Type.Union([Type.Literal("long"), Type.Literal("short"), Type.Literal("neutral")]),
+      entry: Type.Optional(Type.Number()),
+      stop: Type.Optional(Type.Number()),
+      target: Type.Optional(Type.Number()),
+      ...optionalReason,
+    },
+    { additionalProperties: false },
+  ),
+  episodeRecordedTradeActionSchema,
+]);
 
 export const episodeTerminationReasonSchema = Type.Union([
   Type.Literal("abstain"),
@@ -61,7 +108,7 @@ export const episodeActionRecordSchema = Type.Object(
     tradeId: Type.Optional(Type.Union([Type.Integer({ minimum: 1 }), Type.Null()])),
     at: Type.String(),
     effectiveBarTime: Type.Union([Type.String(), Type.Null()]),
-    action: episodeActionSchema,
+    action: episodeRecordedActionSchema,
   },
   { additionalProperties: false },
 );
@@ -92,6 +139,7 @@ export const episodeClosedTradeSchema = Type.Object(
     mfeR: Type.Number({ minimum: 0 }),
     maeR: Type.Number({ minimum: 0 }),
     holdingBars: Type.Integer({ minimum: 0 }),
+    entryReason: Type.Optional(episodeTradeReasonSchema),
   },
   { additionalProperties: false },
 );

--- a/app/packages/bench/src/schema/index.ts
+++ b/app/packages/bench/src/schema/index.ts
@@ -2,18 +2,26 @@ export { barSchema, type Bar } from "./bar.js";
 export { newsItemSchema, type BenchNewsItem } from "./newsItem.js";
 export type { MockMode } from "./mode.js";
 export { submissionSchema, type Submission } from "./submission.js";
+export {
+  episodeTradeReasonCategorySchema,
+  episodeTradeReasonSchema,
+  type EpisodeTradeReason,
+  type EpisodeTradeReasonCategory,
+} from "./tradeReason.js";
 export { questionSchema, type Question, type RunnerQuestion } from "./question.js";
 export { answerLineSchema, type AnswerLine } from "./answerLine.js";
 export { runConfigSchema, weightsSchema, type RunConfig, RUN_CONFIG_DEFAULTS } from "./runConfig.js";
 export { scoresSchema, cellVerdictSchema, type Scores } from "./scores.js";
 export {
   episodeActionSchema,
+  episodeSubmissionSchema,
   episodeTradeActionSchema,
   episodeAnswerSchema,
   episodeClosedTradeSchema,
   episodeTradeResultSchema,
   episodeTerminationReasonSchema,
   type EpisodeAction,
+  type EpisodeSubmission,
   type EpisodeTradeAction,
   type EpisodeActionRecord,
   type EpisodeAnswer,

--- a/app/packages/bench/src/schema/submission.ts
+++ b/app/packages/bench/src/schema/submission.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "typebox";
+import { episodeTradeReasonSchema } from "./tradeReason.js";
 
 const anchorSchema = Type.Object(
   {
@@ -51,6 +52,7 @@ export const submissionSchema = Type.Object(
     entry_plan: Type.Optional(entryPlanSchema),
     scenarios: Type.Array(scenarioSchema, { minItems: 2, maxItems: 4 }),
     range_plan: Type.Optional(rangePlanSchema),
+    decision_reason: Type.Optional(episodeTradeReasonSchema),
     comment: Type.String(),
   },
   { additionalProperties: false },

--- a/app/packages/bench/src/schema/tradeReason.ts
+++ b/app/packages/bench/src/schema/tradeReason.ts
@@ -1,0 +1,32 @@
+import { type Static, Type } from "typebox";
+
+export const episodeTradeReasonCategorySchema = Type.Union([
+  Type.Literal("trend_following"),
+  Type.Literal("breakout"),
+  Type.Literal("pullback"),
+  Type.Literal("mean_reversion"),
+  Type.Literal("support_resistance"),
+  Type.Literal("momentum"),
+  Type.Literal("volume_flow"),
+  Type.Literal("volatility"),
+  Type.Literal("news_event"),
+  Type.Literal("fundamental"),
+  Type.Literal("risk_management"),
+  Type.Literal("thesis_invalidated"),
+  Type.Literal("profit_protection"),
+  Type.Literal("time_horizon"),
+  Type.Literal("no_setup"),
+  Type.Literal("other"),
+]);
+
+export type EpisodeTradeReasonCategory = Static<typeof episodeTradeReasonCategorySchema>;
+
+export const episodeTradeReasonSchema = Type.Object(
+  {
+    category: episodeTradeReasonCategorySchema,
+    summary: Type.String({ minLength: 1, maxLength: 800 }),
+  },
+  { additionalProperties: false },
+);
+
+export type EpisodeTradeReason = Static<typeof episodeTradeReasonSchema>;

--- a/app/packages/bench/test/episode/engine.test.ts
+++ b/app/packages/bench/test/episode/engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { advanceEpisode, createEpisodeState, observeEpisode, submitEpisode } from "../../src/episode/engine.js";
+import type { EpisodeTradeAction } from "../../src/schema/episode.js";
 import type { Question } from "../../src/schema/question.js";
 import type { Submission } from "../../src/schema/submission.js";
 
@@ -41,6 +42,7 @@ function prediction(direction: "long" | "short", entry: number, stop: number, ta
       { label: "主情景", probability: 60 },
       { label: "反向情景", probability: 40 },
     ],
+    decision_reason: { category: "breakout", summary: "价格突破关键结构，按计划入场。" },
     comment: "测试交易计划",
   };
 }
@@ -53,21 +55,36 @@ function neutral(): Submission {
       { label: "区间", probability: 60 },
       { label: "突破", probability: 40 },
     ],
+    decision_reason: { category: "no_setup", summary: "当前没有满足风险收益要求的机会。" },
     comment: "继续观察",
   };
+}
+
+function reasoned<T extends Record<string, unknown>>(action: T): EpisodeTradeAction {
+  return {
+    ...action,
+    reason: { category: "risk_management", summary: "结构尚未失效，继续按既定风险计划执行。" },
+  } as EpisodeTradeAction;
 }
 
 describe("episode engine", () => {
   it("allows immediate B0 trading and multiple round trips before the fixed horizon", () => {
     const q = question();
     let state = submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 104)).state;
-    const firstExit = advanceEpisode(state, q, { type: "hold" });
+    const firstExit = advanceEpisode(state, q, reasoned({ type: "hold" }));
     expect(firstExit).toMatchObject({ terminal: false, event: "target_hit" });
     expect(firstExit.state).toMatchObject({ phase: "flat", cursor: 0, decisionBar: 0 });
     expect(firstExit.state.trades).toHaveLength(1);
+    expect(firstExit.state.trades[0].entryReason).toEqual({
+      category: "breakout",
+      summary: "价格突破关键结构，按计划入场。",
+    });
+    expect(firstExit.state.actions.map((record) =>
+      "reason" in record.action ? record.action.reason?.category : null
+    )).toEqual(["breakout", "risk_management"]);
 
     state = submitEpisode(firstExit.state, q, prediction("short", 105, 110, 101)).state;
-    const secondExit = advanceEpisode(state, q, { type: "hold" });
+    const secondExit = advanceEpisode(state, q, reasoned({ type: "hold" }));
     expect(secondExit).toMatchObject({ terminal: false, event: "target_hit" });
     expect(secondExit.state.trades).toHaveLength(2);
 
@@ -92,7 +109,7 @@ describe("episode engine", () => {
     const submitted = submitEpisode(observed.state, q, prediction("short", 105, 110, 101));
     expect(submitted.state).toMatchObject({ phase: "pending", decisionBar: 1 });
 
-    const exited = advanceEpisode(submitted.state, q, { type: "hold" });
+    const exited = advanceEpisode(submitted.state, q, reasoned({ type: "hold" }));
     expect(exited).toMatchObject({ terminal: false, event: "target_hit" });
     expect(exited.state.trades[0]).toMatchObject({
       decisionBar: 1,
@@ -121,7 +138,7 @@ describe("episode engine", () => {
       bar("2026-03-23T15:30:00Z", 95, 100, 94, 99),
     ]);
     const submitted = submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 120));
-    const stopped = advanceEpisode(submitted.state, q, { type: "hold" });
+    const stopped = advanceEpisode(submitted.state, q, reasoned({ type: "hold" }));
     expect(stopped).toMatchObject({ terminal: false, event: "stop_hit" });
     expect(stopped.state).toMatchObject({ phase: "flat", cursor: 0 });
     expect(() => submitEpisode(stopped.state, q, prediction("long", 95, 90, 100))).not.toThrow();
@@ -134,8 +151,8 @@ describe("episode engine", () => {
       bar("2026-03-23T16:30:00Z", 101, 103, 100, 102),
     ]);
     let state = submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 110)).state;
-    state = advanceEpisode(state, q, { type: "hold" }).state;
-    const stopped = advanceEpisode(state, q, { type: "amend", stop: 101 });
+    state = advanceEpisode(state, q, reasoned({ type: "hold" })).state;
+    const stopped = advanceEpisode(state, q, reasoned({ type: "amend", stop: 101 }));
     expect(stopped).toMatchObject({ terminal: false, event: "stop_hit" });
     expect(stopped.state.trades[0]).toMatchObject({ exitReason: "stop", grossR: 0.2 });
   });
@@ -145,9 +162,9 @@ describe("episode engine", () => {
     const filled = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 120)).state,
       q,
-      { type: "hold" },
+      reasoned({ type: "hold" }),
     );
-    const exited = advanceEpisode(filled.state, q, { type: "exit_next_open" });
+    const exited = advanceEpisode(filled.state, q, reasoned({ type: "exit_next_open" }));
     expect(exited).toMatchObject({ terminal: false, event: "manual_exit" });
     expect(exited.state.trades[0]).toMatchObject({ exitReason: "manual", exit: { price: 105 } });
   });
@@ -160,14 +177,14 @@ describe("episode engine", () => {
       bar("2026-03-23T17:30:00Z", 103, 105, 102, 104),
     ]);
     let state = submitEpisode(createEpisodeState(), q, prediction("long", 90, 85, 100)).state;
-    state = advanceEpisode(state, q, { type: "hold" }).state;
-    state = advanceEpisode(state, q, { type: "hold" }).state;
-    const expired = advanceEpisode(state, q, { type: "hold" });
+    state = advanceEpisode(state, q, reasoned({ type: "hold" })).state;
+    state = advanceEpisode(state, q, reasoned({ type: "hold" })).state;
+    const expired = advanceEpisode(state, q, reasoned({ type: "hold" }));
     expect(expired).toMatchObject({ terminal: false, event: "no_fill" });
     expect(expired.state.phase).toBe("flat");
 
     const pending = submitEpisode(expired.state, q, prediction("long", 90, 85, 100));
-    const cancelled = advanceEpisode(pending.state, q, { type: "cancel" });
+    const cancelled = advanceEpisode(pending.state, q, reasoned({ type: "cancel" }));
     expect(cancelled).toMatchObject({ terminal: false, event: "cancelled", bar: null });
     expect(cancelled.state.phase).toBe("flat");
   });
@@ -177,7 +194,7 @@ describe("episode engine", () => {
     const result = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 106)).state,
       q,
-      { type: "hold" },
+      reasoned({ type: "hold" }),
     );
     expect(result).toMatchObject({ terminal: true, event: "stop_hit" });
     expect(result.result!.trades![0]).toMatchObject({ exitReason: "stop", grossR: -1 });
@@ -188,7 +205,7 @@ describe("episode engine", () => {
     const result = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction("long", 100.1, 98.6, 101.8)).state,
       q,
-      { type: "hold" },
+      reasoned({ type: "hold" }),
     );
 
     expect(result).toMatchObject({ terminal: true, event: "stop_hit" });
@@ -205,7 +222,7 @@ describe("episode engine", () => {
     const result = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction("short", 95, 105, 90)).state,
       q,
-      { type: "hold" },
+      reasoned({ type: "hold" }),
     );
     expect(result).toMatchObject({ terminal: true, event: "target_hit" });
     expect(result.result!.trades![0]).toMatchObject({
@@ -224,7 +241,7 @@ describe("episode engine", () => {
     const result = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction("long", 100, 95, 120)).state,
       q,
-      { type: "hold" },
+      reasoned({ type: "hold" }),
     );
     expect(result).toMatchObject({ terminal: true, event: "horizon_exit" });
     expect(result.result).toMatchObject({ terminationReason: "horizon", tradeCount: 1, grossR: 0.4 });

--- a/app/packages/bench/test/episode/report.test.ts
+++ b/app/packages/bench/test/episode/report.test.ts
@@ -62,6 +62,7 @@ const answer: EpisodeAnswer = {
       { label: "下跌", probability: 60 },
       { label: "反弹", probability: 40 },
     ],
+    decision_reason: { category: "breakout", summary: "日线与周线同步跌破关键支撑。" },
     comment: "测试",
   },
   result: {
@@ -76,7 +77,7 @@ const answer: EpisodeAnswer = {
     mfeR: 0.4874559,
     maeR: 0.2134045,
     holdingBars: 1,
-    steps: 2,
+    steps: 3,
     decisionBar: 1,
     decisionTime: "2026-03-26T13:30:00Z",
     observationBars: 1,
@@ -98,6 +99,7 @@ const answer: EpisodeAnswer = {
       mfeR: 0.4874559,
       maeR: 0.2134045,
       holdingBars: 1,
+      entryReason: { category: "breakout", summary: "日线与周线同步跌破关键支撑。" },
     }],
     tradeCount: 1,
     winCount: 1,
@@ -105,7 +107,27 @@ const answer: EpisodeAnswer = {
     maxDrawdownR: 0,
     actions: [
       { step: 1, at: question.cutoff, effectiveBarTime: "2026-03-26T13:30:00Z", action: { type: "observe" } },
-      { step: 2, at: "2026-03-26T13:30:00Z", effectiveBarTime: "2026-03-26T14:30:00Z", action: { type: "hold" } },
+      {
+        step: 2,
+        tradeId: 1,
+        at: "2026-03-26T13:30:00Z",
+        effectiveBarTime: "2026-03-26T14:30:00Z",
+        action: {
+          type: "submit",
+          direction: "short",
+          entry: 379.5,
+          stop: 389.2,
+          target: 361,
+          reason: { category: "breakout", summary: "日线与周线同步跌破关键支撑。" },
+        },
+      },
+      {
+        step: 3,
+        tradeId: 1,
+        at: "2026-03-26T13:30:00Z",
+        effectiveBarTime: "2026-03-26T14:30:00Z",
+        action: { type: "hold", reason: { category: "risk_management", summary: "止损仍有效，继续执行原计划。" } },
+      },
     ],
   },
   metrics: { durationMs: 25_095, costUsd: 0.12715, toolCalls: 7, inputTokens: 10_490, outputTokens: 826 },
@@ -141,8 +163,8 @@ describe("episode HTML report", () => {
       { type: "tool_call", sequence: 3, name: "fetch_kline", args: { period: "week", count: 30 }, contextBefore: { barIndex: 0, phase: "flat" }, contextAfter: { barIndex: 0, phase: "flat" }, durationMs: 2 },
       { type: "tool_call", sequence: 4, name: "observe_next_bar", args: {}, contextBefore: { barIndex: 0, phase: "flat" }, contextAfter: { barIndex: 1, phase: "flat" }, resultSummary: '{"barIndex":1,"event":"observed","terminal":false}', durationMs: 1 },
       { type: "prompt_context", barIndex: 1, phase: "flat", remainingBars: 1, tradeCount: 0, episodeNetR: 0, warningInjected: true, warningPriority: "critical" },
-      { type: "tool_call", sequence: 5, name: "submit_prediction", args: { direction: "short" }, contextBefore: { barIndex: 1, phase: "flat" }, contextAfter: { barIndex: 1, phase: "pending", decisionBar: 1 }, resultSummary: '{"barIndex":1,"event":"waiting_fill","terminal":false}', durationMs: 2 },
-      { type: "tool_call", sequence: 6, name: "advance_trade", args: { type: "hold" }, contextBefore: { barIndex: 1, phase: "pending", decisionBar: 1 }, contextAfter: { barIndex: 2, phase: "terminal", decisionBar: 1 }, resultSummary: '{"barIndex":2,"event":"target_hit","terminal":true}', durationMs: 1 },
+      { type: "tool_call", sequence: 5, name: "submit_prediction", args: { direction: "short", decision_reason: { category: "breakout", summary: "日线与周线同步跌破关键支撑。" } }, contextBefore: { barIndex: 1, phase: "flat" }, contextAfter: { barIndex: 1, phase: "pending", decisionBar: 1 }, resultSummary: '{"barIndex":1,"event":"waiting_fill","terminal":false}', durationMs: 2 },
+      { type: "tool_call", sequence: 6, name: "advance_trade", args: { type: "hold", reason: { category: "risk_management", summary: "止损仍有效，继续执行原计划。" } }, contextBefore: { barIndex: 1, phase: "pending", decisionBar: 1 }, contextAfter: { barIndex: 2, phase: "terminal", decisionBar: 1 }, resultSummary: '{"barIndex":2,"event":"target_hit","terminal":true}', durationMs: 1 },
     ]],
   ]);
   const rendered = renderEpisodeReportHtml({
@@ -190,6 +212,10 @@ describe("episode HTML report", () => {
     expect(rendered.html).toContain("T-2 强平提醒");
     expect(rendered.html).toContain("T-1 强平提醒");
     expect(rendered.html).toContain("过程检查 5/5");
+    expect(rendered.html).toContain("交易原因统计");
+    expect(rendered.html).toContain("理由覆盖 2/2 · 100.0%");
+    expect(rendered.html).toContain("日线与周线同步跌破关键支撑");
+    expect(rendered.html).toContain("止损仍有效，继续执行原计划");
     expect(rendered.html).toContain("payload.snapshotPatches");
   });
 
@@ -216,7 +242,42 @@ describe("episode HTML report", () => {
       averageToolCalls: 7,
       averageTokens: 11_316,
       averageDecisionBars: 1,
+      reasonCoverage: 1,
+      reasonedActions: 2,
+      decisionActions: 2,
+      reasonCoverageByModel: [{
+        model: answer.model,
+        reasonedActions: 2,
+        decisionActions: 2,
+        coverage: 1,
+      }],
       dataAuditPassed: true,
     });
+    expect(rendered.summary.reasonStats).toEqual([
+      {
+        model: answer.model,
+        category: "breakout",
+        actions: 1,
+        actionBreakdown: { submit: 1 },
+        entries: 1,
+        trades: 1,
+        wins: 1,
+        winRate: 1,
+        averageNetR: 0.4428025,
+        totalNetR: 0.4428025,
+      },
+      {
+        model: answer.model,
+        category: "risk_management",
+        actions: 1,
+        actionBreakdown: { hold: 1 },
+        entries: 0,
+        trades: 0,
+        wins: 0,
+        winRate: null,
+        averageNetR: null,
+        totalNetR: 0,
+      },
+    ]);
   });
 });

--- a/app/packages/bench/test/episode/view.test.ts
+++ b/app/packages/bench/test/episode/view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { advanceEpisode, createEpisodeState, submitEpisode } from "../../src/episode/engine.js";
 import { buildEpisodeQuestionView } from "../../src/episode/view.js";
+import type { EpisodeTradeAction } from "../../src/schema/episode.js";
 import type { Question } from "../../src/schema/question.js";
 import type { Submission } from "../../src/schema/submission.js";
 
@@ -64,13 +65,19 @@ const SUBMISSION: Submission = {
     { label: "上涨", probability: 60 },
     { label: "回撤", probability: 40 },
   ],
+  decision_reason: { category: "trend_following", summary: "多周期趋势保持向上。" },
   comment: "多周期视图测试",
+};
+
+const HOLD: EpisodeTradeAction = {
+  type: "hold",
+  reason: { category: "risk_management", summary: "趋势未失效，继续持有。" },
 };
 
 describe("episode rolling multi-timeframe view", () => {
   it("reveals one hourly bar and builds a partial day/week without exposing later bars", () => {
     const submitted = submitEpisode(createEpisodeState(), QUESTION, SUBMISSION);
-    const first = advanceEpisode(submitted.state, QUESTION, { type: "hold" });
+    const first = advanceEpisode(submitted.state, QUESTION, HOLD);
     const view = buildEpisodeQuestionView(QUESTION, first.state);
 
     expect(view.fixtures.kline["1h"].map((entry) => entry.time)).toEqual([
@@ -86,8 +93,8 @@ describe("episode rolling multi-timeframe view", () => {
 
   it("updates the same day candle, then starts a new day while retaining all revealed hours", () => {
     let state = submitEpisode(createEpisodeState(), QUESTION, SUBMISSION).state;
-    state = advanceEpisode(state, QUESTION, { type: "hold" }).state;
-    state = advanceEpisode(state, QUESTION, { type: "hold" }).state;
+    state = advanceEpisode(state, QUESTION, HOLD).state;
+    state = advanceEpisode(state, QUESTION, HOLD).state;
     let view = buildEpisodeQuestionView(QUESTION, state);
     expect(view.fixtures.kline.day.at(-1)).toMatchObject({
       time: "2026-03-23",
@@ -99,7 +106,7 @@ describe("episode rolling multi-timeframe view", () => {
     });
     expect(view.fixtures.quote).toMatchObject({ last: 104.1, open: 99.5, high: 105.5, low: 98.5, volume: 550 });
 
-    state = advanceEpisode(state, QUESTION, { type: "hold" }).state;
+    state = advanceEpisode(state, QUESTION, HOLD).state;
     view = buildEpisodeQuestionView(QUESTION, state);
     expect(view.fixtures.kline["1h"]).toHaveLength(4);
     expect(view.fixtures.kline.day.slice(-2).map((entry) => entry.time)).toEqual(["2026-03-23", "2026-03-24"]);

--- a/docs/superpowers/specs/2026-07-18-bench-episode-mode-design.md
+++ b/docs/superpowers/specs/2026-07-18-bench-episode-mode-design.md
@@ -104,12 +104,22 @@ flowchart TD
 `advance_trade` 的动作结构：
 
 ```ts
+interface EpisodeTradeReason {
+  category: "trend_following" | "breakout" | "pullback" | "mean_reversion"
+    | "support_resistance" | "momentum" | "volume_flow" | "volatility"
+    | "news_event" | "fundamental" | "risk_management" | "thesis_invalidated"
+    | "profit_protection" | "time_horizon" | "no_setup" | "other";
+  summary: string;
+}
+
 type EpisodeTradeAction =
-  | { type: "hold" }
-  | { type: "amend"; stop?: number; target?: number }
-  | { type: "cancel" }
-  | { type: "exit_next_open" };
+  | { type: "hold"; reason: EpisodeTradeReason }
+  | { type: "amend"; stop?: number; target?: number; reason: EpisodeTradeReason }
+  | { type: "cancel"; reason: EpisodeTradeReason }
+  | { type: "exit_next_open"; reason: EpisodeTradeReason };
 ```
+
+`submit_prediction` 同样必须提交 `decision_reason: EpisodeTradeReason`。这是模型主动提供的、可审计的决策依据摘要，不是隐藏思维链。缺少理由的工具调用由 runner 拒绝，模型必须修正后重新提交。
 
 - `flat + hold` 与继续观察等价；
 - `pending + cancel` 在当前虚拟时点撤单，不公开新 K 线；
@@ -252,6 +262,7 @@ interface EpisodeClosedTrade {
   mfeR: number;
   maeR: number;
   holdingBars: number;
+  entryReason?: EpisodeTradeReason;
 }
 
 interface EpisodeTradeResult {
@@ -288,6 +299,8 @@ interface EpisodeTradeResult {
 | MFE / MAE | 每笔交易持仓期间的最大有利和不利波动 |
 | 最大回撤 | 按已结算交易累计净 R 计算的 Episode 最大回撤 |
 | 决策位置 | 第一次方向提交所在的 B 编号；B0 立即交易是合法结果 |
+| 理由覆盖率 | 已提交结构化理由的交易决策动作数除以全部交易决策动作数，并按模型分别统计 |
+| 原因表现 | 按“模型 × 入场主原因”统计提交数、成交数、胜率、平均净 R 与累计净 R |
 | 效率 | 每 case 的工具调用、模型调用、token、耗时和 USD 成本 |
 
 不允许只统计“有交易的胜率”作为主胜率，也不允许把全程空仓 case 从分母中删除。
@@ -299,15 +312,16 @@ interface EpisodeTradeResult {
 | 区域 | 内容 |
 | --- | --- |
 | 运行总览 | 平均净 R、Episode/交易胜率、方向命中、Profit Factor、参与/成交、期望、MFE/MAE、回撤、成本和耗时 |
+| 交易原因统计 | 按模型和主原因统计理由覆盖、动作分布、入场/成交、胜率和净 R |
 | 数据配置 | 1h/day/week 数量、完整回放窗口、待成交窗口、T-5 提醒、长桥日/周回填 |
 | Case 图表 | TradingView Lightweight Charts 的 1 小时、日线、周线 K 线和成交量 |
 | 图表标注 | `CASE START · B0`、首根回放、`B_end · 强制结算`、每笔决策、成交、初始止损、目标和退出 |
-| 交易明细 | 每笔交易的方向、决策/成交/退出 B 编号、E/S/T/X、退出原因和净 R |
-| 工具链 | 只读查询、观察、提交、管理动作及其 B 编号和阶段变化 |
+| 交易明细 | 每笔交易的方向、决策/成交/退出 B 编号、E/S/T/X、入场理由、退出原因和净 R |
+| 工具链 | 只读查询、观察、提交、管理动作、显式决策理由及其 B 编号和阶段变化 |
 | Message Engine | `T-5` 到 `T-1` 强平提醒节点，以及提醒完整性检查 |
 | 数据审计 | 长桥 1h/day/week、cutoff、时区、滚动周期和未来数据边界 |
 
-点击工具或提醒节点时，图表切换到该节点对应的 B 编号及周期，只展示当时已经公开的数据。报告不展示隐藏推理，只展示工具输入、状态变化、消息注入元数据和结果摘要。
+点击工具或提醒节点时，图表切换到该节点对应的 B 编号及周期，只展示当时已经公开的数据。报告不展示隐藏思维链；它展示模型在每次交易操作中主动提交的结构化理由摘要、工具输入、状态变化、消息注入元数据和结果摘要。
 
 ## 14. Trace 与消息审计
 


### PR DESCRIPTION
## Summary

- add a structured trade-reason taxonomy while preserving compatibility with historical Episode JSONL
- persist entry reasons on completed trades and reasons on every submitted management action
- report reason coverage and performance by model and primary reason category
- show per-action and per-trade rationale summaries in the Episode HTML report

## Verification

- 274 public benchmark tests passed
- all public workspace TypeScript projects passed typecheck
- a real five-session blind run recorded reasons for 38 of 38 decision actions with zero missing reasons
- historical result files still render and correctly report zero reason coverage