### PR TITLE
refactor: resolve pro overlay imports through @pro path alias

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -13,7 +13,8 @@
     "types": ["node", "electron"],
     "paths": {
       "@desktop/*": ["./src/*"],
-      "@server/*": ["../server/src/*"]
+      "@server/*": ["../server/src/*"],
+      "@pro/*": ["../pro/src/*"]
     }
   },
   "include": ["src", "test/**/*.ts"]

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
   define: {
     __DESKTOP_DEV__: JSON.stringify(isDev),
   },
+  resolve: {
+    alias: {
+      '@pro': fileURLToPath(new URL('../pro/src', import.meta.url)),
+    },
+  },
   ssr: {
     // Single-graph invariant: everything JS is bundled so main and the pro
     // chunk share one module instance of every dep (tsuki decorator metadata

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -12,7 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "paths": {
-      "@server/*": ["./src/*"]
+      "@server/*": ["./src/*"],
+      "@pro/*": ["../pro/src/*"]
     }
   },
   "include": ["src", "test/**/*.ts", "scripts/**/*.ts"]

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -4,6 +4,7 @@ export default {
   resolve: {
     alias: {
       '@server': fileURLToPath(new URL('./src', import.meta.url)),
+      '@pro': fileURLToPath(new URL('../pro/src', import.meta.url)),
     },
   },
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "paths": {
-      "@web/*": ["./src/*"]
+      "@web/*": ["./src/*"],
+      "@pro/*": ["../pro/src/*"]
     }
   },
   "include": ["src", "vite.config.ts"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@web': fileURLToPath(new URL('./src', import.meta.url)),
+      '@pro': fileURLToPath(new URL('../pro/src', import.meta.url)),
     },
   },
   server: {

--- a/packages/build-overlay/eslint/plugin.mjs
+++ b/packages/build-overlay/eslint/plugin.mjs
@@ -234,6 +234,45 @@ const noSelfDefaultImport = {
   },
 };
 
