### PR TITLE
fix: chart poller setup race + exact symbol match in analysis lookups

### DIFF
--- a/packages/core/src/charts/store.ts
+++ b/packages/core/src/charts/store.ts
@@ -104,6 +104,11 @@ export interface ListFilter {
   limit?: number;
 }
 
+function canonicalSymbol(raw: string): string {
+  const sym = raw.trim().toUpperCase();
+  return sym.includes('.') ? sym : `${sym}.US`;
+}
+
 export async function listCharts(filter: ListFilter = {}, db: Db = getDb()): Promise<ChartMeta[]> {
   await ensureIndex(db);
   const rows = await db.select().from(chartMeta).orderBy(desc(chartMeta.createdAt));
@@ -113,8 +118,8 @@ export async function listCharts(filter: ListFilter = {}, db: Db = getDb()): Pro
     metas = metas.filter((m) => types.includes(m.type));
   }
   if (filter.symbol) {
-    const s = filter.symbol.toUpperCase();
-    metas = metas.filter((m) => (m.symbol ?? '').toUpperCase().includes(s));
+    const want = canonicalSymbol(filter.symbol);
+    metas = metas.filter((m) => m.symbol != null && canonicalSymbol(m.symbol) === want);
   }
   if (filter.limit && filter.limit > 0) metas = metas.slice(0, filter.limit);
   return metas;

--- a/packages/core/src/realtime/charts.ts
+++ b/packages/core/src/realtime/charts.ts
@@ -48,6 +48,31 @@ function chartIntervalMs(key?: string): number {
 }
 
 const chartPollers = new Map<string, PollerHandle>();
