### PR TITLE
feat(bench): add Yahoo Finance data source for 24h markets

### DIFF
--- a/packages/bench/src/cli.ts
+++ b/packages/bench/src/cli.ts
@@ -24,6 +24,8 @@ import type { EpisodeDataAudit } from './episode/audit.js';
 import { fetchGdeltArticlesLive, fetchEdgarFilingsLive } from './generate/newsSource.js';
 import { runGenerate } from './generate/pipeline.js';
 import { fetchCalendarLive, fetchKlineHistoryLive } from './generate/source.js';
+import { fetchKlineHistoryYahoo } from './generate/yahooFetcher.js';
+import type { FetchEpisodeKlineHistory } from './episode/generate.js';
 import { DEFAULT_SYMBOLS, layerForSymbol, type SymbolSpec } from './generate/symbols.js';
 import { listQuestions, loadQuestionForScorer } from './dataset/loader.js';
 import { parseDatasetPathOptions, type DatasetPaths } from './dataset/paths.js';
@@ -309,13 +311,20 @@ interface GenerateEpisodeCaseArgs {
   cutoffDate: string;
   version: string;
   horizonSessions: number;
+  source: 'longbridge' | 'yahoo';
 }
+
+const KLINE_FETCHERS: Record<GenerateEpisodeCaseArgs['source'], FetchEpisodeKlineHistory> = {
+  longbridge: fetchKlineHistoryLive,
+  yahoo: fetchKlineHistoryYahoo,
+};
 
 function parseGenerateEpisodeCaseArgs(argv: string[]): GenerateEpisodeCaseArgs {
   let symbol: string | undefined;
   let cutoffDate: string | undefined;
   let version: string | undefined;
   let horizonSessions = 40;
+  let source: GenerateEpisodeCaseArgs['source'] = 'longbridge';
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -334,6 +343,14 @@ function parseGenerateEpisodeCaseArgs(argv: string[]): GenerateEpisodeCaseArgs {
       }
       case '--horizon-sessions': {
         horizonSessions = Number(argv[++i]);
+        break;
+      }
+      case '--source': {
+        const next = argv[++i];
+        if (next !== 'longbridge' && next !== 'yahoo') {
+          throw new Error(`--source must be longbridge|yahoo, got: ${next}`);
+        }
+        source = next;
         break;
       }
       default: {
@@ -356,7 +373,7 @@ function parseGenerateEpisodeCaseArgs(argv: string[]): GenerateEpisodeCaseArgs {
   }
 
   layerForSymbol(symbol);
-  return { symbol, cutoffDate, version, horizonSessions };
+  return { symbol, cutoffDate, version, horizonSessions, source };
 }
 
 async function runGenerateEpisodeCaseCommand(argv: string[], paths: DatasetPaths): Promise<void> {
@@ -368,7 +385,7 @@ async function runGenerateEpisodeCaseCommand(argv: string[], paths: DatasetPaths
     version: args.version,
     horizonSessions: args.horizonSessions,
     datasetsRoot: paths.datasetsRoot,
-    fetchKlineHistory: fetchKlineHistoryLive,
+    fetchKlineHistory: KLINE_FETCHERS[args.source],
     fetchCalendar: fetchCalendarLive,
     log: (line) => process.stdout.write(`${line}\n`),
   });

--- a/packages/bench/src/generate/symbols.ts
+++ b/packages/bench/src/generate/symbols.ts
@@ -6,7 +6,14 @@ export interface ArchiveTermSpec {
 
 export interface SymbolSpec {
   symbol: string;
-  layer: 'high-vol-tech' | 'mega-blue-chip' | 'defensive' | 'cyclical' | 'index-etf';
+  layer:
+    | 'high-vol-tech'
+    | 'mega-blue-chip'
+    | 'defensive'
+    | 'cyclical'
+    | 'index-etf'
+    | 'commodity'
+    | 'crypto';
   companyQuery?: string | null;
   cik?: string | null;
   archiveTerms?: ArchiveTermSpec | null;
@@ -136,6 +143,20 @@ export const DEFAULT_SYMBOLS: SymbolSpec[] = [
   { symbol: 'QQQ.US', layer: 'index-etf', companyQuery: null, cik: null, archiveTerms: null },
   { symbol: 'SMH.US', layer: 'index-etf', companyQuery: null, cik: null, archiveTerms: null },
   { symbol: 'IWM.US', layer: 'index-etf', companyQuery: null, cik: null, archiveTerms: null },
+  {
+    symbol: 'GC=F',
+    layer: 'commodity',
+    companyQuery: null,
+    cik: null,
+    archiveTerms: null,
+  },
+  {
+    symbol: 'BTC-USD',
+    layer: 'crypto',
+    companyQuery: null,
+    cik: null,
+    archiveTerms: null,
+  },
 ];
 
 export function layerForSymbol(symbol: string): SymbolSpec['layer'] {

--- a/packages/bench/src/generate/yahooFetcher.ts
+++ b/packages/bench/src/generate/yahooFetcher.ts
@@ -1,0 +1,92 @@
+import type { FetchEpisodeKlineHistory } from '../episode/generate.js';
+import type { QuoteBar } from './assemble.js';
+import type { EpisodeKlinePeriod } from './source.js';
+
+const YAHOO_INTERVAL: Record<EpisodeKlinePeriod, string> = {
+  '1h': '60m',
+  day: '1d',
+  week: '1wk',
+};
+
+const YAHOO_CHART_URL = 'https://query1.finance.yahoo.com/v7/finance/chart';
+
+interface YahooQuoteBlock {
+  open?: (number | null)[];
+  high?: (number | null)[];
+  low?: (number | null)[];
+  close?: (number | null)[];
+  volume?: (number | null)[];
+}
+
+interface YahooChartResult {
+  timestamp?: number[];
+  indicators?: { quote?: YahooQuoteBlock[] };
+  meta?: { symbol?: string; currency?: string; exchangeTimezoneName?: string };
+}
+
+interface YahooChartResponse {
+  chart?: {
+    result?: YahooChartResult[];
+    error?: { code?: string; description?: string } | null;
+  };
+}
+
+async function fetchYahooChart(
+  symbol: string,
+  interval: string,
+  start: string,
+  end: string,
+): Promise<YahooChartResult> {
+  const period1 = Math.floor(Date.parse(`${start}T00:00:00Z`) / 1000);
+  const period2 = Math.floor(Date.parse(`${end}T23:59:59Z`) / 1000);
+  const url = `${YAHOO_CHART_URL}/${encodeURIComponent(symbol)}?interval=${interval}&period1=${period1}&period2=${period2}`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+  if (!res.ok) throw new Error(`yahoo ${symbol}: HTTP ${res.status}`);
+  const data = (await res.json()) as YahooChartResponse;
+  const result = data.chart?.result?.[0];
+  if (!result) {
+    const err = data.chart?.error;
+    throw new Error(`yahoo ${symbol}: ${err?.description ?? err?.code ?? 'no data'}`);
+  }
+  return result;
+}
+
+export const fetchKlineHistoryYahoo: FetchEpisodeKlineHistory = async (
+  symbol,
+  period,
+  start,
+  end,
+) => {
+  const interval = YAHOO_INTERVAL[period];
+  if (!interval) throw new Error(`yahoo fetcher does not support period: ${period}`);
+  const result = await fetchYahooChart(symbol, interval, start, end);
+  const ts = result.timestamp ?? [];
+  const quote = result.indicators?.quote?.[0] ?? {};
+  const bars: QuoteBar[] = [];
+  for (let i = 0; i < ts.length; i += 1) {
+    const open = quote.open?.[i];
+    const high = quote.high?.[i];
+    const low = quote.low?.[i];
+    const close = quote.close?.[i];
+    if (
+      open == null ||
+      high == null ||
+      low == null ||
+      close == null ||
+      !Number.isFinite(open) ||
+      !Number.isFinite(close)
+    ) {
+      continue;
+    }
+    const volume = quote.volume?.[i];
+    bars.push({
+      time: new Date(ts[i] * 1000).toISOString(),
+      open: String(open),
+      high: String(high),
+      low: String(low),
+      close: String(close),
+      volume: String(volume ?? 0),
+    });
+  }
+  return bars.sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+};


### PR DESCRIPTION
## Summary

Longbridge covers US equities only; benchmarking against gold, crypto, or any other 24h market needs a different data path. Add a Yahoo Finance chart API fetcher, wire it through the existing dataset-generation pipeline behind a \`--source\` flag, and register two representative symbols so bench cases can now target them.

## Changes

- **`packages/bench/src/generate/yahooFetcher.ts`** (new) — implements \`FetchEpisodeKlineHistory\` against Yahoo's public chart endpoint. Maps our (\`1h\` | \`day\` | \`week\`) to Yahoo's (\`60m\` | \`1d\` | \`1wk\`), filters null bars during exchange pauses, returns bars in the same \`QuoteBar\` shape the pipeline expects. No API key; only a \`User-Agent\` header. Yahoo \`60m\` retention ceiling ~730 days.
- **`packages/bench/src/generate/symbols.ts`** — \`SymbolSpec.layer\` gains \`'commodity' | 'crypto'\`. Register:
  - \`GC=F\` (COMEX gold futures, layer \`commodity\`) — near-24h with ~1h daily settlement pause, ET-anchored.
  - \`BTC-USD\` (Bitcoin spot, layer \`crypto\`) — fully 24/7 in UTC.
- **`packages/bench/src/cli.ts`** — \`generate-episode-case\` gains \`--source longbridge|yahoo\` (default \`longbridge\`, backwards-compatible). Small \`KLINE_FETCHERS\` map dispatches to the right fetcher without touching pipeline internals.

## Usage

Local dataset, no immutable release involved:

\`\`\`bash
pnpm --filter @kansoku/bench cli generate-episode-case \\
  --symbol GC=F --cutoff 2026-05-08 \\
  --version v2-mixed-local-pilot --horizon-sessions 15 \\
  --source yahoo
\`\`\`

For 24h markets \`horizonSessions\` should be smaller than the 40 used for US equities (\`15\` puts per-case h1 count at ~250-350, comparable to a stock-swing case's ~260).

## Not in this PR

Dataset manifests. The 8-case local pilot (4 gold + 4 BTC) generated with this fetcher lives under \`~/.cache/kansoku/bench/datasets/v2-mixed-local-pilot/\` and is not packaged as an immutable release — that comes later if the mixed cohort proves useful.

## Test plan

- [x] \`pnpm --filter @kansoku/bench test\` — 274/274 passing
- [x] End-to-end sanity: generated 8 cases (4 GC=F + 4 BTC-USD) locally; smoke-tested one GC=F case with \`gpt-5.4-mini\` and got \`completed\` / netR +1.24 / 183s / 39 tool calls.