+const noOverlayRelativeEscape = {
+  create(context) {
+    const filename = context.filename;
+    const options = context.options[0] ?? {};
+    const { overlayRoot, publicRoot } = options;
+    if (!isProFile(filename) || !overlayRoot || !within(overlayRoot, filename)) return {};
+    const appsProRoot = publicRoot ? path.join(publicRoot, 'apps', 'pro') : null;
+    return createSourceVisitor((sourceNode) => {
+      const value = sourceNode.value;
+      if (typeof value !== 'string' || !value.startsWith('.')) return;
+      const { ext, stem } = splitSpecifierExtension(value);
+      const absoluteStem = path.resolve(path.dirname(filename), stem);
+      if (within(overlayRoot, absoluteStem)) {
+        const candidates = [
+          ...(defaultCandidatePaths(absoluteStem, ext) ?? []),
+          ...(proCandidatePaths(absoluteStem, ext) ?? []),
+        ];
+        if (candidates.some(cachedExists)) return;
+      }
+      const effectiveTarget = path.resolve(effectiveDir(filename, options), value);
+      const messageId =
+        appsProRoot && within(appsProRoot, effectiveTarget) ? 'useProAlias' : 'useHostAlias';
+      context.report({ data: { source: value }, messageId, node: sourceNode });
+    });
+  },
+  meta: {
+    docs: {
+      description:
+        'Forbid relative imports in .pro overlays that leave the overlay tree; pro sources use "@pro/*", host sources use the host app alias.',
+    },
+    messages: {
+      useHostAlias: 'Overlay imports a host source via a relative path; use the host app alias (@desktop/@server/@web): {{source}}',
+      useProAlias: 'Overlay imports pro sources via a relative path; use "@pro/*": {{source}}',
+    },
+    schema: optionsSchema,
+    type: 'problem',
+  },
+};
+
 const overlayManifestConsistency = {
   create(context) {
     const filename = context.filename;
@@ -309,6 +348,7 @@ export const overlayPlugin = {
     'no-apps-pro-import': noAppsProImport,
     'no-escaping-import': noEscapingImport,
     'no-explicit-pro-import': noExplicitProImport,
+    'no-overlay-relative-escape': noOverlayRelativeEscape,
     'no-pro-only-resolution': noProOnlyResolution,
     'no-self-default-import': noSelfDefaultImport,
     'overlay-manifest-consistency': overlayManifestConsistency,

--- a/packages/build-overlay/test/eslintRules.test.ts
+++ b/packages/build-overlay/test/eslintRules.test.ts
@@ -231,6 +231,51 @@ describe('no-pro-only-resolution (fs fixtures)', () => {
   });
 });
 
+describe('no-overlay-relative-escape (fs fixtures)', () => {
+  const fixture = makeFixture();
+  writeFile(join(fixture.overlayRoot, 'apps', 'web', 'src', 'pages', 'Page.pro.tsx'));
+  const options = [{ overlayRoot: fixture.overlayRoot, publicRoot: fixture.publicRoot }];
+
+  ruleTester.run('no-overlay-relative-escape', overlayPlugin.rules['no-overlay-relative-escape'], {
+    invalid: [
+      {
+        code: "import { s } from '../../../pro/src/ai/scheduler.js';",
+        errors: [{ data: { source: '../../../pro/src/ai/scheduler.js' }, messageId: 'useProAlias' }],
+        filename: join(fixture.overlayRoot, 'apps', 'desktop', 'src', 'edition', 'pro.pro.ts'),
+        options,
+      },
+      {
+        code: "import { T } from './types.js';",
+        errors: [{ data: { source: './types.js' }, messageId: 'useHostAlias' }],
+        filename: join(fixture.overlayRoot, 'apps', 'desktop', 'src', 'edition', 'pro.pro.ts'),
+        options,
+      },
+    ],
+    valid: [
+      {
+        code: "import { P } from '../pages/Page';",
+        filename: join(fixture.overlayRoot, 'apps', 'web', 'src', 'edition', 'pro.pro.ts'),
+        options,
+      },
+      {
+        code: "import { s } from '@pro/ai/scheduler.js';",
+        filename: join(fixture.overlayRoot, 'apps', 'desktop', 'src', 'edition', 'pro.pro.ts'),
+        options,
+      },
+      {
+        code: "import { x } from './anything.js';",
+        filename: '/repo/pkg/edition.pro.ts',
+        options,
+      },
+      {
+        code: "import { x } from './anything.js';",
+        filename: join(fixture.overlayRoot, 'apps', 'web', 'src', 'edition', 'notPro.ts'),
+        options,
+      },
+    ],
+  });
+});
+
 describe('overlay-manifest-consistency (fs fixtures)', () => {
   const fixture = makeFixture();
   writeFile(join(fixture.publicRoot, 'pkg', 'a.ts'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   apps/license-worker:
     devDependencies:
@@ -128,7 +128,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
       wrangler:
         specifier: ^4.0.0
         version: 4.112.0
@@ -178,9 +178,18 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      lucide-react:
+        specifier: ^1.25.0
+        version: 1.25.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
@@ -192,7 +201,7 @@ importers:
         version: 6.0.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
       ws:
         specifier: ^8.21.1
         version: 8.21.1
@@ -259,7 +268,7 @@ importers:
         version: 6.0.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   apps/web:
     dependencies:
@@ -353,7 +362,7 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   packages/bench:
     dependencies:
@@ -384,7 +393,7 @@ importers:
         version: 6.0.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   packages/build-overlay:
     devDependencies:
@@ -399,7 +408,7 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   packages/core:
     dependencies:
@@ -439,7 +448,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0)
 
   packages/pro-api:
     dependencies:
@@ -5807,7 +5816,6 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12133,7 +12141,7 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -12160,7 +12168,18 @@ snapshots:
       '@types/node': 26.1.1
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## What

- Add `@pro/*` → `apps/pro/src/*` path alias to the desktop/server/web tsconfigs and vite `resolve.alias`, replacing the `../../../pro/src/...` relative imports overlay files had to compute from their projected symlink location (which made the real files under `kansoku-pro/overlays` unresolvable in the editor).
- New eslint rule `overlay/no-overlay-relative-escape` in `@kansoku/build-overlay`: relative imports inside `.pro` overlays may only target files within the overlay tree — pro sources must use `@pro/*`, host sources must use the host app alias (`@desktop`/`@server`/`@web`). Six RuleTester cases added.
- Lockfile: `@kansoku/pro` gains editor-side type devDependencies (react, @types/react, lucide-react).

## Why

The overlay projection is a symlink; relative imports only resolved from the projected path, so the private repo's real files were a wall of unresolvable imports and `overlays/` had no typecheck at all. Companion PR in kansoku-pro rewrites the overlay imports and adds `overlays/tsconfig.json`.

## Safety

- `isProModule`/`proLeakGuard` key on the real `/apps/pro/` path — the alias resolves there, chunk classification verified unchanged (`__pro__/` output intact on full desktop + web builds).
- Free checkout: the alias target is absent but only overlay files (also absent) use it; `KANSOKU_FORCE_FREE` path untouched.

## Verified

- `@kansoku/build-overlay` 104 tests pass; desktop/web typecheck pass; full desktop + web builds pass; `@kansoku/pro` lint/tests/typecheck green against the companion branch.