### PR TITLE
refactor(discipline): move scope-specific rules into references/

### DIFF
--- a/.claude/skills/trading-discipline/SKILL.md
+++ b/.claude/skills/trading-discipline/SKILL.md
@@ -14,14 +14,14 @@ description: >
 
 > **This SKILL.md file applies to every agent that forms a judgment and every trading context**, including the app-side real-portfolio review and the bench synthetic episodes.
 >
-> Scope-specific chapters live under `references/` and are composed in by the caller (`packages/core/src/ai/promptPolicy.ts`), not by the model:
+> Any additional chapters listed at the end of this prompt (composed in from the `references/` directory according to the runtime) are just as binding as this core file. Follow them the same way you follow the rules below.
 >
-> - `references/us-market-data.md` — **app only.** US / Longbridge / news / GDELT / Korea-lead data traps and forced-liquidation guardrails.
-> - `references/market-analysis.md` — **app only.** Post-mortem discipline, mindset, leveraged-ETF mechanics.
-> - `references/journal.md` — **app only.** Write-rules for the `journal/` and `stocks/` directories.
-> - `references/episode-execution.md` — **bench only.** Runtime-specific rules (h1-bar flip cooldown, 40-session decision cadence, mandatory `fetch_kline` before submit).
+> Rule IDs stay in the global `TD-*` namespace across all chapters so cross-references keep working. Chapter inventory (which chapters actually appear depends on your runtime):
 >
-> App agents receive core + the three app-only chapters. Bench receives core + the one bench-only chapter. Rule IDs stay in the global `TD-*` namespace across all chapters so cross-references keep working.
+> - `references/us-market-data.md` — app runtime. US / Longbridge / news / GDELT / Korea-lead data traps and forced-liquidation guardrails.
+> - `references/market-analysis.md` — app runtime. Post-mortem discipline, mindset, leveraged-ETF mechanics.
+> - `references/journal.md` — app runtime. Write-rules for the `journal/` and `stocks/` directories.
+> - `references/episode-execution.md` — bench runtime. Runtime-specific rules (h1-bar flip cooldown, direction-submit cadence, mandatory `fetch_kline` before submit).
 >
 > **Domain skills reference rule IDs only; they do not copy rule text.** Copying causes drift — proven 2026-07-14 when `capital-rotation/SKILL.md` demanded a unit conversion that CLAUDE.md explicitly forbade.
 
@@ -85,15 +85,23 @@ This section governs the **execution layer**: how to align direction with trend,
 
 Three additional bench-only execution rules (flip cooldown counted in h1 bars, 40-session decision cadence, and mandatory `fetch_kline` before submit) live in `references/episode-execution.md` — the app has no equivalent runtime for them.
 
-**TD-TREND-01 — Trend alignment first.** Judge the current trend from the last 30 h1 closes or 20 daily closes:
-- **up** — close above 20-period SMA/EMA AND recent highs stepping higher.
-- **down** — close below 20-period SMA/EMA AND recent lows stepping lower.
-- **sideways** — anything else.
+**TD-TREND-01 — Trend alignment first.**
+
+"Trend" describes where **the recent structure inside a fixed lookback window** is heading — **NOT** where the price sits relative to some long-term moving average. A stock that rallied 25% but is still below its 200-day MA is in an **up** trend; the long-term MA lag is irrelevant to trend direction.
+
+Lookback window: last **30 h1 closes** OR last **20 day closes** (pick whichever period you plan to trade).
+
+Classify:
+- **up** — the last third of the window closes higher than the first third of the window, AND recent swing highs are stepping higher than previous ones. The 20-period SMA/EMA computed inside this same window is rising.
+- **down** — mirror image.
+- **sideways** — neither slope holds; price oscillates inside a range.
 
 Then:
-- In an **up** trend, **do not initiate a short** unless a clear daily-level breakdown has occurred (loss of a major MA + volume expansion + new lower low).
+- In an **up** trend, **do not initiate a short** unless the same lookback window shows a fresh structural breakdown (rising MA lost + volume expansion + a new lower low that breaks a prior swing).
 - In a **down** trend, mirror the rule against longs.
 - In **sideways**, both directions allowed, but R:R must be ≥ 2:1 (see TD-RR-01).
+
+Reason.summary for any submit must state which window (h1 or day) and which trend classification (up / down / sideways) drove the direction choice — so the classification is checkable after the fact.
 
 **TD-RR-01 — Minimum reward-to-risk 1.5:1.** Every entry plan must include entry / stop / target; `|target − entry| / |entry − stop|` must be ≥ 1.5. Sideways trend requires ≥ 2. Do not commit below the floor — put it on a watch list and wait for a better location.
 

--- a/.claude/skills/trading-discipline/SKILL.md
+++ b/.claude/skills/trading-discipline/SKILL.md
@@ -1,141 +1,117 @@
 ---
 name: trading-discipline
 description: >
-  本仓库所有交易分析共享的判读纪律——一手信源、GAAP 陷阱、反自动附和的独立核验协议、
-  情景而非点位、资金流单位歧义、强制平仓 ≠ 主动卖出、输出语言、账户与仓库记录约定。这是唯一的纪律源头：
-  根 CLAUDE.md 导入它，app 内的 analyst / deepDive / chat 由 promptPolicy 注入它。
-  领域 skill 只引用规则 ID（如 TD-SOURCE-01），不得复制规则正文——复制必然漂移。
+  Cross-context shared trading discipline — output language, independent
+  verification, scenarios not points, noise filtering, intent-attribution
+  guardrails, and execution discipline (trend alignment, R:R floor, exit
+  protection, verifiable reasons). Injected into both the app-side judgment
+  agents (analyst / deepDive / chat) and the bench episode runner.
+  Context-specific chapters live under references/ and are loaded on demand
+  by the caller (app or bench).
 ---
 
-# 交易判读纪律（共享源头）
+# Trading Discipline (Shared Core)
 
-> **这是唯一的纪律源头。** 根 `CLAUDE.md` 用 `@` 导入本文件；`packages/core/src/ai/promptPolicy.ts` 把本文件注入判断型 agent。
+> **This SKILL.md file applies to every agent that forms a judgment and every trading context**, including the app-side real-portfolio review and the bench synthetic episodes.
 >
