### PR TITLE
fix(build-overlay): keep dev URL requests on the overlay projection path

### DIFF
--- a/packages/build-overlay/src/index.ts
+++ b/packages/build-overlay/src/index.ts
@@ -1,7 +1,9 @@
 import { existsSync, lstatSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 
-const { dirname, extname, isAbsolute, relative, resolve, sep } = path;
+const { dirname, extname, isAbsolute, join, relative, resolve, sep } = path;
+
+const FS_URL_PREFIX = '/@fs';
 
 export interface ProOverlayOptions {
   enabled?: boolean;
@@ -25,6 +27,7 @@ interface OverlayResolveContext {
 export interface ProOverlayPlugin {
   name: string;
   enforce: 'pre';
+  configResolved(config: { root: string }): void;
   resolveId(
     this: OverlayResolveContext,
     source: string,
@@ -153,11 +156,45 @@ function watchOverlayTarget(context: OverlayResolveContext, candidate: string): 
   context.addWatchFile(realpathSync(candidate));
 }
 
+// A dynamic import is re-fetched by the browser as a standalone URL request,
+// so it reaches resolveId with no importer. Left to vite that request goes to
+// the default resolver, which follows the projection symlink to its real path
+// under the overlay root — and every relative import in the module then
+// resolves against the private tree instead of the public one. Returning the
+// symlink path verbatim keeps the module's identity in the public tree, which
+// is what its relative imports are written against.
+function projectionForRootUrl(
+  source: string,
+  root: string,
+  overlayRoot: string | undefined,
+): string | null {
+  if (!overlayRoot || !source.startsWith('/')) return null;
+  const { path: urlPath, query } = splitQuery(source);
+  const candidate = urlPath.startsWith(`${FS_URL_PREFIX}/`)
+    ? urlPath.slice(FS_URL_PREFIX.length)
+    : join(root, urlPath);
+  if (!existsSync(candidate) || !lstatSync(candidate).isSymbolicLink()) return null;
+  const rel = relative(realpathSync(overlayRoot), realpathSync(candidate));
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+  return `${candidate}${query}`;
+}
+
 export function proOverlayPlugin(options: ProOverlayOptions = {}): ProOverlayPlugin {
+  let root = process.cwd();
   return {
     name: 'kansoku-pro-overlay',
     enforce: 'pre',
+    configResolved(config) {
+      root = config.root;
+    },
     async resolveId(source, importer) {
+      if (source.startsWith('/') && options.enabled !== false) {
+        const projected = projectionForRootUrl(source, root, options.overlayRoot);
+        if (projected) {
+          watchOverlayTarget(this, splitQuery(projected).path);
+          return projected;
+        }
+      }
       if (source.startsWith('.')) {
         const resolved = resolveProOverlayId(source, importer, options);
         if (resolved) watchOverlayTarget(this, splitQuery(resolved).path);

--- a/packages/build-overlay/test/resolve.test.ts
+++ b/packages/build-overlay/test/resolve.test.ts
@@ -357,3 +357,80 @@ describe('proOverlayPlugin host-first resolution', () => {
     );
   });
 });
+
+describe('proOverlayPlugin dev URL requests', () => {
+  function devFixture() {
+    const root = makeRoot('kansoku-overlay-dev-');
+    const viteRoot = join(root, 'apps', 'web');
+    const overlayRoot = join(root, 'apps', 'pro', 'overlays');
+    const target = join(overlayRoot, 'apps', 'web', 'src', 'edition', 'pro.pro.ts');
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, '');
+    const projection = join(viteRoot, 'src', 'edition', 'pro.pro.ts');
+    mkdirSync(path.dirname(projection), { recursive: true });
+    symlinkSync(target, projection);
+    return { overlayRoot, projection, viteRoot };
+  }
+
+  function pluginFor(fixture: ReturnType<typeof devFixture>) {
+    const plugin = proOverlayPlugin({ overlayRoot: fixture.overlayRoot });
+    plugin.configResolved({ root: fixture.viteRoot });
+    return plugin;
+  }
+
+  it('keeps a root-relative URL on its projection path instead of the overlay target', async () => {
+    const fixture = devFixture();
+    const result = await pluginFor(fixture).resolveId.call(
+      {},
+      '/src/edition/pro.pro.ts',
+      join(fixture.viteRoot, 'index.html'),
+    );
+    expect(result).toBe(fixture.projection);
+  });
+
+  it('keeps an /@fs URL on its projection path', async () => {
+    const fixture = devFixture();
+    const result = await pluginFor(fixture).resolveId.call(
+      {},
+      `/@fs${fixture.projection}`,
+      join(fixture.viteRoot, 'index.html'),
+    );
+    expect(result).toBe(fixture.projection);
+  });
+
+  it('preserves a query on a root-relative URL', async () => {
+    const fixture = devFixture();
+    const result = await pluginFor(fixture).resolveId.call(
+      {},
+      '/src/edition/pro.pro.ts?t=1',
+      join(fixture.viteRoot, 'index.html'),
+    );
+    expect(result).toBe(`${fixture.projection}?t=1`);
+  });
+
+  it('ignores a root-relative URL that is not an overlay projection', async () => {
+    const fixture = devFixture();
+    const plain = join(fixture.viteRoot, 'src', 'main.ts');
+    writeFileSync(plain, '');
+    const result = await pluginFor(fixture).resolveId.call(
+      { resolve: async () => null },
+      '/src/main.ts',
+      join(fixture.viteRoot, 'index.html'),
+    );
+    expect(result).toBeNull();
+  });
+
+  it('ignores a symlink whose target lives outside the overlay root', async () => {
+    const fixture = devFixture();
+    const outside = join(fixture.viteRoot, 'outside.ts');
+    writeFileSync(outside, '');
+    const projection = join(fixture.viteRoot, 'src', 'linked.ts');
+    symlinkSync(outside, projection);
+    const result = await pluginFor(fixture).resolveId.call(
+      { resolve: async () => null },
+      '/src/linked.ts',
+      join(fixture.viteRoot, 'index.html'),
+    );
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## What broke

`pnpm dev` died the moment the pro overlay loaded:

```
[plugin:vite:import-analysis] Failed to resolve import "../cockpit/chat/ChatComposer"
from "../pro/overlays/apps/web/src/pages/research/ResearchAssistantPage.pro.tsx"
```

Note the path in that message — `apps/pro/overlays/...`, the private realpath, not the public projection.

## Root cause

A dynamic `import()` is re-fetched by the browser as a **standalone URL request**. That request reaches `resolveId` as a root-relative source (`/src/edition/pro.pro.ts`) with `index.html` as the importer — not the importing module. The plugin passed it through, so vite's own resolver handled it and followed the projection symlink to its realpath under `apps/pro/overlays`.

From there the module's identity is in the private tree, so every relative import in it resolved against `apps/pro/overlays/apps/web/...` — where none of them exist.

Builds were never affected: rollup keeps the id `resolveId` returned and never re-fetches a module by URL. This only ever broke dev, which is why the nightly packaged builds were fine.

## Fix

Resolve a root-relative or `/@fs` URL that lands on an overlay projection symlink to that symlink path verbatim. The module keeps its public-tree identity, which is what its relative imports are written against.

`preserveSymlinks` is deliberately not used — it breaks pnpm's `node_modules` resolution (existing comment in the file).

## Verification

- Reproduced against a live dev server before the fix, confirming the resolved id was the private realpath; after the fix `ResearchAssistantPage` resolves to `/src/pages/research/ResearchAssistantPage.pro.tsx` and every import inside it lands in the public tree.
- 5 new tests covering the root-relative URL, the `/@fs` form, query preservation, a non-overlay path, and a symlink pointing outside the overlay root.
- Non-vacuous: with the fix disabled the 3 positive assertions fail; the 2 negative ones pass either way, as intended.
- `pnpm --filter @kansoku/build-overlay test` — 103 passed. Typecheck clean.
- Rebuilt web with overlays present: `assets/__pro__/pro.pro-*.js` still isolated, leak guard still enforcing.

Independent of #62 (Settings stale-cache crash); the two touch no common files.