### PR TITLE
feat(bench): batch hold and multi-period advance for episodes

### DIFF
--- a/packages/bench/src/episode/engine.ts
+++ b/packages/bench/src/episode/engine.ts
@@ -9,6 +9,7 @@ import type {
 import type { Question } from '../schema/question.js';
 import type { Submission } from '../schema/submission.js';
 import type { EpisodeTradeReason } from '../schema/tradeReason.js';
+import { marketDate, weekKey } from './generate.js';
 
 export type EpisodePhase = 'flat' | 'pending' | 'open' | 'terminal';
 export type EpisodeEvent =
@@ -80,6 +81,8 @@ export interface EpisodeAdvanceResult {
   event: EpisodeEvent;
   terminal: boolean;
   result: EpisodeTradeResult | null;
+  batchAdvancedBars?: number;
+  batchStopReason?: 'requested' | EpisodeEvent | 'terminal';
 }
 
 function numberOf(value: string | number): number {
@@ -493,12 +496,13 @@ function advanceFlat(
   state: EpisodeState,
   question: Question,
   action: Extract<EpisodeAction, { type: 'hold' | 'observe' }>,
+  skipRecord = false,
 ): EpisodeAdvanceResult {
   const nextCursor = state.cursor + 1;
   const bar = replayBar(question, nextCursor);
   if (!bar) throw new Error('episode has no next replay bar');
   const working: EpisodeState = {
-    ...withAction(state, question, action, bar),
+    ...(skipRecord ? state : withAction(state, question, action, bar)),
     cursor: nextCursor,
   };
   if (remainingEpisodeBars(working, question) === 0) {
@@ -516,16 +520,17 @@ export function observeEpisode(
   return advanceFlat(state, question, { type: 'observe' });
 }
 
-export function advanceEpisode(
+function advanceEpisodeSingle(
   state: EpisodeState,
   question: Question,
   action: EpisodeTradeAction,
   options: EpisodeEngineOptions = {},
+  skipRecord = false,
 ): EpisodeAdvanceResult {
   if (state.phase === 'terminal') throw new Error('episode already terminated');
   if (state.phase === 'flat') {
     if (action.type !== 'hold') throw new Error(`action ${action.type} is invalid while flat`);
-    return advanceFlat(state, question, action);
+    return advanceFlat(state, question, action, skipRecord);
   }
   if (state.phase === 'pending' && action.type !== 'hold' && action.type !== 'cancel') {
     throw new Error(`action ${action.type} is invalid while the order is pending`);
@@ -541,7 +546,7 @@ export function advanceEpisode(
 
   const activeTradeId = state.order?.tradeId ?? state.position?.tradeId ?? null;
   if (action.type === 'cancel') {
-    const cancelled = withAction(state, question, action, null, activeTradeId);
+    const cancelled = skipRecord ? state : withAction(state, question, action, null, activeTradeId);
     const nextState: EpisodeState = { ...cancelled, phase: 'flat', order: null };
     return {
       state: nextState,
@@ -557,7 +562,7 @@ export function advanceEpisode(
   const bar = replayBar(question, nextCursor);
   if (!bar) throw new Error('episode has no next replay bar');
   let working: EpisodeState = {
-    ...withAction(state, question, action, bar, activeTradeId),
+    ...(skipRecord ? state : withAction(state, question, action, bar, activeTradeId)),
     cursor: nextCursor,
   };
 
@@ -729,4 +734,76 @@ export function advanceEpisode(
     terminal: false,
     result: null,
   };
+}
+
+function isBoringEvent(event: EpisodeEvent): boolean {
+  return event === 'holding' || event === 'waiting_fill' || event === 'observed';
+}
+
+function computeBatchTargetBars(
+  state: EpisodeState,
+  question: Question,
+  action: Extract<EpisodeTradeAction, { type: 'hold' }>,
+): number {
+  const barsRequested = action.bars ?? 1;
+  const period = action.period ?? 'h1';
+  const allBars = question.replay.bars;
+  const remaining = allBars.length - state.cursor - 1;
+  if (remaining <= 0) return 0;
+  if (period === 'h1') return Math.min(barsRequested, remaining);
+  const keyOf =
+    period === 'day'
+      ? (time: string) => marketDate(time)
+      : (time: string) => weekKey(marketDate(time));
+  const startKey =
+    state.cursor >= 0 ? keyOf(allBars[state.cursor].time) : keyOf(question.cutoff);
+  let currentKey = startKey;
+  let unitsCompleted = 0;
+  let lastMatchingIndex = state.cursor;
+  for (let i = state.cursor + 1; i < allBars.length; i++) {
+    const key = keyOf(allBars[i].time);
+    if (key !== currentKey) {
+      unitsCompleted += 1;
+      if (unitsCompleted > barsRequested) break;
+      currentKey = key;
+    }
+    lastMatchingIndex = i;
+  }
+  return Math.max(1, Math.min(lastMatchingIndex - state.cursor, remaining));
+}
+
+export function advanceEpisode(
+  state: EpisodeState,
+  question: Question,
+  action: EpisodeTradeAction,
+  options: EpisodeEngineOptions = {},
+): EpisodeAdvanceResult {
+  if (action.type !== 'hold') return advanceEpisodeSingle(state, question, action, options, false);
+  const barsRequested = action.bars ?? 1;
+  const period = action.period ?? 'h1';
+  if (barsRequested === 1 && period === 'h1') {
+    return advanceEpisodeSingle(state, question, action, options, false);
+  }
+  const target = computeBatchTargetBars(state, question, action);
+  if (target <= 0) return advanceEpisodeSingle(state, question, action, options, false);
+  let result = advanceEpisodeSingle(state, question, action, options, false);
+  let advanced = 1;
+  if (result.terminal) {
+    return { ...result, batchAdvancedBars: advanced, batchStopReason: 'terminal' };
+  }
+  if (!isBoringEvent(result.event)) {
+    return { ...result, batchAdvancedBars: advanced, batchStopReason: result.event };
+  }
+  const continuationAction = { type: 'hold', reason: action.reason } as const;
+  while (advanced < target) {
+    result = advanceEpisodeSingle(result.state, question, continuationAction, options, true);
+    advanced += 1;
+    if (result.terminal) {
+      return { ...result, batchAdvancedBars: advanced, batchStopReason: 'terminal' };
+    }
+    if (!isBoringEvent(result.event)) {
+      return { ...result, batchAdvancedBars: advanced, batchStopReason: result.event };
+    }
+  }
+  return { ...result, batchAdvancedBars: advanced, batchStopReason: 'requested' };
 }

--- a/packages/bench/src/schema/episode.ts
+++ b/packages/bench/src/schema/episode.ts
@@ -18,7 +18,17 @@ export const episodeSubmissionSchema = Type.Object(
 export type EpisodeSubmission = Static<typeof episodeSubmissionSchema>;
 
 export const episodeTradeActionSchema = Type.Union([
-  Type.Object({ type: Type.Literal('hold'), ...requiredReason }, { additionalProperties: false }),
+  Type.Object(
+    {
+      type: Type.Literal('hold'),
+      bars: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
+      period: Type.Optional(
+        Type.Union([Type.Literal('h1'), Type.Literal('day'), Type.Literal('week')]),
+      ),
+      ...requiredReason,
+    },
+    { additionalProperties: false },
+  ),
   Type.Object(
     {
       type: Type.Literal('amend'),
@@ -56,7 +66,17 @@ export const episodeActionSchema = Type.Union([
 export type EpisodeAction = Static<typeof episodeActionSchema>;
 
 const episodeRecordedTradeActionSchema = Type.Union([
-  Type.Object({ type: Type.Literal('hold'), ...optionalReason }, { additionalProperties: false }),
+  Type.Object(
+    {
+      type: Type.Literal('hold'),
+      bars: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
+      period: Type.Optional(
+        Type.Union([Type.Literal('h1'), Type.Literal('day'), Type.Literal('week')]),
+      ),
+      ...optionalReason,
+    },
+    { additionalProperties: false },
+  ),
   Type.Object(
     {
       type: Type.Literal('amend'),


### PR DESCRIPTION
## Summary
- Add optional `bars` (1..20) and `period` ('h1' | 'day' | 'week') to `advance_trade`'s hold action so a single call can skip N h1 bars or N complete trading days/weeks.
- Loop the existing single-bar advance internally; return early on any fill / take_profit / stop_loss / no_fill / manual_exit / horizon_exit / terminal event with new `batchAdvancedBars` and `batchStopReason` fields, so batching cannot silently skip past a state change.
- Record ONE action per user-facing call (metrics count decisions, not intervening bars).
- Backwards-compatible: `{type:'hold', reason}` without `bars`/`period` behaves exactly as before.

## Motivation
The swing bank forces ~280 h1 bars per case. Requiring one `advance_trade` per bar forces the model to output `tool_use` on every response — on strict models (gpt-5.5) that keeps pi-agent-core's agent loop from ever returning, so a single `agent.prompt()` runs 200+ model calls and hits the per-turn timeout. Batched hold lets the agent emit a short summary text between chunks, so the outer continuation loop can actually drive the episode.

## Test plan
- [x] `pnpm --filter @kansoku/bench test` — 279/279 passing
- [x] Pilot on 4-case swing bank via the private runner (`--max-episode-tool-calls 300 --timeout-ms 1500000`):
  - `gpt-5.4-mini`: tools 1201 → 178 (−85%), wall time 6078s → 781s (−87%), completion stays 4/4
  - `gpt-5.5`: **completion 0/4 → 4/4**, cost \$75.85 → \$22.93 (−70%)
- [ ] Reviewer: verify batch loop correctness by inspecting `engine.ts::computeBatchTargetBars` and the new `advanceEpisode` wrapper.

## Companion PR
The private runner half (CLI flag `--max-episode-tool-calls`, per-cell logging, prompt updates) lives in kansoku-trade/kansoku-pro on the same branch name and depends on this one.