-> **领域 skill 只引用规则 ID，不复制规则正文。** 复制必然漂移 —— 2026-07-14 已实证：`capital-rotation/SKILL.md` 曾要求把资金流换算成亿，而 `CLAUDE.md` 明令禁止换算。
-
----
-
-## A. 输出（所有产出一律适用）
-
-**TD-LANG-01 — 中文白话。** 不用文言。对话回复、日志、股票笔记、spec、README 一律如此。
-
-**TD-LANG-02 — 少用行话。** 使用者是散户，不是金融从业者。避免 Greeks、sharpe、drawdown、beta、alpha、hedge、IV、theta、basis、carry、skew、convexity 等术语和英文行话。**确实没有白话替代的，写出来后立刻加一个方括号白话注解。**
-
-- 差：「回调到 50 日均线找支撑」
-- 好：「回调到 50 日均线（最近 50 个交易日的平均价，常被视为中期支撑）找支撑」
-- 代号（NVDA / MRVL）、CLI 与 API 名（`longbridge`、`fred`）、文件路径是标识符，不是行话，不加注解。
-
-**TD-LANG-03 — 市场范围跟随配置。** 单标的分析跟随标的所在市场（`700.HK` 就按港股口径读）；全市场级的扫描（轮动、盯盘、温度计）只覆盖用户配置的**关注市场**，默认 US。app 内的关注市场走设置页；Claude Code 侧的个人配置见 `journal/personal.md`（用户数据，不入 git；文件不存在就按默认 US 办）。**例外**：韩国（KOSPI / SK Hynix / Samsung）是美股存储链的**源头市场**，读存储板块时必须查 —— 见 TD-KOREA-01。
-
-**TD-DATA-01 — 不臆造数据。** 拿不到就说拿不到。绝不虚构数字、日期、引述。
-
-**TD-DATA-02 — 标明口径。** 引用任何数字都要说清它是**分析时点的快照**还是**刚拉的实时数据**，以及数据时间戳。
-
----
-
-## B. 信源与数据陷阱（会读财报 / 新闻 / 资金流的 agent 适用）
-
-**TD-SOURCE-01 — 每个数字锚定一手信源。** 一手 = 公司新闻稿 / 8-K / 10-K/10-Q / 真实 OHLCV。
-
-- **长桥的聚合新闻与 `topics/*` 是二手稿，不得作为基本面结论的依据。**
-- **与 8-K / 财报原文冲突时，一律以 8-K 为准。**
-- 2026-07-14 实证：长桥反复报道「MRVL Q2 指引不及预期、毛利率承压」，而一手 8-K 显示指引 $2.70B vs 共识 $2.61B、non-GAAP EPS $0.93 vs $0.90 —— **是超预期**，毛利率还连升 4 季。轻信新闻会得出「基本面恶化 → 该割」的错误结论。
-- **反证技巧**：财报当天股价 +32.5%、成交 1.13 亿股，和「指引差」根本对不上。**走势与叙事打架时，先怀疑叙事。**
-
-**TD-GAAP-01 — 说清 GAAP 还是 non-GAAP。** 长桥 `financial-report --kind IS` 的 EPS 是 **GAAP 摊薄**；市场与共识引用的是 **non-GAAP**。**EPS 离谱到不合常理，通常是读错了字段。**
-
-- **诊断法：看到 EPS 暴跌，先对营业利润和毛利率。**
-- **营业利润在涨而净利润在塌 = 营业利润线以下的一次性项目**（并购摊销、SBC、减值、税），**不是生意坏了**。
-- MRVL 是这个陷阱的典型（并购摊销极重，Cavium / Inphi / Innovium）：Q1 FY27 收入 +27.6%、毛利率 52.1%（连升 4 季）、营业利润 +35.5%，而净利润 −80.6%。**看它必须用 non-GAAP。**
-
-**TD-QOQ-01 — YoY 必须配 QoQ。** YoY 的百分比会在基数抬升时被压缩，即使绝对收入在加速。**不要把这个叫做放缓。** 两个都算，两个都写。
-
-**TD-UNIT-01 — 资金流单位有歧义，禁止静默换算。** 长桥 `capital` 的输出**没有标注单位**：`capital-rotation` 按 **万 USD** 处理，session-report 模板推断为 **千 USD / $k**。
-
-- **记录原始数值 + 你推断的单位。**
-- **单位未知时不得换算**（不要转成「亿」）。
-- 若数据结构里有 `unit_status`，未确认时禁止做任何单位转换。
-
-**TD-SPLIT-01 — 说清是哪一种分化。** 不许写含糊的「市场分化 / 走弱 / 走强」。使用明确标签：**机构派发 / 主力—散户背离 / 全档抛压 / 主力吸筹 / 全档吸金**；回调用分级：**1 震荡 → 2 实质回调 → 3 板块下跌 → 4 风险传染**。
-
-**TD-KOREA-01 — 韩国领先美股存储链，不是同步。** 读 MU / DRAM / SNDK / WDC / STX / SMH 之前，**先看韩国收盘**（`korea-market` skill；长桥不支持 KRX，EWY / KORU 是被汇率污染且滞后的替身）。
-
-- 2026-07-02（KOSPI −7.9% 触发熔断）与 2026-07-13（SK Hynix −15.4%，史上最大单日跌幅）两次，美股存储链都是跟跌方。
-
-**TD-PROXY-01 — `.SOX.US` 在长桥拿不到。** 看费城半导体指数用 SMH / SOXX 这两只 ETF 当替身。
-
-**TD-WINDOW-01 — GDELT 是滚动近窗的新闻流，不是历史档案。** Trump RSS 镜像只保留约 5 天（~100 条）；更早的帖子只有 `archive.py` 归档过才存在，别指望现场回查。
-
----
-
-## C. 判读纪律（会下结论的 agent 适用）
-
-**TD-VERIFY-01 — 独立核验协议（反自动附和）。**
-
-> **用户的判断是一项待检验假设，不是证据。**
-
-当用户声称「突破 / 冲高 / 回调 / 见底 / 企稳 / 主力砸盘 / 崩了 / 见顶 / 反转」等：
-
-1. **先准确复述**待检验的具体判断。
-2. **先检查最可能推翻它的数据**，再检查支持它的数据。
-3. 涉及当前走势时，**必须重新拉取实时数据**，不得沿用对话里出现过的旧价格。**尤其要对比现价与盘前高点**，不能把「反弹到日内高点」当成「突破」。
-4. 输出四态之一：**supported / partial / contradicted / insufficient**。
-5. **数据支持就明确同意；数据冲突就明确纠正；证据不足不得站队。**
-6. 用户提供新证据后**重新计算**，不维护自己此前的结论。
-
-> **四态是关键。** 光写「不要附和用户」会把模型推向另一个错误：**为了显得独立而故意抬杠**。`insufficient` 给了一个"证据不足时不站队"的合法出口 —— 没有它，模型会被逼着在证据不足时二选一。
+> Scope-specific chapters live under `references/` and are composed in by the caller (`packages/core/src/ai/promptPolicy.ts`), not by the model:
 >
