### PR TITLE
feat: SB (Second Breakout) structure annotation on intraday dashboard

### DIFF
--- a/.claude/skills/chart/SKILL.md
+++ b/.claude/skills/chart/SKILL.md
@@ -103,11 +103,14 @@ listed here only for completeness:
 - `GET /api/symbols/:sym/latest` — the latest `intraday` chart doc in full, plus `prediction_stale`
 
 The client-side indicator toggle bar (show/hide 金叉死叉、自动背离、自动背驰、123
-结构、K线形态、AI 标注、价位线、EMA 均线; state in localStorage) has no API surface —
-it's a pure front-end feature on both the cockpit and archive pages. Swing 高低点
-are not one of the toggles — they're baked into the divergence/beichi/pattern123
-detectors as the underlying pivot data, not a standalone overlay (deliberate
-deviation from the earlier spec draft).
+结构、SB 结构、K线形态、AI 标注、价位线、EMA 均线; state in localStorage) has no API
+surface — it's a pure front-end feature on both the cockpit and archive pages.
+Swing 高低点 are not one of the toggles — they're baked into the
+divergence/beichi/pattern123/SB detectors as the underlying pivot data, not a
+standalone overlay (deliberate deviation from the earlier spec draft). SB（第二次
+突破/跌破，对应 Al Brooks 的 High 2 / Low 2）标注顺势回调后第二次尝试冲破前高/前低
+的结构：图上灰色 H1/L1 是失败的第一次尝试，金色 H2/L2 箭头是确认成功的第二次突破；
+`technicals` 里对应 `second_breakouts` 这一行。
 
 ### POST body per type
 
@@ -205,7 +208,8 @@ climax top (volume ≥ 2.5×20MA + red close + local high), MA50/MA200 breakdown
    (当日 session VWAP，m5/m15), `emas` (latest
    fast/mid/slow EMA values — price vs EMA stack tells the short-term trend
    posture), recent swing highs/lows, `last_cross` (金叉/死叉),
-   `divergence_candidates`, `beichi_candidates`. Also read `meta.day_context`:
+   `divergence_candidates`, `beichi_candidates`, `second_breakouts` (SB 结构，
+   H2/L2). Also read `meta.day_context`:
    `daily_trend` (up/down/range vs 日线 MA20/MA50), `daily_ma20`/`daily_ma50`,
    `high_20d`/`low_20d`, `prev_day` (昨日高/低/收), `pre_market` 区间,
    `opening_range` (开盘前 30 分钟), `vwap` — the server draws these as the
