### PR TITLE
ci: project pro overlays before building

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -130,6 +130,17 @@ jobs:
       - name: install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The pro overlay projections are gitignored symlinks created from
+      # apps/pro/overlays, so a fresh checkout has none of them. Without this
+      # the vite resolver never sees a .pro override, the build emits a purely
+      # free module graph, and stagePro fails on the missing __pro__ chunks —
+      # or worse, a free artifact ships looking like a pro one.
+      - name: project pro overlays into the public tree
+        if: steps.pro.outputs.present == 'true'
+        run: |
+          pnpm overlay:sync
+          pnpm overlay:check
+
       - name: link first-party skills into .agents
         run: python3 scripts/sync-agents-skills.py
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -148,6 +148,16 @@ jobs:
       # the prepare script above creates .agents/skills (third-party copies only),
       # which un-skips agentsSkillsParity.test.ts — link the first-party skills in
       # so the guard sees the same layout it enforces locally.
+      # The pro overlay projections are gitignored symlinks created from
+      # apps/pro/overlays, so a fresh checkout has none of them. Without this
+      # the vite resolver never sees a .pro override, the build emits a purely
+      # free module graph, and stagePro fails on the missing __pro__ chunks —
+      # or worse, a free artifact ships looking like a pro one.
+      - name: project pro overlays into the public tree
+        run: |
+          pnpm overlay:sync
+          pnpm overlay:check
+
       - name: link first-party skills into .agents
         run: python3 scripts/sync-agents-skills.py
 


### PR DESCRIPTION
The first nightly run failed at packaging:

```
stagePro: apps/pro present but dist-main __pro__ missing — run pnpm build first
```

## Root cause

Under the build-time composition architecture, pro code enters the module graph
through gitignored symlinks projected from `apps/pro/overlays` into the public tree.
A fresh CI checkout has none of them, so the vite resolver never sees a `.pro`
override, `pnpm build` emits a purely free module graph, and `stagePro` correctly
refuses to continue.

It never showed up locally because a development tree always has the projections
already synced.

## Scope — this was not only a nightly problem

`desktop-release.yml` had the identical gap. A real pro release would have failed
the same way; and had `stagePro` been laxer about a missing `__pro__`, it would have
published a free artifact indistinguishable from a pro one. Both workflows are fixed
here.

## The fix

Run `pnpm overlay:sync` followed by `pnpm overlay:check` after `pnpm install` and
before any build step. The `check` is not redundant — `sync` creates the projections
and `check` asserts they match the overlay tree, so a stale or partial projection
fails the build instead of silently producing a wrong artifact.

On the nightly the step is gated on the pro slot actually having been fetched. The
release workflow has no such output, so it runs unconditionally there; that is safe
because `overlaySync` returns an empty projection set when `apps/pro/overlays` is
absent, making it a no-op on a free build.

## Verification

`pnpm overlay:sync` and `pnpm overlay:check` both run clean locally and report the
same 4 projections. The real test is the next nightly dispatch, which is the point
of having built one.