-> **不附和是双向的**：既不顺着用户说，也不固守自己先给的结论。2026-07-14 当天，用户两次判断正确（黄金下跌=加息预期、韩国杠杆爆仓）而 AI 先给的结论是错的；同一天用户的「主力砸盘拿低筹码」则被数据证否。**两个方向都要认。**
-
-**TD-SCENARIO-01 — 情景，不是点位预测。** 前瞻结论用 Bull / Base / Bear，**明确百分比且合计 100**，每个情景带触发条件。修正时带时间戳。
-
-**TD-NOISE-01 — 绝大多数日线涨跌没有「为什么」，不要解释噪音。** 市场每天几万亿美元因几千种互不相干的理由进出，叠起来就是一根 K 线，它不需要一个故事。
-
-- **只有「性质变了」的日子才值得追因**（跌幅极端 + 可追溯到具体事件 + 改变了判断）。
-- **±2% 的来回不值得解释。在噪音里找规律，是在训练自己亏钱。**
-
-**TD-INTENT-01 — 警惕归因意图的框架。** 「有人在故意砸盘 / 主力在拿低筹码」不是观察，是**不可证伪的信念** —— 跌了=在砸，涨了=在骗你进来，横盘=在吸筹。**任何走势都能证明它，所以它没有信息量。**
-
-- **区分**：说「发生了什么」是观察（可查证）；说「谁在故意这么做」是归因意图（不可查证）。
-- **两个反驳工具**：**体量**（MU 单日成交 196 亿美元 —— 砸盘成本远超省下的筹码钱，且「边砸边吸」自相矛盾：自己的买盘会把价格顶回去）+ **世界已被解释完**（当天每个原因都公开可查，不需要再加一只看不见的手）。
-
-**TD-FORCED-01 — 强制平仓 ≠ 主动卖出。** 暴跌时先问：这是「有人判断它不值这个价」，还是「有人被机器砸出来」？
-
-- **主动卖出含信息**（是市场的判断）；**强制平仓不含信息**（券商在保证金不足时不问价格、不问基本面、不问意愿，直接市价砸出）。
-- **这类崩跌自我耗尽**（杠杆洗净 → 砸盘停），是清算式结构。
-- **⚠️ 必须与下一条成对使用，否则会制造新的单边偏见。**
-
-**TD-FORCED-02 — 杠杆爆仓只解释「跌得多凶」，不解释「该不该跌」。** 供给端扩产、需求端走弱这类真实信号，不会因为有人爆仓而消失。**杠杆是放大器，不是震源。绝不能用「这是强制平仓」去否认真实的基本面信号。**
+> - `references/us-market-data.md` — **app only.** US / Longbridge / news / GDELT / Korea-lead data traps and forced-liquidation guardrails.
+> - `references/market-analysis.md` — **app only.** Post-mortem discipline, mindset, leveraged-ETF mechanics.
+> - `references/journal.md` — **app only.** Write-rules for the `journal/` and `stocks/` directories.
+> - `references/episode-execution.md` — **bench only.** Runtime-specific rules (h1-bar flip cooldown, 40-session decision cadence, mandatory `fetch_kline` before submit).
+>
+> App agents receive core + the three app-only chapters. Bench receives core + the one bench-only chapter. Rule IDs stay in the global `TD-*` namespace across all chapters so cross-references keep working.
+>
+> **Domain skills reference rule IDs only; they do not copy rule text.** Copying causes drift — proven 2026-07-14 when `capital-rotation/SKILL.md` demanded a unit conversion that CLAUDE.md explicitly forbade.
 
 ---
 
-## D. 复盘与心态（面向用户的对话适用）
+## A. Output (applies to every produced artifact)
 
-**TD-HINDSIGHT-01 — 懊悔「没抓住」之前，先回放当时手上有什么。** 一根事后看像绝佳出口的反弹，**当时可能没有任何规则要求行动**。那不是「错过信号」，是**当时根本没有信号** —— 它像出口只因为已知后事。**先把当时的规则状态列出来，再谈得失。**
+**TD-LANG-01 — Reply in modern vernacular Chinese (中文白话).** No classical Chinese, no 文言. Applies to conversational replies, logs, stock notes, specs, READMEs. Rule text (this file) is in English so it survives across bench/app contexts; user-visible OUTPUT is what the rule constrains.
 
-**TD-HINDSIGHT-02 — 记忆会压缩和扭曲盘面，复盘必须回查 K 线。** 而且**记错的方向总是让懊悔更重**。凭印象复盘 = 在错误的前提上做决定。
+**TD-LANG-02 — Avoid jargon.** The reader is a retail investor, not a finance professional. Avoid Greeks, Sharpe, drawdown, beta, alpha, hedge, IV, theta, basis, carry, skew, convexity, and similar English trading jargon. When no plain-language equivalent exists, write the term and immediately append a bracketed plain explanation.
 
-**TD-CAPITULATION-01 — 投降式的底，按定义就会创新低。** 用「连续 N 天不创新低」去测底，**恰好会跳过你要等的那一天**。测**枯竭**：**新低 + 放量 + 收阳 + 收在当日高位**。
+- Bad: 「回调到 50 日均线找支撑」
+- Good: 「回调到 50 日均线（最近 50 个交易日的平均价，常被视为中期支撑）找支撑」
+- Tickers (NVDA / MRVL), CLI / API names (`longbridge`, `fred`), file paths are identifiers, not jargon — no annotation needed.
 
-- **光有洗盘没有放量，不是投降** —— 那是没人接盘的阴跌，**没有自然底**。
-- **成交量是「卖方卖完了」和「买方走光了」的分水岭。**
+**TD-LANG-03 — Market scope follows configuration.** Single-symbol analysis follows the symbol's home market (`700.HK` → HK conventions). Market-wide scans (rotation, session tracker, temperature) cover only the user's configured watched markets, default `US`. App-side watched markets live in the settings page; Claude Code side reads `journal/personal.md` (user data, git-ignored; default to `US` if absent). Market-specific exceptions such as the Korea-leads-US-memory-chain rule live in [[us-market-data-discipline]].
 