@@ -252,7 +256,7 @@ climax top (volume ≥ 2.5×20MA + red close + local high), MA50/MA200 breakdown
     },
   ],
   "signals": [
-    // 可选；背离/背驰/K线形态/123 结构均由服务端自动检测绘制，无需在此重复
+    // 可选；背离/背驰/K线形态/123 结构/SB 结构均由服务端自动检测绘制，无需在此重复
     {
       "type": "other",
       "timeframe": "m5",

--- a/apps/web/src/charts/intraday/useIndicatorToggles.ts
+++ b/apps/web/src/charts/intraday/useIndicatorToggles.ts
@@ -6,6 +6,7 @@ export type IndicatorToggleKey =
   | 'divergence'
   | 'beichi'
   | 'pattern123'
+  | 'sb'
   | 'candle'
   | 'ai'
   | 'levels'
@@ -22,6 +23,7 @@ export const INDICATOR_TOGGLE_ORDER: IndicatorToggleKey[] = [
   'daylevel',
   'fvg',
   'pattern123',
+  'sb',
   'optwall',
   'crosses',
   'divergence',
@@ -35,6 +37,7 @@ export const INDICATOR_TOGGLE_LABELS: Record<IndicatorToggleKey, string> = {
   divergence: '自动背离',
   beichi: '自动背驰',
   pattern123: '123 结构',
+  sb: 'SB 结构',
   candle: 'K线形态',
   ai: 'AI 标注',
   levels: '价位线',
@@ -52,6 +55,7 @@ export const INDICATOR_TOGGLE_COLORS: Record<IndicatorToggleKey, string> = {
   daylevel: theme.textPrimary,
   fvg: theme.up,
   pattern123: theme.accent,
+  sb: theme.accent,
   optwall: theme.down,
   crosses: theme.up,
   divergence: theme.down,
@@ -64,7 +68,7 @@ export const INDICATOR_TOGGLE_KEYS = INDICATOR_TOGGLE_ORDER;
 
 const STORAGE_KEY = 'intraday-indicators';
 
-const DEFAULT_ON = new Set<IndicatorToggleKey>(['ema', 'vwap', 'levels', 'daylevel']);
+const DEFAULT_ON = new Set<IndicatorToggleKey>(['ema', 'vwap', 'levels', 'daylevel', 'sb']);
 
 function defaultToggles(): Record<IndicatorToggleKey, boolean> {
   return Object.fromEntries(INDICATOR_TOGGLE_KEYS.map((k) => [k, DEFAULT_ON.has(k)])) as Record<

--- a/apps/web/src/charts/intraday/useIntradayCharts.ts
+++ b/apps/web/src/charts/intraday/useIntradayCharts.ts
@@ -99,11 +99,12 @@ const filterByGroup = <T extends { group?: SeriesMarker['group'] }>(
 
 const secondBreakoutMarkers = (sbs: SecondBreakout[]): SeriesMarker[] => {
   const markers: SeriesMarker[] = [];
-  for (const sb of sbs) {
+  sbs.forEach((sb, i) => {
     const bullish = sb.kind === 'H2';
     const firstText = bullish ? 'H1' : 'L1';
     const attemptVerb = bullish ? '突破' : '跌破';
     markers.push({
+      id: `sb-${i}-first`,
       time: sb.first.time,
       position: bullish ? 'aboveBar' : 'belowBar',
       color: theme.textSecondary,
@@ -113,6 +114,7 @@ const secondBreakoutMarkers = (sbs: SecondBreakout[]): SeriesMarker[] => {
     });
     if (sb.status === 'forming') {
       markers.push({
+        id: `sb-${i}-signal`,
         time: sb.signal.time,
         position: bullish ? 'aboveBar' : 'belowBar',
         color: theme.textSecondary,
@@ -121,16 +123,18 @@ const secondBreakoutMarkers = (sbs: SecondBreakout[]): SeriesMarker[] => {
         tooltip: `SB 结构酝酿中：等待收盘${attemptVerb} $${sb.signal.price.toFixed(2)}`,
       });
     } else if (sb.trigger) {
+      const extremeText = bullish ? '最高' : '最低';
       markers.push({
+        id: `sb-${i}-trigger`,
         time: sb.trigger.time,
         position: bullish ? 'belowBar' : 'aboveBar',
         color: theme.accent,
         shape: bullish ? 'arrowUp' : 'arrowDown',
         text: sb.kind,
-        tooltip: `${sb.kind} 结构确认\n收盘 $${sb.trigger.price.toFixed(2)} ${attemptVerb}信号棒`,
+        tooltip: `${sb.kind} 结构确认\n${extremeText} $${sb.trigger.price.toFixed(2)} ${attemptVerb}信号棒`,
       });
     }
-  }
+  });
   return markers;
 };
 

--- a/apps/web/src/charts/intraday/useIntradayCharts.ts
+++ b/apps/web/src/charts/intraday/useIntradayCharts.ts
@@ -13,6 +13,7 @@ import {
 import type {
   IntradayBuilt,
   IntradayPriceZone,
+  SecondBreakout,
   SeriesMarker,
   TimeframeKey,
 } from '@kansoku/shared/types';
@@ -95,6 +96,43 @@ const filterByGroup = <T extends { group?: SeriesMarker['group'] }>(
   items: T[],
   toggles: Record<IndicatorToggleKey, boolean>,
 ): T[] => items.filter((item) => groupAllowed(toggles, item.group));
+
+const secondBreakoutMarkers = (sbs: SecondBreakout[]): SeriesMarker[] => {
+  const markers: SeriesMarker[] = [];
+  for (const sb of sbs) {
+    const bullish = sb.kind === 'H2';
+    const firstText = bullish ? 'H1' : 'L1';
+    const attemptVerb = bullish ? '突破' : '跌破';
+    markers.push({
+      time: sb.first.time,
+      position: bullish ? 'aboveBar' : 'belowBar',
+      color: theme.textSecondary,
+      shape: 'circle',
+      text: firstText,
+      tooltip: `${firstText}（第一次${attemptVerb}尝试，未成立）`,
+    });
+    if (sb.status === 'forming') {
+      markers.push({
+        time: sb.signal.time,
+        position: bullish ? 'aboveBar' : 'belowBar',
+        color: theme.textSecondary,
+        shape: 'circle',
+        text: '',
+        tooltip: `SB 结构酝酿中：等待收盘${attemptVerb} $${sb.signal.price.toFixed(2)}`,
+      });
+    } else if (sb.trigger) {
+      markers.push({
+        time: sb.trigger.time,
+        position: bullish ? 'belowBar' : 'aboveBar',
+        color: theme.accent,
+        shape: bullish ? 'arrowUp' : 'arrowDown',
+        text: sb.kind,
+        tooltip: `${sb.kind} 结构确认\n收盘 $${sb.trigger.price.toFixed(2)} ${attemptVerb}信号棒`,
+      });
+    }
+  }
+  return markers;
+};
 
 export interface DrawingChartHandle {
   chart: IChartApi;
@@ -274,7 +312,10 @@ export function useIntradayCharts(
     h.anchorBg.setData(
       toggles.ai && anchorHere ? [Math.floor(Date.parse(anchorHere.time) / 1000)] : [],
     );
-    const markers = filterByGroup(d.markers, toggles);
+    const sbMarkers = toggles.sb ? secondBreakoutMarkers(d.secondBreakouts ?? []) : [];
+    const markers = [...filterByGroup(d.markers, toggles), ...sbMarkers].sort(
+      (a, b) => a.time - b.time,
+    );
     h.candleMarkers.setMarkers(toMarkers(markers));
     h.mainTip.setMarkers(markers);
     h.dif.setData(padLineData(d.macdDif, timeline));

--- a/docs/superpowers/specs/2026-07-20-sb-second-breakout-annotation-design.md
+++ b/docs/superpowers/specs/2026-07-20-sb-second-breakout-annotation-design.md
@@ -8,8 +8,9 @@ Status: approved
 Auto-detect and annotate SB (Second Breakout, Al Brooks High 2 / Low 2) structures on the
 `intraday` multi-timeframe dashboard (5m / 15m / 1h), alongside the existing 123-structure,
 divergence, and candle-pattern detectors. Detection runs server-side in `@kansoku/core`,
-results are frozen into the chart JSON, rendered as markers in the web app, and summarized
-into `technicals` text so AI reads (e.g. the `intraday-signal` skill) can use them.
+results are frozen into the chart JSON, rendered as markers in the web app, and carried in
+each timeframe's `technicals` summary so AI reads (e.g. the `intraday-signal` skill) see them
+via the ReassessPack JSON already sent to the AI.
 
 ## Definition being implemented
 
@@ -73,9 +74,11 @@ interface SecondBreakout {
 ### 3. Orchestrator wiring — `packages/core/src/services/intraday.ts`
 
 - Run the detector once per timeframe (5m / 15m / 1h).
-- Emit results into the intraday chart JSON document next to `pattern123` / `fvgZones`.
-- Append a line per timeframe to the `technicals` text (e.g. "5m: H2 confirmed at 108.10
-  (trigger 14:35), trend up") so AI consumers see it without reading the JSON.
+- Emit results into the intraday chart JSON document next to `pattern123` / `fvgZones`, and
+  into each timeframe's `technicals` summary as `second_breakouts`.
+- AI visibility needs no separate free-text line: `second_breakouts` rides inside each
+  timeframe's summary in the ReassessPack JSON (`packages/core/src/ai/datapack.ts`) that AI
+  consumers (e.g. `analystMessagesEngine`/chat) already receive.
 
 ### 4. Rendering — `apps/web`
 

--- a/docs/superpowers/specs/2026-07-20-sb-second-breakout-annotation-design.md
+++ b/docs/superpowers/specs/2026-07-20-sb-second-breakout-annotation-design.md
@@ -1,0 +1,109 @@
+# SB (Second Breakout) Structure Annotation — Design
+
+Date: 2026-07-20
+Status: approved
+
+## Goal
+
+Auto-detect and annotate SB (Second Breakout, Al Brooks High 2 / Low 2) structures on the
+`intraday` multi-timeframe dashboard (5m / 15m / 1h), alongside the existing 123-structure,
+divergence, and candle-pattern detectors. Detection runs server-side in `@kansoku/core`,
+results are frozen into the chart JSON, rendered as markers in the web app, and summarized
+into `technicals` text so AI reads (e.g. the `intraday-signal` skill) can use them.
+
+## Definition being implemented
+
+SB is a with-trend continuation structure:
+
+1. A clear trend is in place (trend filter below).
+2. Price pulls back, then makes a first with-trend attempt (H1 in an uptrend, L1 in a
+   downtrend) that fails: it does not break the prior trend extreme and price falls back
+   into the pullback, making a new pullback extreme.
+3. A second with-trend attempt forms. The bar that breaks the second attempt's signal-bar
+   high (uptrend) or low (downtrend) is the trigger bar: the SB structure is confirmed
+   and annotated on that bar.
+4. Both attempts must belong to the same pullback structure. If they are too far apart or
+   the market has degraded into a range, no SB is counted.
+
+Counting method: swing-pivot based (approved choice), not Brooks bar-by-bar counting.
+Pivots come from the existing swing detection, mirroring `pattern123.ts`'s
+`findPivots`-style alternating pivot sequence.
+
+## Trend filter
+
+EMA20 on each timeframe's own bars:
+
+- Price above EMA20 and EMA20 rising → uptrend: count H2 only.
+- Price below EMA20 and EMA20 falling → downtrend: count L2 only.
+- Price repeatedly crossing the EMA (range) → no SB annotation.
+
+The concrete "repeatedly crossing" rule and the "too far apart" cap (max bar distance
+between the two attempts) are implementation-tuned constants defined in the detector with
+the same fixture-driven approach used by `pattern123.ts` thresholds.
+
+## Components
+
+### 1. Detector — `packages/core/src/services/secondBreakout.ts`
+
+New service following the `pattern123.ts` pattern:
+
+- Input: OHLC series + timestamps for one timeframe.
+- Reuses swing/pivot detection (`findSwings` in `indicators.ts`, or a local
+  `findPivots`-style alternating sequence like `pattern123.ts`).
+- Computes EMA20 internally for the trend filter.
+- Output: `SecondBreakout[]`.
+- Status is two-valued like `Pattern123`: `forming` (second attempt visible, trigger not
+  yet broken) and `confirmed` (trigger bar closed beyond the signal bar extreme).
+
+### 2. Shared type — `packages/shared/types.ts`
+
+```ts
+interface SecondBreakout {
+  kind: 'H2' | 'L2'
+  firstAttempt: { time: number; price: number }   // H1/L1 pivot
+  signalBar: { time: number; price: number }      // second-attempt signal bar + its extreme
+  trigger?: { time: number; price: number }       // trigger bar, present when confirmed
+  status: 'forming' | 'confirmed'
+}
+```
+
+(Exact field names may be adjusted during implementation to match neighboring types like
+`Pattern123`; semantics above are fixed.)
+
+### 3. Orchestrator wiring — `packages/core/src/services/intraday.ts`
+
+- Run the detector once per timeframe (5m / 15m / 1h).
+- Emit results into the intraday chart JSON document next to `pattern123` / `fvgZones`.
+- Append a line per timeframe to the `technicals` text (e.g. "5m: H2 confirmed at 108.10
+  (trigger 14:35), trend up") so AI consumers see it without reading the JSON.
+
+### 4. Rendering — `apps/web`
+
+- `apps/web/src/charts/intraday/useIntradayCharts.ts`: draw via `attachMarkers`:
+  - H2: amber/gold arrow-up marker below the trigger bar, text "H2".
+  - L2: arrow-down marker above the trigger bar, text "L2".
+  - H1/L1: small grey markers at the failed first attempt, same toggle, for context.
+  - `forming` structures render the H1/L1 + signal-bar marker in grey without the
+    trigger marker.
+- `apps/web/src/charts/intraday/useIndicatorToggles.ts`: new toggle key `sb`, label
+  "SB 结构", default on, persisted to localStorage like existing toggles.
+
+## Non-goals
+
+- No Brooks bar-by-bar counting mode (explicitly rejected).
+- No standalone chart type; annotation lives only on the `intraday` dashboard.
+- No entry/stop/target logic — this is annotation only; trade logic stays in the
+  `intraday-signal` skill layer.
+- No user-drawn/manual variant (the `drawings` system is unrelated).
+
+## Testing
+
+Unit tests in `packages/core` with hand-crafted candle fixtures:
+
+1. Uptrend H2: full sequence detects one confirmed H2 at the right bar.
+2. Downtrend L2: mirrored sequence detects one confirmed L2.
+3. Range: price oscillating across EMA20 produces no SB.
+4. Attempts too far apart / structure degraded: no SB despite two nominal attempts.
+
+Plus: `.claude/skills/chart/SKILL.md` indicator inventory updated to document the new
+overlay and toggle.

--- a/packages/core/src/services/intraday.ts
+++ b/packages/core/src/services/intraday.ts
@@ -61,11 +61,6 @@ export const TIMEFRAME_LABELS: Record<TimeframeKey, string> = {
   m15: '15分钟',
   h1: '1小时',
 };
-const TECHNICALS_NOTE_TF_LABELS: Record<TimeframeKey, string> = {
-  m5: '5m',
-  m15: '15m',
-  h1: '1h',
-};
 export const DEFAULT_EMA_PERIODS = [9, 21, 55];
 const MACD_MIN_BARS = 60;
 const SIGNAL_ICON: Record<string, string> = {
@@ -704,24 +699,6 @@ function pattern123Overlay(patterns: Pattern123[], lastBarTime: number): TfOverl
   return { markers, priceConnectors, macdConnectors: [] };
 }
 
-function secondBreakoutNoteLine(tfKey: TimeframeKey, sb: SecondBreakout): string {
-  const tfLabel = TECHNICALS_NOTE_TF_LABELS[tfKey];
-  if (sb.trigger) {
-    return `${tfLabel}: ${sb.kind} confirmed at ${sb.trigger.price.toFixed(2)} (trigger ${barTimeShort(sb.trigger.time)})`;
-  }
-  return `${tfLabel}: ${sb.kind} forming at ${sb.signal.price.toFixed(2)}`;
-}
-
-function buildTechnicalsNotes(tfs: Record<TimeframeKey, CoercedTimeframe>): string[] {
-  const notes: string[] = [];
-  for (const k of TIMEFRAME_ORDER) {
-    const latest = tfs[k].secondBreakouts.at(-1);
-    if (!latest) continue;
-    notes.push(secondBreakoutNoteLine(k, latest));
-  }
-  return notes;
-}
-
 export function computeIntradayEntryPlan(
   raw: NonNullable<IntradayPrediction['entry_plan']>,
   direction: string,
@@ -1062,8 +1039,6 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
     TimeframeKey,
     IntradayTfSummary
   >;
-  const technicalsNotes = buildTechnicalsNotes(tfs);
-
   const lastM5 = tfs.m5.candles.at(-1)!;
   const dayContext = buildDayContext(
     input.day_kline ?? [],
@@ -1093,7 +1068,6 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
       entryPlan,
       position,
       technicals,
-      technicalsNotes,
       dayContext,
       optionsLevels: input.options_levels ?? null,
       eventRisk: input.event_risk ?? null,
@@ -1109,7 +1083,6 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
       number
     >,
     technicals,
-    technicals_notes: technicalsNotes,
     day_context: dayContext,
     options_levels: input.options_levels ?? null,
     event_risk: input.event_risk ?? null,

--- a/packages/core/src/services/intraday.ts
+++ b/packages/core/src/services/intraday.ts
@@ -26,6 +26,7 @@ import {
   type Pattern123,
   type PredictionScenario,
   type RawBar,
+  type SecondBreakout,
   type SeriesMarker,
   type SwingPoint,
   type TimeframeKey,
@@ -44,6 +45,7 @@ import {
   type MacdStructure,
 } from './macdStructure.js';
 import { detect123Patterns } from './pattern123.js';
+import { detectSecondBreakouts } from './secondBreakout.js';
 import {
   enrichCandlePatterns,
   offSessionSignalKeeper,
@@ -58,6 +60,11 @@ export const TIMEFRAME_LABELS: Record<TimeframeKey, string> = {
   m5: '5分钟',
   m15: '15分钟',
   h1: '1小时',
+};
+const TECHNICALS_NOTE_TF_LABELS: Record<TimeframeKey, string> = {
+  m5: '5m',
+  m15: '15m',
+  h1: '1h',
 };
 export const DEFAULT_EMA_PERIODS = [9, 21, 55];
 const MACD_MIN_BARS = 60;
@@ -282,6 +289,7 @@ export interface CoercedTimeframe {
   autoDivergence: DivergencePair[];
   autoBeichi: DivergencePair[];
   pattern123: Pattern123[];
+  secondBreakouts: SecondBreakout[];
   fvgZones: IntradayFvgZone[];
   lastClose: number;
   summary: IntradayTfSummary;
@@ -388,6 +396,9 @@ export function coerceIntradayTimeframe(
   const pattern123 = detect123Patterns(highs, lows, closes, timesTs)
     .filter((p) => keepSignal(p.confirm?.time ?? p.p3.time))
     .slice(-2);
+  const secondBreakouts = detectSecondBreakouts(highs, lows, closes, timesTs)
+    .filter((sb) => keepSignal(sb.trigger?.time ?? sb.signal.time))
+    .slice(-2);
   structure.signals = structure.signals.filter((s) => keepSignal(s.time));
 
   return {
@@ -404,6 +415,7 @@ export function coerceIntradayTimeframe(
     autoDivergence: autoDivergence.slice(-2),
     autoBeichi: autoBeichi.slice(-2),
     pattern123,
+    secondBreakouts,
     fvgZones,
     lastClose: closes.at(-1)!,
     summary: {
@@ -421,6 +433,7 @@ export function coerceIntradayTimeframe(
       zero_tangle: structure.tangle,
       candle_patterns: candlePatterns.slice(-6),
       pattern_123: pattern123,
+      second_breakouts: secondBreakouts,
     },
   };
 }
@@ -689,6 +702,24 @@ function pattern123Overlay(patterns: Pattern123[], lastBarTime: number): TfOverl
     }
   }
   return { markers, priceConnectors, macdConnectors: [] };
+}
+
+function secondBreakoutNoteLine(tfKey: TimeframeKey, sb: SecondBreakout): string {
+  const tfLabel = TECHNICALS_NOTE_TF_LABELS[tfKey];
+  if (sb.trigger) {
+    return `${tfLabel}: ${sb.kind} confirmed at ${sb.trigger.price.toFixed(2)} (trigger ${barTimeShort(sb.trigger.time)})`;
+  }
+  return `${tfLabel}: ${sb.kind} forming at ${sb.signal.price.toFixed(2)}`;
+}
+
+function buildTechnicalsNotes(tfs: Record<TimeframeKey, CoercedTimeframe>): string[] {
+  const notes: string[] = [];
+  for (const k of TIMEFRAME_ORDER) {
+    const latest = tfs[k].secondBreakouts.at(-1);
+    if (!latest) continue;
+    notes.push(secondBreakoutNoteLine(k, latest));
+  }
+  return notes;
 }
 
 export function computeIntradayEntryPlan(
@@ -1017,6 +1048,7 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
       autoDivergence: tf.autoDivergence,
       autoBeichi: tf.autoBeichi,
       pattern123: tf.pattern123,
+      secondBreakouts: tf.secondBreakouts,
       fvgZones: tf.fvgZones,
       offSession: offSessionSegments(
         tf.candles.map((c) => c.time),
@@ -1030,6 +1062,7 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
     TimeframeKey,
     IntradayTfSummary
   >;
+  const technicalsNotes = buildTechnicalsNotes(tfs);
 
   const lastM5 = tfs.m5.candles.at(-1)!;
   const dayContext = buildDayContext(
@@ -1060,6 +1093,7 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
       entryPlan,
       position,
       technicals,
+      technicalsNotes,
       dayContext,
       optionsLevels: input.options_levels ?? null,
       eventRisk: input.event_risk ?? null,
@@ -1075,6 +1109,7 @@ export function buildIntraday(input: IntradayInput): { built: IntradayBuilt; met
       number
     >,
     technicals,
+    technicals_notes: technicalsNotes,
     day_context: dayContext,
     options_levels: input.options_levels ?? null,
     event_risk: input.event_risk ?? null,

--- a/packages/core/src/services/secondBreakout.ts
+++ b/packages/core/src/services/secondBreakout.ts
@@ -1,0 +1,120 @@
+import type { SecondBreakout, SwingPoint } from '@kansoku/shared/types';
+import { ema } from './indicators.js';
+
+const PIVOT_WINDOW = 3;
+const EMA_PERIOD = 20;
+const EMA_SLOPE_LOOKBACK = 5;
+const MAX_ATTEMPT_GAP = 25;
+const RANGE_CROSS_WINDOW = 20;
+const RANGE_CROSS_MAX = 3;
+
+interface Pivot {
+  index: number;
+  price: number;
+  isHigh: boolean;
+}
+
+function findPivots(highs: number[], lows: number[]): Pivot[] {
+  const n = highs.length;
+  const zigzag: Pivot[] = [];
+  for (let i = PIVOT_WINDOW; i < n - PIVOT_WINDOW; i++) {
+    let isHigh = true;
+    let isLow = true;
+    for (let j = i - PIVOT_WINDOW; j <= i + PIVOT_WINDOW; j++) {
+      if (highs[j] > highs[i]) isHigh = false;
+      if (lows[j] < lows[i]) isLow = false;
+    }
+    if (isHigh === isLow) continue;
+    const pivot: Pivot = isHigh
+      ? { index: i, price: highs[i], isHigh: true }
+      : { index: i, price: lows[i], isHigh: false };
+    const last = zigzag.at(-1);
+    if (last && last.isHigh === pivot.isHigh) {
+      const keep = pivot.isHigh ? pivot.price >= last.price : pivot.price <= last.price;
+      if (keep) zigzag[zigzag.length - 1] = pivot;
+    } else {
+      zigzag.push(pivot);
+    }
+  }
+  return zigzag;
+}
+
+export function detectSecondBreakouts(
+  highs: number[],
+  lows: number[],
+  closes: number[],
+  timesTs: number[],
+): SecondBreakout[] {
+  const emaLine = ema(closes, EMA_PERIOD);
+  const pivots = findPivots(highs, lows);
+
+  const trendAt = (i: number): 'up' | 'down' | null => {
+    const e = emaLine[i];
+    const ePrev = emaLine[i - EMA_SLOPE_LOOKBACK];
+    if (e === null || e === undefined || ePrev === null || ePrev === undefined) return null;
+    if (closes[i] > e && e > ePrev) return 'up';
+    if (closes[i] < e && e < ePrev) return 'down';
+    return null;
+  };
+
+  const isRange = (i: number): boolean => {
+    const from = Math.max(EMA_PERIOD - 1, i - RANGE_CROSS_WINDOW);
+    let crosses = 0;
+    let prevSign: number | null = null;
+    for (let j = from; j <= i; j++) {
+      const e = emaLine[j];
+      if (e === null || e === undefined) continue;
+      const sign = closes[j] >= e ? 1 : -1;
+      if (prevSign !== null && sign !== prevSign) crosses++;
+      prevSign = sign;
+    }
+    return crosses > RANGE_CROSS_MAX;
+  };
+
+  const point = (p: Pivot): SwingPoint => ({ time: timesTs[p.index], price: p.price });
+
+  const out: SecondBreakout[] = [];
+  for (let k = 0; k + 4 < pivots.length; k++) {
+    const p0 = pivots[k];
+    const p1 = pivots[k + 1];
+    const p2 = pivots[k + 2];
+    const p3 = pivots[k + 3];
+    const p4 = pivots[k + 4];
+    const bullish = p0.isHigh;
+
+    if (bullish) {
+      if (!(p2.price < p0.price)) continue;
+      if (!(p3.price < p1.price)) continue;
+    } else {
+      if (!(p2.price > p0.price)) continue;
+      if (!(p3.price > p1.price)) continue;
+    }
+    if (p4.index - p2.index > MAX_ATTEMPT_GAP) continue;
+    if (trendAt(p0.index) !== (bullish ? 'up' : 'down')) continue;
+    if (trendAt(p4.index) !== (bullish ? 'up' : 'down')) continue;
+    if (isRange(p4.index)) continue;
+
+    let trigger: SwingPoint | null = null;
+    let invalidated = false;
+    for (let j = p4.index + 1; j < closes.length; j++) {
+      if (bullish ? lows[j] < p3.price : highs[j] > p3.price) {
+        invalidated = true;
+        break;
+      }
+      if (bullish ? highs[j] > p4.price : lows[j] < p4.price) {
+        trigger = { time: timesTs[j], price: bullish ? highs[j] : lows[j] };
+        break;
+      }
+    }
+    if (invalidated) continue;
+
+    out.push({
+      kind: bullish ? 'H2' : 'L2',
+      status: trigger ? 'confirmed' : 'forming',
+      first: point(p2),
+      signal: point(p4),
+      trigger,
+    });
+  }
+  return out;
+}

--- a/packages/core/test/intraday.test.ts
+++ b/packages/core/test/intraday.test.ts
@@ -267,6 +267,78 @@ describe('intraday parity vs python golden fixture', () => {
     }
   });
 
+  it('flows a confirmed H2 through coerceIntradayTimeframe into summary and tf data', () => {
+    const upRamp = (from: number, to: number, step: number) => {
+      const out: number[] = [];
+      for (let v = from; step > 0 ? v <= to : v >= to; v += step) out.push(v);
+      return out;
+    };
+    const UP_TREND = upRamp(70, 130, 1);
+    const UP_H2_STRUCTURE = [
+      129, 128, 127, 126, 125,
+      126, 127, 128,
+      127, 126, 125, 124, 123,
+      124, 125, 126, 127, 126, 125, 124,
+      125, 126, 127, 128,
+    ];
+    const closes = [...UP_TREND, ...UP_H2_STRUCTURE];
+    const base = Date.parse('2026-06-01T08:00:00.000Z') / 1000;
+    const raw: RawBar[] = closes.map((c, i) => ({
+      time: new Date((base + i * 300) * 1000).toISOString(),
+      open: c,
+      high: c + 0.5,
+      low: c - 0.5,
+      close: c,
+      volume: 1000,
+    }));
+    const tf = coerceIntradayTimeframe(raw, 'm5');
+    expect(tf.secondBreakouts).toHaveLength(1);
+    expect(tf.secondBreakouts[0].kind).toBe('H2');
+    expect(tf.secondBreakouts[0].status).toBe('confirmed');
+    expect(tf.summary.second_breakouts).toEqual(tf.secondBreakouts);
+  });
+
+  it('emits a secondBreakouts field and a technicals note line for a confirmed SB structure', () => {
+    const upRamp = (from: number, to: number, step: number) => {
+      const out: number[] = [];
+      for (let v = from; step > 0 ? v <= to : v >= to; v += step) out.push(v);
+      return out;
+    };
+    const UP_TREND = upRamp(70, 130, 1);
+    const UP_H2_STRUCTURE = [
+      129, 128, 127, 126, 125,
+      126, 127, 128,
+      127, 126, 125, 124, 123,
+      124, 125, 126, 127, 126, 125, 124,
+      125, 126, 127, 128,
+    ];
+    const closes = [...UP_TREND, ...UP_H2_STRUCTURE];
+    const base = Date.parse('2026-06-01T08:00:00.000Z') / 1000;
+    const sbBars: RawBar[] = closes.map((c, i) => ({
+      time: new Date((base + i * 300) * 1000).toISOString(),
+      open: c,
+      high: c + 0.5,
+      low: c - 0.5,
+      close: c,
+      volume: 1000,
+    }));
+    const { built, meta } = buildIntraday({
+      ...input,
+      timeframes: { ...input.timeframes, m5: sbBars },
+    });
+
+    expect(built.timeframes.m5.secondBreakouts).toHaveLength(1);
+    expect(built.timeframes.m5.secondBreakouts?.[0].status).toBe('confirmed');
+    expect(built.sidebar.technicalsNotes.some((line) => line.startsWith('5m: H2 confirmed at')))
+      .toBe(true);
+    expect(meta.technicals_notes).toEqual(built.sidebar.technicalsNotes);
+    expect(
+      built.sidebar.technicalsNotes.some(
+        (line) => line.startsWith('m15:') || line.startsWith('1h:'),
+      ),
+    ).toBe(false);
+  });
+
   it('throws ClientError when sources_used is not an array', () => {
     const context = {
       generated_at: '2026-07-05T14:00:00.000Z',

--- a/packages/core/test/intraday.test.ts
+++ b/packages/core/test/intraday.test.ts
@@ -298,7 +298,7 @@ describe('intraday parity vs python golden fixture', () => {
     expect(tf.summary.second_breakouts).toEqual(tf.secondBreakouts);
   });
 
-  it('emits a secondBreakouts field and a technicals note line for a confirmed SB structure', () => {
+  it('emits a secondBreakouts field for a confirmed SB structure', () => {
     const upRamp = (from: number, to: number, step: number) => {
       const out: number[] = [];
       for (let v = from; step > 0 ? v <= to : v >= to; v += step) out.push(v);
@@ -322,21 +322,14 @@ describe('intraday parity vs python golden fixture', () => {
       close: c,
       volume: 1000,
     }));
-    const { built, meta } = buildIntraday({
+    const { built } = buildIntraday({
       ...input,
       timeframes: { ...input.timeframes, m5: sbBars },
     });
 
     expect(built.timeframes.m5.secondBreakouts).toHaveLength(1);
     expect(built.timeframes.m5.secondBreakouts?.[0].status).toBe('confirmed');
-    expect(built.sidebar.technicalsNotes.some((line) => line.startsWith('5m: H2 confirmed at')))
-      .toBe(true);
-    expect(meta.technicals_notes).toEqual(built.sidebar.technicalsNotes);
-    expect(
-      built.sidebar.technicalsNotes.some(
-        (line) => line.startsWith('m15:') || line.startsWith('1h:'),
-      ),
-    ).toBe(false);
+    expect(built.sidebar.technicals.m5.second_breakouts).toEqual(built.timeframes.m5.secondBreakouts);
   });
 
   it('throws ClientError when sources_used is not an array', () => {

--- a/packages/core/test/secondBreakout.test.ts
+++ b/packages/core/test/secondBreakout.test.ts
@@ -76,17 +76,25 @@ describe('detectSecondBreakouts', () => {
     expect(detectSecondBreakouts(highs, lows, c, timesTs)).toHaveLength(0);
   });
 
+  const buildAttemptGapStructure = (descentStep: number) => [
+    ...UP_TREND,
+    129, 128, 127, 126, 125,
+    126, 127, 128,
+    ...ramp(127, 123, -descentStep),
+    124, 125, 126, 127, 126, 125, 124,
+    125, 126, 127, 128,
+  ];
+
+  it('detects the H2 when the two attempts still fit within MAX_ATTEMPT_GAP', () => {
+    const closes = buildAttemptGapStructure(0.2);
+    const { highs, lows, closes: c, timesTs } = bars(closes);
+    const found = detectSecondBreakouts(highs, lows, c, timesTs);
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('H2');
+  });
+
   it('drops the structure when the two attempts are too far apart', () => {
-    const gapFiller = Array.from({ length: 60 }, (_, i) => 128 + ((i % 6) - 3) * 0.2);
-    const closes = [
-      ...UP_TREND,
-      129, 128, 127, 126, 125,
-      126, 127, 128,
-      ...gapFiller,
-      127, 126, 125, 124, 123,
-      124, 125, 126, 127, 126, 125, 124,
-      125, 126, 127, 128,
-    ];
+    const closes = buildAttemptGapStructure(0.1);
     const { highs, lows, closes: c, timesTs } = bars(closes);
     expect(detectSecondBreakouts(highs, lows, c, timesTs)).toHaveLength(0);
   });

--- a/packages/core/test/secondBreakout.test.ts
+++ b/packages/core/test/secondBreakout.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { detectSecondBreakouts } from '../src/services/secondBreakout.js';
+
+function bars(closes: number[]): {
+  highs: number[];
+  lows: number[];
+  closes: number[];
+  timesTs: number[];
+} {
+  return {
+    highs: closes.map((c) => c + 0.5),
+    lows: closes.map((c) => c - 0.5),
+    closes,
+    timesTs: closes.map((_, i) => 1_700_000_000 + i * 300),
+  };
+}
+
+const ramp = (from: number, to: number, step: number) => {
+  const out: number[] = [];
+  for (let v = from; step > 0 ? v <= to : v >= to; v += step) out.push(v);
+  return out;
+};
+
+const UP_TREND = ramp(100, 130, 1);
+const UP_H2_STRUCTURE = [
+  129, 128, 127, 126, 125,
+  126, 127, 128,
+  127, 126, 125, 124, 123,
+  124, 125, 126, 127, 126, 125, 124,
+  125, 126, 127, 128,
+];
+
+const DOWN_TREND = ramp(130, 100, -1);
+const DOWN_L2_STRUCTURE = [
+  101, 102, 103, 104, 105,
+  104, 103, 102,
+  103, 104, 105, 106, 107,
+  106, 105, 104, 103, 104, 105, 106,
+  105, 104, 103, 102,
+];
+
+describe('detectSecondBreakouts', () => {
+  it('detects a confirmed H2 in an uptrend', () => {
+    const closes = [...UP_TREND, ...UP_H2_STRUCTURE];
+    const { highs, lows, closes: c, timesTs } = bars(closes);
+    const found = detectSecondBreakouts(highs, lows, c, timesTs);
+    expect(found).toHaveLength(1);
+    const sb = found[0];
+    expect(sb.kind).toBe('H2');
+    expect(sb.status).toBe('confirmed');
+    expect(sb.first.price).toBe(128.5);
+    expect(sb.signal.price).toBe(127.5);
+    expect(sb.trigger).not.toBeNull();
+    expect(sb.trigger?.price).toBe(128.5);
+    expect(sb.trigger?.time).toBe(timesTs[UP_TREND.length + 23]);
+  });
+
+  it('detects a confirmed L2 in a downtrend', () => {
+    const closes = [...DOWN_TREND, ...DOWN_L2_STRUCTURE];
+    const { highs, lows, closes: c, timesTs } = bars(closes);
+    const found = detectSecondBreakouts(highs, lows, c, timesTs);
+    expect(found).toHaveLength(1);
+    const sb = found[0];
+    expect(sb.kind).toBe('L2');
+    expect(sb.status).toBe('confirmed');
+    expect(sb.first.price).toBe(101.5);
+    expect(sb.signal.price).toBe(102.5);
+    expect(sb.trigger).not.toBeNull();
+    expect(sb.trigger?.price).toBe(101.5);
+    expect(sb.trigger?.time).toBe(timesTs[DOWN_TREND.length + 23]);
+  });
+
+  it('stays quiet in a range crossing EMA20 repeatedly', () => {
+    const closes = Array.from({ length: 80 }, (_, i) => 100 + (i % 4 < 2 ? 1 : -1));
+    const { highs, lows, closes: c, timesTs } = bars(closes);
+    expect(detectSecondBreakouts(highs, lows, c, timesTs)).toHaveLength(0);
+  });
+
+  it('drops the structure when the two attempts are too far apart', () => {
+    const gapFiller = Array.from({ length: 60 }, (_, i) => 128 + ((i % 6) - 3) * 0.2);
+    const closes = [
+      ...UP_TREND,
+      129, 128, 127, 126, 125,
+      126, 127, 128,
+      ...gapFiller,
+      127, 126, 125, 124, 123,
+      124, 125, 126, 127, 126, 125, 124,
+      125, 126, 127, 128,
+    ];
+    const { highs, lows, closes: c, timesTs } = bars(closes);
+    expect(detectSecondBreakouts(highs, lows, c, timesTs)).toHaveLength(0);
+  });
+});

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -545,7 +545,6 @@ export interface IntradaySidebar {
   entryPlan: IntradayEntryPlan | null;
   position: PositionView | null;
   technicals: Record<TimeframeKey, IntradayTfSummary>;
-  technicalsNotes: string[];
   dayContext?: IntradayDayContext | null;
   optionsLevels?: IntradayOptionsLevels | null;
   eventRisk?: IntradayEventRisk | null;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -222,6 +222,7 @@ export interface IntradayTfData {
   autoDivergence: DivergencePair[];
   autoBeichi: DivergencePair[];
   pattern123?: Pattern123[];
+  secondBreakouts?: SecondBreakout[];
   offSession?: OffSessionSegment[];
   fvgZones?: IntradayFvgZone[];
 }
@@ -359,6 +360,7 @@ export interface IntradayTfSummary {
   zero_tangle?: boolean;
   candle_patterns?: CandlePattern[];
   pattern_123?: Pattern123[];
+  second_breakouts?: SecondBreakout[];
 }
 
 export interface IntradayEntryPlan {
@@ -543,6 +545,7 @@ export interface IntradaySidebar {
   entryPlan: IntradayEntryPlan | null;
   position: PositionView | null;
   technicals: Record<TimeframeKey, IntradayTfSummary>;
+  technicalsNotes: string[];
   dayContext?: IntradayDayContext | null;
   optionsLevels?: IntradayOptionsLevels | null;
   eventRisk?: IntradayEventRisk | null;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -336,6 +336,14 @@ export interface Pattern123 {
   implication: string;
 }
 
+export interface SecondBreakout {
+  kind: 'H2' | 'L2';
+  status: 'forming' | 'confirmed';
+  first: SwingPoint;
+  signal: SwingPoint;
+  trigger: SwingPoint | null;
+}
+
 export interface IntradayTfSummary {
   last_dif: number | null;
   last_dea: number | null;


### PR DESCRIPTION
## Summary

Auto-detects and annotates SB (Second Breakout, Al Brooks High 2 / Low 2) structures on the intraday multi-timeframe dashboard (5m / 15m / 1h), alongside the existing 123-structure, divergence, and candle-pattern detectors.

- New detector `packages/core/src/services/secondBreakout.ts`: swing-pivot based H1/H2 (L1/L2) counting with an EMA20 trend filter (uptrend → H2 only, downtrend → L2 only, range → nothing) and a same-pullback bar-distance cap (`MAX_ATTEMPT_GAP`).
- `SecondBreakout` shared type; orchestrator wiring emits `secondBreakouts` per timeframe into the chart document and `second_breakouts` into each timeframe's technicals summary, which rides the ReassessPack JSON that AI consumers already receive.
- Web rendering: confirmed H2 amber arrow-up below the trigger bar / L2 arrow-down above, grey H1/L1 context markers, forming structures in grey without a trigger marker; hover tooltips with price details; new `sb` indicator toggle ("SB 结构", default on, persisted).
- Chart skill doc updated with the new overlay.

Design spec: `docs/superpowers/specs/2026-07-20-sb-second-breakout-annotation-design.md`

## Testing

- 6 detector/orchestrator fixtures incl. a paired positive/negative control proving the gap cap is the operative rejection
- Full `@kansoku/core` suite: 899 passed / 3 skipped; `tsc --noEmit` clean for core + web