### PR TITLE
fix(settings): stale persisted role cache crashes the Settings page

### DIFF
--- a/apps/desktop/scripts/stagePro.mjs
+++ b/apps/desktop/scripts/stagePro.mjs
@@ -11,7 +11,8 @@ const destFile = join(destDir, 'pro.enc');
 rmSync(destDir, { recursive: true, force: true });
 
 const nodeStage = join(desktopDir, 'dist-main', '__pro__');
-const webStage = join(desktopDir, '..', 'web', 'dist', 'assets', '__pro__');
+const webDistRoot = join(desktopDir, '..', 'web', 'dist');
+const webStage = join(webDistRoot, 'assets', '__pro__');
 
 if (process.env.KANSOKU_FORCE_FREE === '1' || !existsSync(join(proDir, 'package.json'))) {
   if (existsSync(nodeStage) || existsSync(webStage)) {
@@ -42,6 +43,8 @@ const args = [
   nodeStage,
   '--web',
   webStage,
+  '--web-root',
+  webDistRoot,
   '--out',
   destFile,
 ];

--- a/apps/web/src/pages/settings/SettingsPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetCapabilitiesStoreForTests } from '@web/capabilitiesStore';
+import { resetLicenseModalStoreForTests } from '@web/licenseModalStore';
+import type { AiSettings, Catalog, RoleSetting } from './types';
+
+const getAi = vi.fn();
+const getCatalog = vi.fn();
+const getUsageToday = vi.fn();
+const getWatchedMarkets = vi.fn();
+const getSubscribeUrl = vi.fn();
+const credentialsStatus = vi.fn();
+const capabilitiesGet = vi.fn();
+const lobehubGetAccount = vi.fn();
+const lobehubGetCredits = vi.fn();
+
+vi.mock('@web/client', () => ({
+  client: {
+    settings: {
+      getAi: (...args: unknown[]) => getAi(...args),
+      getCatalog: (...args: unknown[]) => getCatalog(...args),
+      getUsageToday: (...args: unknown[]) => getUsageToday(...args),
+      getWatchedMarkets: (...args: unknown[]) => getWatchedMarkets(...args),
+      getSubscribeUrl: (...args: unknown[]) => getSubscribeUrl(...args),
+    },
+    credentials: {
+      status: (...args: unknown[]) => credentialsStatus(...args),
+    },
+    capabilities: {
+      get: (...args: unknown[]) => capabilitiesGet(...args),
+    },
+    lobehub: {
+      getAccount: (...args: unknown[]) => lobehubGetAccount(...args),
+      getCredits: (...args: unknown[]) => lobehubGetCredits(...args),
+    },
+  },
+}));
+
+const { SettingsPage } = await import('./SettingsPage');
+
+const disabled: RoleSetting = { mode: 'disabled', provider: null, modelId: null, thinkingLevel: null, stale: false };
+
+// The 'memory' role shipped 2026-07-20 (aa9bb43). A settings.getAi response
+// restored from react-query's localStorage persistence (queryClient.ts) can
+// still carry a pre-'memory' role set from before that release.
+const preMemoryRoleSettings: AiSettings = {
+  roles: {
+    primary: disabled,
+    comment: disabled,
+    analyst: disabled,
+    deepDive: disabled,
+    chat: disabled,
+  } as AiSettings['roles'],
+  credentials: [],
+  masterKey: 'missing',
+};
+
+const catalog: Catalog = { providers: [] };
+
+function renderWithClient(children: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+}
+
+describe('SettingsPage', () => {
+  afterEach(() => {
+    cleanup();
+    resetCapabilitiesStoreForTests();
+    resetLicenseModalStoreForTests();
+    for (const mock of [
+      getAi,
+      getCatalog,
+      getUsageToday,
+      getWatchedMarkets,
+      getSubscribeUrl,
+      credentialsStatus,
+      capabilitiesGet,
+      lobehubGetAccount,
+      lobehubGetCredits,
+    ]) {
+      mock.mockReset();
+    }
+  });
+
+  it('renders without crashing when the settings.getAi response is missing a role added after the client last cached it', async () => {
+    getAi.mockResolvedValue(preMemoryRoleSettings);
+    getCatalog.mockResolvedValue(catalog);
+    getUsageToday.mockResolvedValue({
+      roles: {
+        comment: { calls: 0, cost: 0 },
+        analyst: { calls: 0, cost: 0 },
+        deepDive: { calls: 0, cost: 0 },
+        chat: { calls: 0, cost: 0 },
+        memory: { calls: 0, cost: 0 },
+      },
+      total: { calls: 0, cost: 0 },
+    });
+    getWatchedMarkets.mockResolvedValue({ markets: ['US'] });
+    getSubscribeUrl.mockResolvedValue({ subscribeUrl: null });
+    credentialsStatus.mockResolvedValue({ configured: false, path: null });
+    capabilitiesGet.mockResolvedValue({ pro: false, licensed: false, license: { state: 'unlicensed' } });
+    lobehubGetAccount.mockResolvedValue({
+      status: 'disconnected',
+      email: null,
+      name: null,
+      userId: null,
+      updatedAt: null,
+      baseUrl: '',
+    });
+    lobehubGetCredits.mockResolvedValue(null);
+
+    renderWithClient(<SettingsPage />);
+
+    expect(await screen.findByText('记忆整理')).toBeTruthy();
+  });
+});

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { SettingsStatusStrip } from './SettingsStatusStrip';
 import { TimeDisplaySettingsCard } from './TimeDisplaySettingsCard';
 import { WatchedMarketsCard } from './WatchedMarketsCard';
 import { deriveSettingsViewModel } from './settingsViewModel';
+import { normalizeAiRoles } from './types';
 import type {
   AiRoles,
   AiSettings,
@@ -195,13 +196,15 @@ export function SettingsPage() {
     );
   }
 
+  const normalizedSettings: AiSettings = { ...settings, roles: normalizeAiRoles(settings.roles) };
+
   return (
     <div className="page settings-page">
       <SettingsBackLink />
       <h1>设置</h1>
       <div className="settings-page-subtitle">显示、AI 模型、Provider 与用量</div>
       <SettingsWorkspace
-        settings={settings}
+        settings={normalizedSettings}
         catalog={catalog}
         usage={usage}
         usageError={usageError}

--- a/apps/web/src/pages/settings/types.test.ts
+++ b/apps/web/src/pages/settings/types.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAiRoles, ROLES, type AiRoles, type RoleSetting } from './types';
+
+const configured: RoleSetting = {
+  mode: 'custom',
+  provider: 'anthropic',
+  modelId: 'claude-opus',
+  thinkingLevel: 'off',
+  stale: false,
+};
+
+describe('normalizeAiRoles', () => {
+  it('passes a complete AiRoles object through unchanged', () => {
+    const roles: AiRoles = {
+      primary: configured,
+      comment: configured,
+      analyst: configured,
+      deepDive: configured,
+      chat: configured,
+      memory: configured,
+    };
+
+    expect(normalizeAiRoles(roles)).toEqual(roles);
+  });
+
+  it('fills in a role missing from a stale persisted-cache snapshot with its default setting', () => {
+    const staleRoles = {
+      primary: configured,
+      comment: configured,
+      analyst: configured,
+      deepDive: configured,
+      chat: configured,
+      // 'memory' absent, as in a react-query localStorage cache persisted
+      // before the 2026-07-20 role addition (aa9bb43).
+    } as Partial<AiRoles>;
+
+    const normalized = normalizeAiRoles(staleRoles);
+
+    expect(normalized.memory).toEqual({
+      mode: 'inherit',
+      provider: null,
+      modelId: null,
+      thinkingLevel: null,
+      stale: false,
+    });
+    for (const role of ROLES) {
+      expect(normalized[role]).toBeDefined();
+    }
+  });
+
+  it('falls back to a fully-default AiRoles object when given null or undefined', () => {
+    for (const input of [null, undefined] as const) {
+      const normalized = normalizeAiRoles(input);
+      expect(normalized.primary).toEqual({
+        mode: 'disabled',
+        provider: null,
+        modelId: null,
+        thinkingLevel: null,
+        stale: false,
+      });
+      for (const role of ROLES) {
+        expect(normalized[role]).toEqual({
+          mode: 'inherit',
+          provider: null,
+          modelId: null,
+          thinkingLevel: null,
+          stale: false,
+        });
+      }
+    }
+  });
+});

--- a/apps/web/src/pages/settings/types.ts
+++ b/apps/web/src/pages/settings/types.ts
@@ -63,6 +63,29 @@ export interface Catalog {
 
 export const ROLES: Role[] = ['comment', 'analyst', 'deepDive', 'chat', 'memory'];
 
+function defaultRoleSetting(role: Role | 'primary'): RoleSetting {
+  return {
+    mode: role === 'primary' ? 'disabled' : 'inherit',
+    provider: null,
+    modelId: null,
+    thinkingLevel: null,
+    stale: false,
+  };
+}
+
+// react-query persists settings.getAi responses to localStorage
+// (queryClient.ts) and restores them before the live refetch lands, so a
+// role added after a user's last persisted snapshot (e.g. 'memory' on
+// 2026-07-20) is briefly missing from `roles` on app launch — normalize so
+// every ROLES consumer can always index it.
+export function normalizeAiRoles(roles: Partial<AiRoles> | null | undefined): AiRoles {
+  const normalized = {} as AiRoles;
+  for (const role of ['primary', ...ROLES] as const) {
+    normalized[role] = roles?.[role] ?? defaultRoleSetting(role);
+  }
+  return normalized;
+}
+
 export const ROLE_LABEL: Record<Role, string> = {
   comment: '盘中快评',
   analyst: '升级分析',


### PR DESCRIPTION
## Summary

- The Settings page can crash with `Cannot read properties of undefined (reading 'mode')` on
  first paint after upgrading across the `aa9bb43` "add dedicated memory model role" commit. Root
  cause: `settings.getAi()` always returns a complete `AiRoles` object, but successful queries are
  persisted to `localStorage` (`queryClient.ts`, react-query persist client) and restored
  synchronously on boot before the live refetch lands. A snapshot cached before that commit no
  longer matches the current `Role`/`ROLES` shape, and `PERSIST_BUSTER` was never bumped, so
  `deriveSettingsViewModel`'s `for (const role of ROLES)` loop indexes a role (`memory`) the stale
  cached object never had.
- Not pro-specific — `AiRoles`/`deriveSettingsViewModel` are open-core; confirmed the same
  condition reproduces under `KANSOKU_FORCE_FREE=1` by inspection (nothing pro-side touches this
  code path).
- Fix: add `normalizeAiRoles()` and apply it once, where `settings` enters the render tree
  (`SettingsPage.tsx`, right after the loading gate), filling any role missing from a
  fetched/cached `AiRoles` value with the server's own default-for-an-unseen-role semantics
  (`mode: 'disabled'` for primary, `'inherit'` for task roles). This fixes `roleDrafts` seeding,
  `RoleModelsCard`'s `initialRoles` prop, and `deriveSettingsViewModel`'s `roles` input from one
  choke point. Deliberately did not bump `PERSIST_BUSTER` — that would only paper over this one
  incident (and discard every other cached query for every user) rather than fix the underlying
  contract violation for the next role addition.

Full writeup with the real reproduction stack (via `pnpm dev:desktop` over CDP) and packaged-build
verification (seeded a synthetic stale `REACT_QUERY_OFFLINE_CACHE` entry against the actual
packaged `.app`): `.superpowers/sdd/settings-crash-fix-report.md`.

## Test plan

- [x] New test (`SettingsPage.test.tsx`) constructs the exact stale shape (roles missing
      `'memory'`) and asserts the page renders through to the memory role row; fails on pre-fix
      code, passes after (verified via `git stash`).
- [x] New unit tests for `normalizeAiRoles` (`types.test.ts`).
- [x] `pnpm --filter @kansoku/web test` — 84 files / 526 tests green.
- [x] `pnpm --filter @kansoku/core test` — 108 files / 902 passed, 3 skipped, green.
- [x] `cd apps/desktop && pnpm test` — 45 files / 308 tests green.
- [x] `pnpm typecheck` — all 10 workspace projects clean.
- [x] Packaged `.app` build, isolated `--user-data-dir`, seeded stale persisted cache: Settings
      opens cleanly with all five role rows including 记忆整理 (memory), no exception.