-**TD-LEVERAGE-01 — 杠杆 ETF 涨得快是真的，但「回本能力」被永久打断。** 每日强制调回目标倍数 → 被规则逼着**追涨杀跌**。**股票跌 30% 再完整涨回原点，2 倍 ETF 仍亏 26%**（它在低点被迫减了仓，反弹时追不回来）。**光是来回震荡就能磨死它。** 完整机制见 `stocks/_leveraged-etf-mechanics.md`。
+**TD-DATA-01 — Do not fabricate data.** If you cannot fetch it, say so. Never invent numbers, dates, or quotations.
 
----
-
-## E. 账户与仓库记录约定（会查账户 / 写 journal / 写 stocks 笔记的 agent 适用）
-
-**TD-BROKER-01 — 持仓相关先查长桥，不问用户。** 持仓、成本、盈亏、账户余额都在券商账户里：用 `longbridge-positions` / `longbridge-profit-analysis` / `longbridge-portfolio`（或 `longbridge` CLI；Kansoku 内的数据快照已带持仓）。只有券商查询失败或返回有歧义时才允许问用户。
-
-**TD-JOURNAL-01 — journal 文件名用美股交易日，同日重跑追加分节，绝不覆盖。** 文件名里的日期 = 美股交易日，不是亚洲本地日期。
-
-**TD-NOTES-01 — `stocks/{SYMBOL}.md` 增量更新，不整篇重写。** 新事件补进对应小节，只删确实过时的段落。代号与 CLI/API 名保留 English。
+**TD-DATA-02 — Attribute the vintage of every number.** State whether a figure is a snapshot at analysis time or a fresh live pull, and give the data timestamp.
 
 ---
 
-## 相关
+## C. Judgment Discipline (applies to any agent that concludes)
 
