### PR TITLE
fix(desktop): pass packEnc the web dist root, not just the __pro__ dir

### DIFF
--- a/apps/desktop/scripts/stagePro.mjs
+++ b/apps/desktop/scripts/stagePro.mjs
@@ -11,7 +11,8 @@ const destFile = join(destDir, 'pro.enc');
 rmSync(destDir, { recursive: true, force: true });
 
 const nodeStage = join(desktopDir, 'dist-main', '__pro__');
-const webStage = join(desktopDir, '..', 'web', 'dist', 'assets', '__pro__');
+const webDistRoot = join(desktopDir, '..', 'web', 'dist');
+const webStage = join(webDistRoot, 'assets', '__pro__');
 
 if (process.env.KANSOKU_FORCE_FREE === '1' || !existsSync(join(proDir, 'package.json'))) {
   if (existsSync(nodeStage) || existsSync(webStage)) {
@@ -42,6 +43,8 @@ const args = [
   nodeStage,
   '--web',
   webStage,
+  '--web-root',
+  webDistRoot,
   '--out',
   destFile,
 ];


### PR DESCRIPTION
## Summary

Companion to kansoku-trade/kansoku-pro#15. The packaged app's Settings page crashed because the web pro chunk (`assets/__pro__/pro.pro-*.js`) 404'd from the `app://` protocol handler — the encrypted manifest's keys didn't match the request path the renderer used.

`stagePro.mjs` now passes `packEnc.mjs` a new `--web-root` argument (the web dist root, `apps/web/dist`) alongside the existing `--web` argument (the `__pro__` subdirectory being staged), so the manifest keys packEnc produces are relative to the dist root the protocol handler actually resolves requests against. See the linked pro-repo PR for the full root-cause writeup and the round-trip test that exercises this end to end.

## Test plan
- [x] `pnpm --filter @kansoku/core test` — 902/905 passing (3 pre-existing skips), no core changes here but ran to confirm no regression
- [x] `cd apps/desktop && pnpm test` — 308/308 passing
- [x] `pnpm typecheck` — clean across the workspace
- [x] Packaged a real build (`KANSOKU_BUNDLE_KEY=<random> KANSOKU_BUNDLE_KEY_ID=smoke pnpm overlay:sync && cd apps/desktop && pnpm package`) with the paired pro-repo fix checked out, then decrypted the produced `pro.enc` and confirmed its manifest key is `web/assets/__pro__/pro.pro-*.js` — matching the real `assets/__pro__/...` request path exactly
- [x] `node scripts/verifyFourStates.mjs` — all four states pass (active w/ correct key, free w/ no key, free w/ wrong key, free community build)