+const chartPollerSetups = new Map<string, Promise<PollerHandle>>();
+
+// Concurrent first subscribers for one key must share a single setup: without this
+// both see no poller, both build one, and the loser's onStop later tears down the
+// shared candle state under the winner. The in-flight entry is cleared on both
+// success and failure so a failed setup can be retried by a later subscriber.
+async function getOrCreatePoller(
+  key: string,
+  setup: () => Promise<PollerHandle>,
+): Promise<PollerHandle> {
+  const existing = chartPollers.get(key);
+  if (existing) return existing;
+  const inflight = chartPollerSetups.get(key);
+  if (inflight) return inflight;
+  const promise = setup()
+    .then((handle) => {
+      chartPollers.set(key, handle);
+      return handle;
+    })
+    .finally(() => {
+      chartPollerSetups.delete(key);
+    });
+  chartPollerSetups.set(key, promise);
+  return promise;
+}
 
 function predictionFields(doc: ChartDoc) {
   return {
@@ -273,11 +298,10 @@ export async function subscribeChart(
     return () => {};
 
   const key = viewCount === undefined ? id : `${id}#${viewCount}`;
-  let handle = chartPollers.get(key);
-  if (!handle) {
+  const handle = await getOrCreatePoller(key, async () => {
     chartMarkets.set(key, market);
     if (doc.type === 'intraday') setupCandleState(key, id, viewCount, doc);
-    handle = createPoller({
+    return createPoller({
       intervalMs: () => chartIntervalMs(key),
       task: async () => {
         const latest = await loadChart(id);
@@ -322,8 +346,7 @@ export async function subscribeChart(
         teardownCandleState(key);
       },
     });
-    chartPollers.set(key, handle);
-  }
+  });
   return handle.subscribe(push);
 }
 
@@ -336,8 +359,7 @@ export async function subscribePreview(
   const normalized = normalizeSymbol(symbol);
   const key = `preview:${normalized}`;
 
-  let handle = chartPollers.get(key);
-  if (!handle) {
+  const handle = await getOrCreatePoller(key, async () => {
     const result = await buildChart({ type: 'intraday', symbol: normalized, session: 'intraday' });
     chartMarkets.set(key, marketOf(normalized));
     setupPreviewCandleState(key, normalized, result.input, result.title);
@@ -348,7 +370,7 @@ export async function subscribePreview(
         ? await buildFromState(initialState, initialLatest)
         : { built: result.built };
     previewInitialBuilt.set(key, initialData);
-    handle = createPoller({
+    return createPoller({
       intervalMs: () => chartIntervalMs(key),
       task: async () => {
         const state = candleStates.get(key);
@@ -379,8 +401,7 @@ export async function subscribePreview(
         previewInitialBuilt.delete(key);
       },
     });
-    chartPollers.set(key, handle);
-  }
+  });
 
   const initial = previewInitialBuilt.get(key);
   if (initial !== undefined && !handle.hasData())

--- a/packages/core/test/chartStoreSymbolFilter.test.ts
+++ b/packages/core/test/chartStoreSymbolFilter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createDb, type Db } from '../src/db/index.js';
+import { chartMeta } from '../src/db/schema.js';
+import { listCharts } from '../src/charts/store.js';
+
+function seedMeta(db: Db, id: string, symbol: string, createdAt: string) {
+  return db.insert(chartMeta).values({
+    id,
+    schemaVersion: 1,
+    type: 'intraday',
+    title: id,
+    symbol,
+    createdAt,
+    updatedAt: createdAt,
+    predictionUpdatedAt: null,
+  });
+}
+
+describe('listCharts symbol filter', () => {
+  async function seededDb(): Promise<Db> {
+    const db = createDb(':memory:');
+    await seedMeta(db, '2026-07-20-mu-intraday', 'MU.US', '2026-07-20T14:00:00.000Z');
+    await seedMeta(db, '2026-07-21-smu-intraday', 'SMU.US', '2026-07-21T14:00:00.000Z');
+    return db;
+  }
+
+  it('does not match a substring symbol (MU.US must not return newer SMU.US)', async () => {
+    const db = await seededDb();
+    const latest = await listCharts({ symbol: 'MU.US', type: 'intraday', limit: 1 }, db);
+    expect(latest).toHaveLength(1);
+    expect(latest[0].symbol).toBe('MU.US');
+    expect(latest[0].id).toBe('2026-07-20-mu-intraday');
+  });
+
+  it('lists only exact-symbol docs for the analyses path', async () => {
+    const db = await seededDb();
+    const analyses = await listCharts({ symbol: 'MU.US', type: 'intraday' }, db);
+    expect(analyses.map((m) => m.symbol)).toEqual(['MU.US']);
+  });
+
+  it('normalizes a bare ticker to its .US form when matching', async () => {
+    const db = await seededDb();
+    const metas = await listCharts({ symbol: 'MU', type: 'intraday' }, db);
+    expect(metas.map((m) => m.id)).toEqual(['2026-07-20-mu-intraday']);
+  });
+});

--- a/packages/core/test/realtimeCharts.test.ts
+++ b/packages/core/test/realtimeCharts.test.ts
@@ -607,6 +607,50 @@ describe('subscribePreview', () => {
     unsub2();
   });
 
+  it('dedupes two concurrent first subscribers into one poller and one candle state, and survives the first leaving', async () => {
+    const events1: string[] = [];
+    const events2: string[] = [];
+    const [unsub1, unsub2] = await Promise.all([
+      subscribePreview('PQQ7.US', (e) => events1.push(e)),
+      subscribePreview('PQQ7.US', (e) => events2.push(e)),
+    ]);
+
+    expect(build.buildChart).toHaveBeenCalledTimes(1);
+    expect(longbridgeStream.subscribeCandlesticks).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(events1[0]).data.built.kind).toBe('intraday');
+    expect(JSON.parse(events2[0]).data.built.kind).toBe('intraday');
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    unsub1();
+
+    for (const period of ['5m', '15m', '60m']) {
+      expect(unsubSpies.get(period)).not.toHaveBeenCalled();
+    }
+
+    events2.length = 0;
+    build.rebuild.mockClear();
+    const m5cb = callbacksByPeriod.get('5m')!;
+    m5cb({
+      symbol: 'PQQ7.US',
+      period: '5m',
+      ts: 2_000,
+      open: 2,
+      high: 2,
+      low: 2,
+      close: 2,
+      volume: 5,
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(build.rebuild).toHaveBeenCalledTimes(1);
+    expect(events2.map((e) => JSON.parse(e)).some((e) => e.type === 'data' && e.data.built.pushed)).toBe(
+      true,
+    );
+    unsub2();
+  });
+
   it('tears down state once both subscribers leave and rebuilds from scratch on a fresh subscribe', async () => {
     const unsub1 = await subscribePreview('PQQ4.US', () => {});
     const unsub2 = await subscribePreview('PQQ4.US', () => {});


### PR DESCRIPTION
## Summary

Two pre-existing defects surfaced by the live-default-view review (PR #65):

- **Poller setup race** (`packages/core/src/realtime/charts.ts`): `subscribeChart` / `subscribePreview` had an async gap between checking and registering the shared per-key poller — two concurrent first subscribers each built one, the second registration orphaned the first, and the orphan's teardown destroyed the shared candle state under surviving viewers. Now a shared `getOrCreatePoller` memoizes in-flight setup per key: concurrent first subscribers await one setup, failures clear the entry for retry, and orphans are impossible by construction.
- **Substring symbol match** (`packages/core/src/charts/store.ts`): symbol filtering used `.includes`, so `MU.US` matched `SMU.US` docs — `latestIntradayDoc` could return (and since #65, overlay) the wrong symbol's analysis. Now normalized exact equality, applied symmetrically to query and stored symbol; caller survey confirmed no consumer relied on substring semantics, and HK-style symbols (`700.HK`) are unaffected.

## Testing

4 new tests (concurrent-subscription race; MU/SMU disambiguation × 3), each proven RED against the old code; full core suite 914 passed | 3 skipped.