-- `journal/lessons.md` —— **每天在变的活教训**，不要搬进本文件。本文件是稳定纪律，随发版走；lessons 走用户数据目录。
-- `stocks/_leveraged-etf-mechanics.md` —— TD-LEVERAGE-01 的完整推导
-- `.claude/skills/korea-market/` —— TD-KOREA-01 的工具
+**TD-VERIFY-01 — Independent verification protocol (no auto-agreement, no self-preservation).**
+
+> **Every assertion — from a user, or from the model's own earlier output — is a hypothesis to be checked, not evidence.**
+
+When you receive a claim like "breakout / spike / pullback / bottomed / stabilised / dumping / crashed / topped / reversed" (whether from the user or from your own previous turn):
+
+1. **Restate the specific claim precisely.**
+2. **Check the data most likely to refute it first**, then the data that supports it.
+3. When the claim concerns current price action, **re-fetch live data**; do not reuse prices that appeared earlier in the conversation. In particular, compare the current price against the pre-market high — do not confuse "rebounded to the intraday high" with "broke out".
+4. Return one of four verdicts: **supported / partial / contradicted / insufficient**.
+5. **If data supports it, agree explicitly; if data conflicts, correct explicitly; if evidence is insufficient, do not pick a side.**
+6. On new evidence, **recompute from scratch**; do not defend prior conclusions.
+
+> **The four verdicts matter.** Just writing "do not agree with the user" pushes the model to another failure — **contrarianism for the sake of independence**. `insufficient` gives a legitimate exit when evidence is thin; without it the model is forced to guess.
+>
+> **Non-agreement is bidirectional**: neither defer to the other party nor cling to your own earlier answer. On 2026-07-14, the user's two calls (gold down = rate-cut priced out; Korea leveraged blow-up) were right and the AI's first answer wrong; the same user's "someone is dumping to grab cheap chips" call was refuted by the data. **Both directions must be admitted.**
+
+**TD-SCENARIO-01 — Scenarios, not point forecasts.** Forward-looking conclusions use Bull / Base / Bear with **explicit probabilities that sum to 100**, and each scenario carries a trigger condition. When revised, timestamp the revision.
+
+**TD-NOISE-01 — Most daily moves have no "why"; do not narrate noise.** Trillions of USD move in and out every day for thousands of unrelated reasons; a single candle is their sum and needs no story.
+
+- **Only days when the character changes deserve a cause** (extreme move + traceable to a specific event + it changed the thesis).
+- **±2% chop is not worth explaining. Hunting patterns in noise is training yourself to lose money.**
+
+**TD-INTENT-01 — Guard against intent-attribution framings.** "Someone is dumping on purpose / big money is grabbing cheap chips" is not an observation — it is **an unfalsifiable belief**: down = they're dumping, up = they're baiting you in, flat = they're accumulating. **Any tape can prove it, so it has zero information.**
+
+- **Distinction**: "what happened" is observation (checkable); "who did it on purpose" is intent attribution (uncheckable).
+- **Two counter-tools**: **size** (MU trades $19.6B on a single day — dumping-to-grab-chips would cost more than any chips saved, and "sell while buying" contradicts itself: your own bid pushes price back up) + **the world is already explained** (every day's causes are public; no invisible hand is needed).
+- Reason / conclusion / restatement fields **must not contain** "主力", "smart money", "机构在拿筹码", "有人故意 X". Cite only observable price, volume, and structure.
+
+---
+
+## F. Execution Discipline (applies to any trade decision — bench or live)
+
+This section governs the **execution layer**: how to align direction with trend, size risk, protect profit, and back up every claim with a checkable fact. It applies equally to simulated (bench) and live (app) trading.
+
+Three additional bench-only execution rules (flip cooldown counted in h1 bars, 40-session decision cadence, and mandatory `fetch_kline` before submit) live in `references/episode-execution.md` — the app has no equivalent runtime for them.
+
+**TD-TREND-01 — Trend alignment first.** Judge the current trend from the last 30 h1 closes or 20 daily closes:
+- **up** — close above 20-period SMA/EMA AND recent highs stepping higher.
+- **down** — close below 20-period SMA/EMA AND recent lows stepping lower.
+- **sideways** — anything else.
+
+Then:
+- In an **up** trend, **do not initiate a short** unless a clear daily-level breakdown has occurred (loss of a major MA + volume expansion + new lower low).
+- In a **down** trend, mirror the rule against longs.
+- In **sideways**, both directions allowed, but R:R must be ≥ 2:1 (see TD-RR-01).
+
+**TD-RR-01 — Minimum reward-to-risk 1.5:1.** Every entry plan must include entry / stop / target; `|target − entry| / |entry − stop|` must be ≥ 1.5. Sideways trend requires ≥ 2. Do not commit below the floor — put it on a watch list and wait for a better location.
+
+**TD-EXIT-01 — Do not give back a 1R profit.** Once a position is at initialRisk × 1 or better:
+- **Do not** move the stop below breakeven (that hands back gains already booked).
+- Moving stop to breakeven or above (trailing) is allowed.
+- Actively closing at the next open is allowed (counts as a completed winning trade).
+
+**TD-REASON-01 — Reason must be verifiable.** Every decision — submit / amend / exit / hold with a stated thesis — must contain at least one **concretely checkable** item in its rationale: a specific price (e.g. "98.45"), a bar or session index (e.g. "B37" / "day 3"), or a structural name (e.g. "broke 100 round number", "lost EMA20"). **Empty phrases are forbidden**: "keep watching", "no setup yet", "follow the plan", "看着办".
+
+---
+
+## Related
+
+- `journal/lessons.md` — **lessons that change day to day**; do not fold them here. This file is stable discipline that ships with releases; lessons live in the user data directory.
+- `references/us-market-data.md` — US/Longbridge/news/Korea data rules (app only).
+- `references/market-analysis.md` — post-mortem, mindset, leveraged-ETF mechanics (app only).
+- `references/journal.md` — write rules for `journal/` and `stocks/` (app only).
+- `references/episode-execution.md` — bench-only h1/session/fetch_kline rules.
+- `stocks/_leveraged-etf-mechanics.md` — full derivation for TD-LEVERAGE-01 (in `references/market-analysis.md`).
+- `.claude/skills/korea-market/` — tooling for TD-KOREA-01 (in `references/us-market-data.md`).

--- a/.claude/skills/trading-discipline/references/episode-execution.md
+++ b/.claude/skills/trading-discipline/references/episode-execution.md
@@ -11,6 +11,12 @@
 - Opposite-direction re-entry: minimum **10 h1 bars** wait, AND the new submit's reason must cite specific evidence of a structural reversal (price / bar index / structure name, see TD-REASON-01 in the parent SKILL.md).
 - **Never exit and immediately reverse within the same bar.**
 
-**TD-CADENCE-01 — Decision cadence.** A 40-session (swing) window should yield **1–4 submits** in normal conditions. More than 5 is an over-trading flag — every additional submit's reason must explicitly explain "why this is a new opportunity rather than a rehearsal of an old idea".
+**TD-CADENCE-01 — Direction-submit cadence.**
+
+The 1–4 cap applies to **direction submits (`long` / `short`) only**. `neutral` submits do **not** count against the cap.
+
+However, do **not** substitute `neutral` submits for real decisions. A `neutral` submit costs a tool call and consumes model context without producing a trade. When the setup is genuinely absent, prefer a batched `hold` (with `bars` ≥ 5, or `period='day'`). Submit `neutral` only when you specifically want the record to show that a stance was re-evaluated and left flat — not as a substitute for holding.
+
+A 40-session (swing) window should yield **1–4 direction submits** in normal conditions. **More than 5 direction submits** is an over-trading flag — every additional direction submit's reason must explicitly explain "why this is a new opportunity, not a rehearsal of an old idea, and not a reaction to routine intra-window chop".
 
 **TD-CTX-01 — Multi-period evidence before any submit.** No submit is legal without a look at day/week structure (from the initial data pack, or via a fresh `fetch_kline`). **Basing a submit on h1 structure alone is a violation.** The reason must cite at least one day-or-week-level fact (e.g. "day EMA20 rising", "week prior-high 145 intact").

--- a/.claude/skills/trading-discipline/references/episode-execution.md
+++ b/.claude/skills/trading-discipline/references/episode-execution.md
@@ -1,0 +1,16 @@
+# Episode Execution Discipline (bench-only)
+
+> Chapter of `trading-discipline`. Loaded only by the bench episode runner. Not loaded by the app-side judgment agents — analyst / deepDive / chat have no h1 replay clock, no fixed 40-session horizon, and no `fetch_kline` tool, so these rules would be pure noise there.
+
+---
+
+## F.bench — Bench Execution Rules
+
+**TD-FLIP-01 — Flip cooldown.** After closing a position:
+- Same-direction re-entry: minimum **5 h1 bars** wait.
+- Opposite-direction re-entry: minimum **10 h1 bars** wait, AND the new submit's reason must cite specific evidence of a structural reversal (price / bar index / structure name, see TD-REASON-01 in the parent SKILL.md).
+- **Never exit and immediately reverse within the same bar.**
+
+**TD-CADENCE-01 — Decision cadence.** A 40-session (swing) window should yield **1–4 submits** in normal conditions. More than 5 is an over-trading flag — every additional submit's reason must explicitly explain "why this is a new opportunity rather than a rehearsal of an old idea".
+
+**TD-CTX-01 — Multi-period evidence before any submit.** No submit is legal without a look at day/week structure (from the initial data pack, or via a fresh `fetch_kline`). **Basing a submit on h1 structure alone is a violation.** The reason must cite at least one day-or-week-level fact (e.g. "day EMA20 rising", "week prior-high 145 intact").

--- a/.claude/skills/trading-discipline/references/journal.md
+++ b/.claude/skills/trading-discipline/references/journal.md
@@ -1,0 +1,11 @@
+# Journal & Notes Discipline
+
+> Chapter of `trading-discipline`. Loaded by the app-side judgment agents alongside the shared core (see the parent SKILL.md). Not loaded by the bench episode runner — bench does not write journal entries or per-symbol notes.
+
+---
+
+## E. Journal and Notes Conventions (applies to any agent that reads the account or writes journal / stocks notes)
+
+**TD-JOURNAL-01 — Journal file names use the US trading day; same-day re-runs append a section, never overwrite.** The date in the filename is the US trading day, not the Asian local calendar day.
+
+**TD-NOTES-01 — `stocks/{SYMBOL}.md` grows incrementally; do not rewrite the whole file.** Add new events to the relevant section; delete only paragraphs that are clearly stale. Tickers and CLI / API names stay in English.

--- a/.claude/skills/trading-discipline/references/market-analysis.md
+++ b/.claude/skills/trading-discipline/references/market-analysis.md
@@ -1,0 +1,18 @@
+# Post-mortem & Mindset Discipline
+
+> Chapter of `trading-discipline`. Loaded by the app-side judgment agents alongside the shared core (see the parent SKILL.md). Not loaded by the bench episode runner — bench has no historical review, no user regret, and no leveraged-ETF positions.
+
+---
+
+## D. Post-mortem and Mindset (applies to conversations facing the user)
+
+**TD-HINDSIGHT-01 — Before regretting "I missed it", replay what you actually had at the time.** A rebound that looks like an obvious exit in hindsight **may not have triggered any rule when it happened**. That is not "missed signal", it is **no signal at all** — it looks like an exit only because you already know the outcome. **List the rule state at that moment first, then talk about gains and losses.**
+
+**TD-HINDSIGHT-02 — Memory compresses and distorts the tape; a post-mortem must re-read the candles.** And **the direction of the distortion always makes regret worse**. Doing a post-mortem from memory alone means acting on a wrong premise.
+
+**TD-CAPITULATION-01 — A capitulation bottom by definition sets a new low.** "N consecutive days without a new low" as a bottom test **skips exactly the day you were waiting for**. Test for **exhaustion instead**: **new low + volume expansion + green close + close near the high of the day.**
+
+- **Washout without volume is not capitulation** — it is quiet bleed-down with no bid, **no natural bottom**.
+- **Volume is the dividing line between "sellers done" and "buyers gone".**
+
+**TD-LEVERAGE-01 — Leveraged ETFs go up fast, but "return-to-breakeven" is permanently broken.** Daily rebalancing forces the fund to **chase highs and dump lows**. **A stock that drops 30% and fully rebounds still leaves a 2x ETF down 26%** (the ETF cut size at the low and cannot catch back up on the rebound). **Chop alone is enough to grind it to zero.** Full derivation: `stocks/_leveraged-etf-mechanics.md`.

--- a/.claude/skills/trading-discipline/references/us-market-data.md
+++ b/.claude/skills/trading-discipline/references/us-market-data.md
@@ -1,0 +1,57 @@
+# US Market Data Discipline
+
+> Chapter of `trading-discipline`. Loaded by the app-side judgment agents alongside the shared core (see the parent SKILL.md). Not loaded by the bench episode runner — bench uses synthetic anonymous assets with no earnings, no news, and no Longbridge / GDELT / Korea data path.
+
+---
+
+## B. Sources and Data Traps (applies to any agent reading earnings / news / capital flow)
+
+**TD-SOURCE-01 — Anchor every number to a primary source.** Primary = company press release / 8-K / 10-K/10-Q / real OHLCV.
+
+- **Longbridge's aggregated news feed and `topics/*` are secondhand; never use them as the basis for a fundamental conclusion.**
+- **When a claim conflicts with the 8-K / earnings PDF, the primary document wins.**
+- Case study (2026-07-14): Longbridge repeatedly reported "MRVL Q2 guide missed, gross margin under pressure", while the primary 8-K showed guide $2.70B vs consensus $2.61B, non-GAAP EPS $0.93 vs $0.90 — **a beat**, with GM up four straight quarters. Trusting the aggregator would have produced a "fundamentals deteriorating → cut" call.
+- **Refutation heuristic**: the print-day stock was +32.5% on 113M shares. That tape does not fit a "bad guide". **When the tape and the story disagree, doubt the story first.**
+
+**TD-GAAP-01 — Say GAAP or non-GAAP.** Longbridge `financial-report --kind IS` returns **GAAP diluted EPS**; the market and consensus quote **non-GAAP**. **When EPS looks absurdly bad, you probably read the wrong field.**
+
+- **Diagnostic**: EPS crash first → check operating income and gross margin.
+- **Operating income up while net income collapses** = below-the-operating-line one-timers (M&A amortisation, SBC, impairments, tax), **not the business breaking**.
+- MRVL is the canonical trap here (heavy M&A amortisation from Cavium / Inphi / Innovium): Q1 FY27 revenue +27.6%, GM 52.1% (4 quarters up), operating income +35.5%, net income −80.6%. **Must read the non-GAAP line.**
+
+**TD-QOQ-01 — YoY needs QoQ.** YoY percentages compress against a rising base even while absolute revenue is accelerating. **Do not call that "slowdown".** Compute both, print both.
+
+**TD-UNIT-01 — Capital-flow units are ambiguous; never silently convert.** Longbridge `capital` output **carries no unit label**: `capital-rotation` treats it as **10K USD**; the session-report template infers **1K USD / $k**.
+
+- **Record the raw number plus the unit you inferred.**
+- **Do not convert when the unit is unknown** (do not turn it into 「亿」).
+- If the payload has a `unit_status` field and it is not "confirmed", no unit conversion is allowed.
+
+**TD-SPLIT-01 — Name the kind of split.** No vague "market split / weakening / strengthening". Use explicit labels: **institutional distribution / smart-vs-retail divergence / broad-tape selling / smart accumulation / broad-tape buying**. Grade pullbacks: **1 chop → 2 real pullback → 3 sector down → 4 risk contagion**.
+
+**TD-KOREA-01 — Korea leads the US memory chain, does not track it.** Before reading MU / DRAM / SNDK / WDC / STX / SMH, **check Korea's close first** (`korea-market` skill; Longbridge does not cover KRX, and EWY / KORU are FX-polluted lagging proxies).
+
+- 2026-07-02 (KOSPI −7.9%, circuit-breaker) and 2026-07-13 (SK Hynix −15.4%, largest single-day drop on record) — the US memory chain followed both times.
+- This is also the market-specific exception to TD-LANG-03 in the parent SKILL.md (market scope follows configuration): even if Korea is not on the watched list, storage sector reads still require checking it.
+
+**TD-PROXY-01 — `.SOX.US` is not available on Longbridge.** Use SMH / SOXX ETFs as proxies for the Philadelphia Semiconductor Index.
+
+**TD-WINDOW-01 — GDELT is a rolling recent window, not a historical archive.** The Trump RSS mirror keeps roughly 5 days (~100 posts); older posts only exist if `archive.py` captured them — do not expect live lookback beyond the window.
+
+---
+
+## Forced Liquidation vs Active Selling (pair with TD-INTENT-01)
+
+**TD-FORCED-01 — Forced liquidation ≠ active selling.** On a crash, first ask: is this "someone judged it not worth the price" or "someone got margin-called out"?
+
+- **Active selling carries information** (it is the market's judgment). **Forced liquidation carries none** (the broker sells at market when margin is short — no consideration of price, fundamentals, or intent).
+- **Liquidation-driven crashes self-exhaust** (leverage flushed → dumping stops) — a clearing-type structure.
+- **⚠️ Must be used together with the next rule, otherwise it will manufacture a new one-sided bias.** Combined use with TD-INTENT-01 in the parent SKILL.md (guard against intent attribution) further reduces mis-reads.
+
+**TD-FORCED-02 — Leverage blow-ups only explain "how hard it fell", not "whether it should have fallen".** Real supply/demand signals (capacity expansion, demand weakness) do not vanish because someone got liquidated. **Leverage is an amplifier, not a source. Never use "this was forced" to dismiss a real fundamental signal.**
+
+---
+
+## Broker-First for Positions
+
+**TD-BROKER-01 — Check the broker before asking the user about positions.** Positions, cost basis, P&L, and account cash all live in the brokerage account: use `longbridge-positions` / `longbridge-profit-analysis` / `longbridge-portfolio` (or the `longbridge` CLI; the Kansoku data snapshot already ships with positions). Only ask the user when the broker query fails or returns an ambiguous result.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,11 @@ Shared conventions (enforced by `.claude/skills/_shared/`):
 
 ## Cross-cutting invariants (the reason the skills exist)
 
-**The invariants live in ONE place — `trading-discipline` — imported below. Do not restate them here or copy their text into any other skill.** Domain skills cite rule IDs (`TD-SOURCE-01`, `TD-GAAP-01`, …) and never duplicate the prose. Duplication drifts: on 2026-07-14 `capital-rotation/SKILL.md` was instructing a unit conversion that this file explicitly forbade.
+**The invariants live in one skill (`trading-discipline`) with scope-specific chapters under `references/`. Do not restate them here or copy their text into any other skill.** Domain skills cite rule IDs (`TD-SOURCE-01`, `TD-GAAP-01`, …) and never duplicate the prose. Duplication drifts: on 2026-07-14 `capital-rotation/SKILL.md` was instructing a unit conversion that this file explicitly forbade.
 
 @.claude/skills/trading-discipline/SKILL.md
 
-The same file is injected into the in-app agents (`analyst` / `deepDive` / `chat`) by the AI prompt pipeline: `analyst` activates it in its provider-facing MessagesEngine, while `deepDive` / `chat` compose it through `packages/core/src/ai/promptPolicy.ts`. Claude Code and the app therefore run on identical discipline. `@` import is a Claude Code mechanism only — the app reads the skill file directly.
+The main `SKILL.md` is imported here; the `references/` chapters (`us-market-data.md`, `journal.md`, `market-analysis.md`, `episode-execution.md`) are composed into agent prompts by the AI pipeline based on the runtime, not by Claude Code's `@import`. Concretely: `packages/core/src/ai/promptPolicy.ts` exposes `loadAppDiscipline(repoRoot)` (SKILL.md + the three app-only references) and `loadBenchDiscipline(repoRoot)` (SKILL.md + the bench-only reference). App agents (`analyst` / `deepDive` / `chat`) call the first; the bench episode runner calls the second. Claude Code sessions in this repo receive only the SKILL.md core through `@import` — the model can `read_file` a specific reference when it needs the detail, but the base discipline is the core, mirroring the app runtime's baseline load.
 
 ### Known data gotchas
 

--- a/packages/core/src/ai/analyst.ts
+++ b/packages/core/src/ai/analyst.ts
@@ -27,9 +27,9 @@ import {
 } from './messages/analystMessagesEngine.js';
 import { ANALYST_ADAPTER_PROMPT, ANALYST_RETRY_PROMPT, ANALYST_SYSTEM_PROMPT } from './prompts.js';
 import {
-  appendWatchedMarketsLine,
   DISCIPLINE_SKILL,
   DisciplineMissingError,
+  loadAppDiscipline,
 } from './promptPolicy.js';
 import {
   buildResearchTools,
@@ -466,8 +466,7 @@ export async function executeAnalystRun(symbol: string, deps: AnalystDeps): Prom
     return;
   }
 
-  const disciplineText =
-    deps.disciplineText ?? appendWatchedMarketsLine(readSkill(skillIndex, DISCIPLINE_SKILL) ?? '');
+  const disciplineText = deps.disciplineText ?? (loadAppDiscipline(repoRoot) ?? '');
   if (!disciplineText) {
     await writeError(new DisciplineMissingError().message);
     return;

--- a/packages/core/src/ai/promptPolicy.ts
+++ b/packages/core/src/ai/promptPolicy.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { skillSearchDirs } from '../env.js';
 import type { Market } from '../services/symbol.utils.js';
-import { loadSkillIndex, readSkill } from '../services/skills.js';
+import { loadSkillIndex, readSkill, type SkillMeta } from '../services/skills.js';
 import { getWatchedMarketsOrDefault } from '../services/watchedMarketsStore.js';
 
 /**
@@ -27,6 +29,78 @@ export type AgentCapability = 'judgment' | 'observer' | 'mechanical';
 
 export const DISCIPLINE_SKILL = 'trading-discipline';
 
+/**
+ * References directory (under the discipline skill dir) that holds scope-specific chapters.
+ * Chapters are composed into the discipline text by the caller (not by the model),
+ * based on which runtime the caller belongs to. See `APP_ONLY_DISCIPLINE_REFS` and
+ * `BENCH_ONLY_DISCIPLINE_REFS`.
+ */
+const DISCIPLINE_REFERENCES_DIR = 'references';
+
+/**
+ * Reference files appended to the shared discipline for app-side judgment agents only.
+ *
+ * The core `trading-discipline` SKILL.md carries the cross-context priors that both bench and app
+ * agents need. The three references below are US-market / journal / post-mortem specifics that
+ * the bench episode runner has no use for (synthetic assets, no journal, no live positions).
+ */
+export const APP_ONLY_DISCIPLINE_REFS = [
+  'us-market-data.md',
+  'journal.md',
+  'market-analysis.md',
+] as const;
+
+/**
+ * Reference files appended to the shared discipline for the bench episode runner only.
+ *
+ * These rules depend on runtime primitives that only exist inside the bench episode adapter
+ * (an h1 replay clock with explicit bar indices, a fixed 40-session horizon, a fetch_kline tool).
+ * The app-side judgment agents have no equivalent runtime — analyst / deepDive / chat operate on
+ * a pre-built multi-period data pack against user-scoped questions and emit advice rather than
+ * sequenced orders — so injecting these rules on the app side is pure noise.
+ */
+export const BENCH_ONLY_DISCIPLINE_REFS = ['episode-execution.md'] as const;
+
+function readDisciplineReference(index: SkillMeta[], filename: string): string | null {
+  const meta = index.find((entry) => entry.name === DISCIPLINE_SKILL);
+  if (!meta) return null;
+  const path = join(meta.dir, DISCIPLINE_REFERENCES_DIR, filename);
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function composeDisciplineWithRefs(
+  index: SkillMeta[],
+  core: string,
+  refs: readonly string[],
+): string {
+  const parts = [core];
+  for (const ref of refs) {
+    const text = readDisciplineReference(index, ref);
+    if (text && text.trim()) parts.push(text);
+  }
+  return parts.join('\n\n---\n\n');
+}
+
+/** App-side composition: SKILL.md core + the three app-only reference chapters. */
+export function loadAppDiscipline(repoRoot: string): string | null {
+  const index = loadSkillIndex(skillSearchDirs(repoRoot));
+  const core = readSkill(index, DISCIPLINE_SKILL);
+  if (!core) return null;
+  return appendWatchedMarketsLine(composeDisciplineWithRefs(index, core, APP_ONLY_DISCIPLINE_REFS));
+}
+
+/** Bench-side composition: SKILL.md core + the bench-only reference chapter. */
+export function loadBenchDiscipline(repoRoot: string): string | null {
+  const index = loadSkillIndex(skillSearchDirs(repoRoot));
+  const core = readSkill(index, DISCIPLINE_SKILL);
+  if (!core) return null;
+  return appendWatchedMarketsLine(composeDisciplineWithRefs(index, core, BENCH_ONLY_DISCIPLINE_REFS));
+}
+
 export class DisciplineMissingError extends Error {
   constructor() {
     super(`${DISCIPLINE_SKILL} SKILL.md is unavailable; aborting because this agent must not run without its discipline.`);
@@ -52,9 +126,13 @@ export function appendWatchedMarketsLine(disciplineText: string): string {
   return [disciplineText, '', watchedMarketsLine(getWatchedMarketsOrDefault())].join('\n');
 }
 
+/**
+ * @deprecated App callers should use `loadAppDiscipline`; bench callers should use
+ * `loadBenchDiscipline`. Kept as a thin alias for `loadAppDiscipline` to avoid churn
+ * in existing chat / assistantChat call sites during migration.
+ */
 export function loadSharedDiscipline(repoRoot: string): string | null {
-  const text = readSkill(loadSkillIndex(skillSearchDirs(repoRoot)), DISCIPLINE_SKILL);
-  return text ? appendWatchedMarketsLine(text) : null;
+  return loadAppDiscipline(repoRoot);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the closed #52 with a cleaner file layout. Same scoping decisions, one skill instead of four.

Before this change the entire `trading-discipline` SKILL.md was injected into every judgment agent — app-side analyst / deepDive / chat and the bench episode runner alike. Bench measurements showed that ~80% of the file (US-specific data traps, Longbridge/broker rules, journal write conventions, post-mortem / leveraged-ETF rules) is pure noise inside a synthetic anonymous episode, and that the few rules which actually apply to bench execution (h1-bar flip cooldown, 40-session decision cadence, mandatory `fetch_kline` before submit) are equally noisy on the app side.

Restructure the discipline as one skill with scope-specific chapters:

```
.claude/skills/trading-discipline/
├── SKILL.md                          shared core (output / judgment / F. execution)
└── references/
    ├── us-market-data.md             app only (sources, GAAP, Korea, forced-liquidation, broker)
    ├── journal.md                    app only (journal + notes writing rules)
    ├── market-analysis.md            app only (post-mortem, mindset, leveraged ETFs)
    └── episode-execution.md          bench only (h1 flip cooldown, 40-session cadence, fetch_kline)
```

Rule IDs stay in the global `TD-*` namespace so existing `capital-rotation`, `market-session-tracker`, `trade-gate` references keep working.

## Composition API

`promptPolicy.ts` exposes two composition helpers:

```ts
export function loadAppDiscipline(repoRoot: string): string | null;   // SKILL.md + APP_ONLY_DISCIPLINE_REFS
export function loadBenchDiscipline(repoRoot: string): string | null; // SKILL.md + BENCH_ONLY_DISCIPLINE_REFS
```

References are composed at load time by the **caller**, not by the model — the model does not have to decide which chapters to read. `loadSharedDiscipline` becomes a thin deprecated alias for `loadAppDiscipline` so `chat` / `assistantChat` call sites keep working unchanged.

`buildAnalystSkillContexts` is simplified back to no options — its `disciplineText` parameter is now the fully-composed text supplied by the caller.

## CLAUDE.md

`@import`s just the `SKILL.md` core — Claude Code sessions can `read_file` a specific reference on demand when detail is needed, but the base discipline load mirrors what the app runtime injects. Since Claude Code sessions in this repo do real US analysis and journal writing, they can still pull in the app-only chapters manually as needed.

## Test plan

- [x] `pnpm --filter @kansoku/core test` — 896/896 passing
- [x] `pnpm --filter @kansoku/pro test` — 280/280 passing
- [x] `python3 scripts/sync-agents-skills.py` idempotent — 15 first-party skills linked (the previous four extra skill dirs are gone)
- [x] `loadAppDiscipline` probe: 18122 chars, contains TD-GAAP-01 / TD-JOURNAL-01 / TD-HINDSIGHT-01, does not contain TD-FLIP-01 / TD-CADENCE-01 / TD-CTX-01.
- [x] `loadBenchDiscipline` probe: 11337 chars, contains TD-FLIP-01 / TD-CADENCE-01 / TD-CTX-01, does not contain TD-GAAP-01 / TD-JOURNAL-01 / TD-HINDSIGHT-01.

## Companion PR

kansoku-trade/kansoku-pro `refactor/discipline-references-layout` switches `scaffold.ts` to `loadBenchDiscipline`. Merge this PR first.