### PR TITLE
restore: per-version bundle key rotation lost in main history rewrite

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -215,23 +215,68 @@ jobs:
           grep -q '^  identity: null$' electron-builder.yml
           sed -i '' '/^  identity: null$/d' electron-builder.yml
 
+      # 每个 release 换一把新 bundle key:这里只生成(不推送),打包成功后由
+      # 后面的 "push rotated bundle key" 步骤 wrangler secret put 到 Worker。
+      # 故意拆开:构建失败时 Worker 继续发旧 key,已安装的旧包不受影响;推送
+      # 失败则 workflow 在发布前挂掉,不会发出一把 Worker 不认识的 key。旧安装
+      # 包下次 revalidate 领到新 key 后,客户端 keyId 校验拒绝旧 bundle —— 某版
+      # key 泄漏的影响限于该版。CLOUDFLARE_API_TOKEN 未配置时回退到静态
+      # KANSOKU_BUNDLE_KEY/_ID secrets(老行为,不轮换也不推送)。
+      - name: generate bundle key for this release (pro builds only)
+        id: bundlekey
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          STATIC_BUNDLE_KEY: ${{ secrets.KANSOKU_BUNDLE_KEY }}
+          STATIC_BUNDLE_KEY_ID: ${{ secrets.KANSOKU_BUNDLE_KEY_ID }}
+        run: |
+          if [ ! -d apps/pro ]; then
+            echo "pro slot absent — free build, no bundle key needed"
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            OUT="$(node apps/license-worker/scripts/rotateBundleKey.mjs --key-id "${{ steps.version.outputs.tag }}")"
+            KEY="$(echo "$OUT" | sed -n 's/^key=//p')"
+            KEY_ID="$(echo "$OUT" | sed -n 's/^keyId=//p')"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::CLOUDFLARE_API_TOKEN not set — falling back to static KANSOKU_BUNDLE_KEY secrets (no per-release rotation)"
+            KEY="$STATIC_BUNDLE_KEY"
+            KEY_ID="$STATIC_BUNDLE_KEY_ID"
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -z "$KEY" ] || [ -z "$KEY_ID" ]; then
+            echo "::error::pro slot present but no bundle key available (neither CLOUDFLARE_API_TOKEN nor static secrets)"
+            exit 1
+          fi
+          echo "::add-mask::$KEY"
+          echo "KANSOKU_BUNDLE_KEY=$KEY" >> "$GITHUB_ENV"
+          echo "KANSOKU_BUNDLE_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+
       - name: package desktop (dmg + zip; Developer ID + notarization when secrets present, ad-hoc otherwise)
         working-directory: apps/desktop
-        # KANSOKU_BUNDLE_KEY / KANSOKU_BUNDLE_KEY_ID only matter when the pro
-        # slot got fetched above — stagePro.mjs no-ops on a free build. When
-        # the slot IS present, scripts/packEnc.mjs (apps/pro) hard-fails
-        # without these, which is intentional: a pro release must never ship
-        # without encryption. See apps/pro README「发版：KANSOKU_BUNDLE_KEY 来源
-        # 与 keyId 轮换」for how the secrets are provisioned/rotated.
+        # KANSOKU_BUNDLE_KEY / KANSOKU_BUNDLE_KEY_ID come from the generation
+        # step above (via GITHUB_ENV) — fresh per release, or the static repo
+        # secrets as fallback. stagePro.mjs no-ops on a free build; with the
+        # pro slot present, scripts/packEnc.mjs (apps/pro) hard-fails without
+        # these, which is intentional: a pro release must never ship without
+        # encryption.
         env:
-          KANSOKU_BUNDLE_KEY: ${{ secrets.KANSOKU_BUNDLE_KEY }}
-          KANSOKU_BUNDLE_KEY_ID: ${{ secrets.KANSOKU_BUNDLE_KEY_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm package
+
+      # 打包成功了才把新 key 推上 Worker;推送失败直接挂掉 workflow,发布步骤
+      # 不会执行。key 走环境变量(KANSOKU_BUNDLE_KEY 在生成步骤已写入 GITHUB_ENV),
+      # 不落命令行参数。
+      - name: push rotated bundle key to the license Worker
+        if: steps.bundlekey.outputs.push == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: node apps/license-worker/scripts/rotateBundleKey.mjs --push
 
       - name: verify signature (dmg + zip both embed the already-signed app)
         working-directory: apps/desktop

--- a/apps/desktop/src/data/credentials/secretBox.ts
+++ b/apps/desktop/src/data/credentials/secretBox.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import type { MasterKeyStatus, SecretBox } from '@kansoku/pro-api';
 import {
@@ -72,16 +72,10 @@ function readLegacyKey(path: string): Buffer | null {
   return readFileSync(path);
 }
 
-function writeLegacyKey(path: string, key: Buffer): void {
-  writeFileSync(path, key, { mode: 0o600 });
-  chmodSync(path, 0o600);
-}
-
 // Migration order on every boot: prefer an already-wrapped key (steady
-// state); else wrap a pre-P3 plaintext keyfile in place, keeping the
-// original file untouched (never delete user data); else mint a fresh key.
-// The legacy plaintext file, if wrapped, is intentionally left on disk —
-// this function only adds a safeStorage-wrapped copy alongside it.
+// state); else wrap a pre-P3 plaintext keyfile and DELETE the plaintext —
+// leaving the bare key on disk next to the Keychain-wrapped copy would
+// defeat the wrapping entirely; else mint a fresh key.
 function resolveKey(deps: DesktopSecretBoxDeps): Buffer | null {
   const wrapped = readWrappedKey(deps.wrappedKeyPath, deps.safeStorage);
   if (wrapped) return wrapped;
@@ -91,6 +85,13 @@ function resolveKey(deps: DesktopSecretBoxDeps): Buffer | null {
   const legacy = readLegacyKey(deps.legacyKeyPath);
   if (legacy) {
     writeWrappedKey(deps.wrappedKeyPath, legacy, deps.safeStorage);
+    try {
+      rmSync(deps.legacyKeyPath, { force: true });
+    } catch (error) {
+      // The wrapped copy is already in place, so a failed unlink is not
+      // fatal — but the plaintext key is still on disk, so make noise.
+      console.warn('[secretBox] migrated master key but could not delete legacy keyfile:', error);
+    }
     return legacy;
   }
 
@@ -130,11 +131,9 @@ export function createDesktopSecretBox(deps: DesktopSecretBoxDeps): SecretBox {
       }
       const fresh = randomBytes(KEY_BYTES);
       writeWrappedKey(deps.wrappedKeyPath, fresh, deps.safeStorage);
-      // A bare-Node host sharing this data root (no Electron, no safeStorage)
-      // reads the master key straight from legacyKeyPath — if that file is
-      // still around, keep it in lockstep or it'd decrypt with a stale key
-      // after this reset.
-      if (readLegacyKey(deps.legacyKeyPath)) writeLegacyKey(deps.legacyKeyPath, fresh);
+      // Never write the fresh key back to the legacy plaintext path — the
+      // bare keyfile is gone for good once the safeStorage wrap exists.
+      rmSync(deps.legacyKeyPath, { force: true });
     },
   };
 }

--- a/apps/desktop/test/credentials/secretBox.test.ts
+++ b/apps/desktop/test/credentials/secretBox.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createDesktopSecretBox } from '@desktop/data/credentials/secretBox.js';
 import { SecretBoxError } from '@kansoku/core/platform/secretCrypto';
@@ -55,7 +55,7 @@ describe('desktopSecretBox', () => {
     expect(box.status()).toBe('ready');
   });
 
-  it('legacy path: wraps a pre-existing plaintext keyfile and keeps the original', () => {
+  it('legacy path: wraps a pre-existing plaintext keyfile and deletes the original', () => {
     const legacyKey = Buffer.alloc(32, 7);
     writeFileSync(legacyKeyPath, legacyKey, { mode: 0o600 });
 
@@ -67,8 +67,9 @@ describe('desktopSecretBox', () => {
     const envelope = box.encrypt('longbridge', 'secret-value');
 
     expect(existsSync(wrappedKeyPath)).toBe(true);
-    expect(existsSync(legacyKeyPath)).toBe(true);
-    expect(readFileSync(legacyKeyPath)).toEqual(legacyKey);
+    // The bare plaintext key must not survive migration — leaving it next to
+    // the Keychain-wrapped copy would defeat the wrapping.
+    expect(existsSync(legacyKeyPath)).toBe(false);
     expect(box.decrypt('longbridge', envelope)).toBe('secret-value');
   });
 
@@ -83,7 +84,8 @@ describe('desktopSecretBox', () => {
     });
     const envelope = boxA.encrypt('longbridge', 'secret-value');
 
-    rmSync(legacyKeyPath);
+    // migration already deleted the plaintext keyfile; a fresh box instance
+    // must still decrypt via the wrapped copy alone
     const boxB = createDesktopSecretBox({
       safeStorage: fakeSafeStorage(),
       wrappedKeyPath,
@@ -150,7 +152,7 @@ describe('desktopSecretBox', () => {
     expect(() => box.resetKey()).toThrow(SecretBoxError);
   });
 
-  it('resetKey keeps an existing legacy keyfile in sync with the new wrapped key', () => {
+  it('resetKey deletes an existing legacy keyfile instead of rewriting it', () => {
     const legacyKey = Buffer.alloc(32, 3);
     writeFileSync(legacyKeyPath, legacyKey, { mode: 0o600 });
     const box = createDesktopSecretBox({
@@ -161,20 +163,9 @@ describe('desktopSecretBox', () => {
 
     box.resetKey();
 
-    const rewrittenLegacy = readFileSync(legacyKeyPath);
-    expect(rewrittenLegacy).not.toEqual(legacyKey);
-    expect(rewrittenLegacy).toHaveLength(32);
-    expect(statSync(legacyKeyPath).mode & 0o777).toBe(0o600);
-
-    // A bare-Node consumer reading only legacyKeyPath must decrypt with the
-    // same key resetKey() just wrapped.
-    const envelope = box.encrypt('longbridge', 'secret-value');
-    const bareNodeBox = createDesktopSecretBox({
-      safeStorage: fakeSafeStorage(),
-      wrappedKeyPath: join(dirname(wrappedKeyPath), 'unrelated-wrapped.json'),
-      legacyKeyPath,
-    });
-    expect(bareNodeBox.decrypt('longbridge', envelope)).toBe('secret-value');
+    expect(existsSync(legacyKeyPath)).toBe(false);
+    const fresh = box.encrypt('longbridge', 'secret-value');
+    expect(box.decrypt('longbridge', fresh)).toBe('secret-value');
   });
 
   it('resetKey does not create a legacy keyfile that never existed', () => {

--- a/apps/license-worker/README.md
+++ b/apps/license-worker/README.md
@@ -2,6 +2,10 @@
 
 Cloudflare Worker，全代理客户端到 Dodo 的三个 license 端点（`/activate` `/validate` `/deactivate`），验证通过时下发解密 `pro.enc` 用的 `bundleKey` / `keyId`。设计见仓库根 `.superpowers/sdd/spec.md`「Cloudflare Worker（全代理）」一节。
 
+## 设备绑定（device-bound bundleKey）
+
+客户端激活时生成一对 ECDH P-256 设备密钥对，随请求上传 `device_public_key`（`activate` 和 `validate` 都会带）。Worker 转发给 Dodo 前会**剥掉**这个字段（Dodo 看不到它）；下发 `bundleKey` 时，如果请求带了合法的设备公钥，就用「临时 ECDH → HKDF-SHA256 → AES-256-GCM」把 key 包裹后再发（响应里多一个 `bundleKeyWrap: { alg, eph, iv }`，`bundleKey` 字段是密文）。客户端用设备私钥解包——私钥只存在本机 safeStorage 加密的 license 记录里，所以把记录/key 拷到别的机器上也解不开，分享 key 必须连设备私钥一起给。没带设备公钥的旧客户端走明文 `bundleKey` 老路径，保持兼容。两侧实现：`src/bundleKeyWrap.ts`（WebCrypto）与 `packages/core/src/license/bundleKeyWrap.ts`（node:crypto），靠同一个 alg 标识和 HKDF info 字符串保持字节兼容。
+
 ## 环境变量
 
 - `DODO_BASE_URL`：转发目标（`wrangler.jsonc` 里 live/test 环境各配一份，非 secret）。
@@ -36,4 +40,6 @@ pnpm --filter @kansoku/license-worker test
    pnpm exec wrangler deploy --env production                 # 生产环境（live.dodopayments.com）
    ```
 3. **绑定自定义域名**：客户端默认指向 `https://kansoku-portal.innei.dev`（`packages/core/src/license/dodoClient.ts` 的 `DEFAULT_LICENSE_API_URL`，可用 `KANSOKU_LICENSE_API_URL` 覆盖）。在 Cloudflare Dashboard 的 Worker 设置里给 `kansoku-license-worker`（生产环境）加一条 Custom Domain 指向 `kansoku-portal.innei.dev`，或者在 `wrangler.jsonc` 的 `env.production` 下加 `routes`/`custom_domain` 配置后重新 `deploy`。domain 生效前，客户端会打到 Worker 默认的 `*.workers.dev` 地址（`deploy` 命令输出里能看到），可以先拿它联调。
-4. **key 泄漏后的换 key 流程**：生成新的 `BUNDLE_KEY` + 新的 `BUNDLE_KEY_ID`，`wrangler secret put` 覆盖两者并重新 `deploy`；下一次发版打包时用同一对新值（见 `apps/pro` README「发版：KANSOKU_BUNDLE_KEY 来源与 keyId 轮换」）。旧 key 加密的旧安装包会在这一刻起拿不到 key（`validate`/`activate` 返回的是新 key），相当于强制所有旧包升级。
+4. **key 轮换**：分两种——
+   - **每版自动轮换（默认）**：`desktop-release` workflow 在打包前跑 `scripts/rotateBundleKey.mjs --key-id <release-tag>` 生成新 key（只生成不推送），打包成功后、发布前再 `--push` 把新 `BUNDLE_KEY` + `BUNDLE_KEY_ID` `wrangler secret put` 到 Worker。需要 repo secret `CLOUDFLARE_API_TOKEN`（对本 Worker 有 Workers Scripts 编辑权限）；未配置时回退到静态 `KANSOKU_BUNDLE_KEY` / `KANSOKU_BUNDLE_KEY_ID` repo secrets（老行为，不轮换）。推送故意放在打包成功后：构建失败时 Worker 继续发旧 key，已安装的旧包不受影响。
+   - **泄漏后的手动换 key**：生成新的 `BUNDLE_KEY` + 新的 `BUNDLE_KEY_ID`，`wrangler secret put` 覆盖两者；下一次发版用同一对新值打包。旧 key 加密的旧安装包从这一刻起拿不到能用的 key（`validate`/`activate` 返回的是新 key，客户端 keyId 校验也会让旧 bundle 停在免费模式），相当于强制所有旧包升级。

--- a/apps/license-worker/scripts/rotateBundleKey.mjs
+++ b/apps/license-worker/scripts/rotateBundleKey.mjs
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// 每次发版轮换 bundle key,两种用法(desktop-release workflow 里成对出现):
+//
+//   生成(打包前): node scripts/rotateBundleKey.mjs --key-id desktop-vX.Y.Z
+//     只生成 key + keyId 并打印 key=/keyId= 两行,不碰 Worker —— 打包
+//     (packEnc)用这把 key 加密 pro.enc。
+//   推送(打包成功后、发布前): KANSOKU_BUNDLE_KEY=.. node scripts/rotateBundleKey.mjs --push
+//     key 从环境变量 KANSOKU_BUNDLE_KEY / KANSOKU_BUNDLE_KEY_ID 读(--key-id
+//     可覆盖后者),wrangler secret put 到 license Worker。故意不在打包前推:
+//     构建失败时 Worker 还在发旧 key,已安装的旧包不受影响;推送失败则
+//     workflow 在发布前挂掉,不会发出一把 Worker 不认识的 key。
+//
+// 推送需要 CLOUDFLARE_API_TOKEN(对 kansoku-license-worker 有 Workers
+// Scripts 编辑权限)。旧安装包在下一次 revalidate 领到新 key,配合客户端的
+// keyId 校验,等于强制旧包升级;某版 key 泄漏的影响限于那一版。
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const workerDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const workerEnv = argValue("--env") ?? "production";
+const push = process.argv.includes("--push");
+const key = process.env.KANSOKU_BUNDLE_KEY ?? randomBytes(32).toString("hex");
+const keyId = argValue("--key-id") ?? process.env.KANSOKU_BUNDLE_KEY_ID;
+
+if (!keyId) {
+  console.error("rotateBundleKey: --key-id <id> is required (release workflow 传 desktop-vX.Y.Z)");
+  process.exit(1);
+}
+if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+  console.error("rotateBundleKey: key must be a 64-character hex string (32 bytes)");
+  process.exit(1);
+}
+
+if (push) {
+  if (!process.env.KANSOKU_BUNDLE_KEY) {
+    console.error("rotateBundleKey: --push 模式需要 KANSOKU_BUNDLE_KEY 环境变量(避免 key 落在命令行参数里)");
+    process.exit(1);
+  }
+  if (!process.env.CLOUDFLARE_API_TOKEN) {
+    console.error("rotateBundleKey: CLOUDFLARE_API_TOKEN 未设置,无法 wrangler secret put");
+    process.exit(1);
+  }
+  for (const [name, value] of [
+    ["BUNDLE_KEY", key],
+    ["BUNDLE_KEY_ID", keyId],
+  ]) {
+    // wrangler 从 stdin 读 secret 值,不回显;key 不落在命令行参数里
+    execFileSync("pnpm", ["exec", "wrangler", "secret", "put", name, "--env", workerEnv], {
+      cwd: workerDir,
+      input: `${value}\n`,
+      stdio: ["pipe", "inherit", "inherit"],
+    });
+  }
+  console.error(`rotateBundleKey: 已推送 BUNDLE_KEY + BUNDLE_KEY_ID=${keyId} 到 ${workerEnv} 环境`);
+}
+
+console.log(`key=${key}`);
+console.log(`keyId=${keyId}`);

--- a/apps/license-worker/src/bundleKeyWrap.ts
+++ b/apps/license-worker/src/bundleKeyWrap.ts
@@ -1,0 +1,60 @@
+// WebCrypto twin of packages/core/src/license/bundleKeyWrap.ts — the two
+// implementations must stay byte-compatible (same alg id, HKDF info string,
+// and ciphertext+tag layout), the client unwraps with node:crypto.
+export const BUNDLE_KEY_WRAP_ALG = "p256-hkdf-sha256-aes256gcm";
+const HKDF_INFO = "kansoku-bundle-key-wrap-v1";
+
+export interface BundleKeyWrapResult {
+  /** base64 ciphertext+tag — sent as the response's bundleKey field */
+  wrapped: string;
+  wrap: { alg: string; eph: string; iv: string };
+}
+
+function b64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+function bytesToB64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * Wrap the bundle key to the client's device public key (base64 SPKI P-256).
+ * Returns null when the device key is missing/malformed — the caller then
+ * falls back to a plaintext bundleKey for backward compatibility.
+ */
+export async function wrapBundleKeyForDevice(
+  bundleKeyHex: string,
+  devicePublicKeyB64: string | undefined,
+): Promise<BundleKeyWrapResult | null> {
+  if (!devicePublicKeyB64) return null;
+  try {
+    const deviceKey = await crypto.subtle.importKey(
+      "spki",
+      b64ToBytes(devicePublicKeyB64),
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      [],
+    );
+    const ephemeral = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"]);
+    const shared = await crypto.subtle.deriveBits({ name: "ECDH", public: deviceKey }, ephemeral.privateKey, 256);
+    const hkdfKey = await crypto.subtle.importKey("raw", shared, "HKDF", false, ["deriveBits"]);
+    const aesKeyBits = await crypto.subtle.deriveBits(
+      { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new TextEncoder().encode(HKDF_INFO) },
+      hkdfKey,
+      256,
+    );
+    const aesKey = await crypto.subtle.importKey("raw", aesKeyBits, { name: "AES-GCM" }, false, ["encrypt"]);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, aesKey, new TextEncoder().encode(bundleKeyHex));
+    const ephSpki = await crypto.subtle.exportKey("spki", ephemeral.publicKey);
+    return {
+      wrapped: bytesToB64(new Uint8Array(ciphertext)),
+      wrap: { alg: BUNDLE_KEY_WRAP_ALG, eph: bytesToB64(new Uint8Array(ephSpki)), iv: bytesToB64(iv) },
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/license-worker/src/dodoProxy.ts
+++ b/apps/license-worker/src/dodoProxy.ts
@@ -1,5 +1,6 @@
 import type { Env } from "./env.js";
 import type { Throttle } from "./throttle.js";
+import { wrapBundleKeyForDevice } from "./bundleKeyWrap.js";
 
 export interface ProxyDeps {
   fetch: typeof globalThis.fetch;
@@ -15,11 +16,20 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
-async function readLicenseKey(request: Request): Promise<{ bodyText: string; licenseKey?: string } | null> {
+interface ParsedRequest {
+  /** body forwarded to Dodo — device_public_key stripped, Dodo must not see it */
+  forwardBody: string;
+  licenseKey?: string;
+  devicePublicKey?: string;
+}
+
+async function readLicenseKey(request: Request): Promise<ParsedRequest | null> {
   const bodyText = await request.text();
   try {
-    const parsed = JSON.parse(bodyText) as { license_key?: string };
-    return { bodyText, licenseKey: parsed.license_key };
+    const parsed = JSON.parse(bodyText) as { license_key?: string; device_public_key?: string };
+    const devicePublicKey = typeof parsed.device_public_key === "string" ? parsed.device_public_key : undefined;
+    delete parsed.device_public_key;
+    return { forwardBody: JSON.stringify(parsed), licenseKey: parsed.license_key, devicePublicKey };
   } catch {
     return null;
   }
@@ -33,8 +43,15 @@ async function forwardToDodo(deps: ProxyDeps, path: string, bodyText: string): P
   });
 }
 
-async function withBundleKey(response: Response, env: Env): Promise<Response> {
+async function withBundleKey(response: Response, env: Env, devicePublicKey?: string): Promise<Response> {
   const data = (await response.json()) as Record<string, unknown>;
+  // Device-bound when the client uploaded a device keypair: only that
+  // device's private key can unwrap the bundle key, so a shared key is
+  // useless without the (safeStorage-protected) device secret with it.
+  const wrapped = await wrapBundleKeyForDevice(env.BUNDLE_KEY, devicePublicKey);
+  if (wrapped) {
+    return jsonResponse({ ...data, bundleKey: wrapped.wrapped, keyId: env.BUNDLE_KEY_ID, bundleKeyWrap: wrapped.wrap }, response.status);
+  }
   return jsonResponse({ ...data, bundleKey: env.BUNDLE_KEY, keyId: env.BUNDLE_KEY_ID }, response.status);
 }
 
@@ -52,8 +69,8 @@ export async function handleActivate(request: Request, deps: ProxyDeps): Promise
   if (parsed.licenseKey && deps.throttle.isThrottled(parsed.licenseKey, deps.now())) {
     return jsonResponse({ error: "rate_limited" }, 429);
   }
-  const response = await forwardToDodo(deps, "/licenses/activate", parsed.bodyText);
-  if (response.status === 201) return withBundleKey(response, deps.env);
+  const response = await forwardToDodo(deps, "/licenses/activate", parsed.forwardBody);
+  if (response.status === 201) return withBundleKey(response, deps.env, parsed.devicePublicKey);
   return passthrough(response);
 }
 
@@ -63,11 +80,11 @@ export async function handleValidate(request: Request, deps: ProxyDeps): Promise
   if (parsed.licenseKey && deps.throttle.isThrottled(parsed.licenseKey, deps.now())) {
     return jsonResponse({ error: "rate_limited" }, 429);
   }
-  const response = await forwardToDodo(deps, "/licenses/validate", parsed.bodyText);
+  const response = await forwardToDodo(deps, "/licenses/validate", parsed.forwardBody);
   if (!response.ok) return passthrough(response);
   const clone = response.clone();
   const data = (await clone.json()) as { valid?: boolean };
-  if (data.valid === true) return withBundleKey(response, deps.env);
+  if (data.valid === true) return withBundleKey(response, deps.env, parsed.devicePublicKey);
   return passthrough(response);
 }
 
@@ -77,6 +94,6 @@ export async function handleDeactivate(request: Request, deps: ProxyDeps): Promi
   if (parsed.licenseKey && deps.throttle.isThrottled(parsed.licenseKey, deps.now())) {
     return jsonResponse({ error: "rate_limited" }, 429);
   }
-  const response = await forwardToDodo(deps, "/licenses/deactivate", parsed.bodyText);
+  const response = await forwardToDodo(deps, "/licenses/deactivate", parsed.forwardBody);
   return passthrough(response);
 }

--- a/apps/license-worker/test/index.test.ts
+++ b/apps/license-worker/test/index.test.ts
@@ -1,3 +1,4 @@
+import { createDecipheriv, createPrivateKey, createPublicKey, diffieHellman, generateKeyPairSync, hkdfSync } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import type { Env } from "../src/env.js";
 import { createRequestHandler } from "../src/index.js";
@@ -8,6 +9,27 @@ const env: Env = {
   BUNDLE_KEY: "b".repeat(64),
   BUNDLE_KEY_ID: "key-1",
 };
+
+// Independent node:crypto unwrap of the Worker's WebCrypto wrap — mirrors
+// packages/core/src/license/bundleKeyWrap.ts (the production unwrap path).
+function unwrapForTest(wrappedB64: string, wrap: { eph: string; iv: string }, privateKeyB64: string): string {
+  const privateKey = createPrivateKey({ key: Buffer.from(privateKeyB64, "base64"), format: "der", type: "pkcs8" });
+  const eph = createPublicKey({ key: Buffer.from(wrap.eph, "base64"), format: "der", type: "spki" });
+  const shared = diffieHellman({ privateKey, publicKey: eph });
+  const key = Buffer.from(hkdfSync("sha256", shared, "", "kansoku-bundle-key-wrap-v1", 32));
+  const blob = Buffer.from(wrappedB64, "base64");
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(wrap.iv, "base64"));
+  decipher.setAuthTag(blob.subarray(blob.length - 16));
+  return Buffer.concat([decipher.update(blob.subarray(0, blob.length - 16)), decipher.final()]).toString("utf8");
+}
+
+function deviceKeyPair(): { publicKey: string; privateKey: string } {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  return {
+    publicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+    privateKey: privateKey.export({ format: "der", type: "pkcs8" }).toString("base64"),
+  };
+}
 
 function post(path: string, body: unknown): Request {
   return new Request(`https://worker.example${path}`, {
@@ -49,6 +71,40 @@ describe("license-worker activate", () => {
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({ error: "invalid license" });
   });
+
+  it("wraps the bundleKey to the device public key and strips it before forwarding", async () => {
+    const device = deviceKeyPair();
+    const fetchImpl = fakeFetch({ status: 201, body: { id: "lki_1" } });
+    const handler = handlerWith(fetchImpl);
+
+    const res = await handler(
+      post("/activate", { license_key: "lic_1", name: "my-mac", device_public_key: device.publicKey }),
+    );
+
+    // Dodo must never see the device key field
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://test.dodopayments.com/licenses/activate",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ license_key: "lic_1", name: "my-mac" }) }),
+    );
+    const body = (await res.json()) as {
+      bundleKey: string;
+      keyId: string;
+      bundleKeyWrap: { alg: string; eph: string; iv: string };
+    };
+    expect(body.keyId).toBe(env.BUNDLE_KEY_ID);
+    expect(body.bundleKeyWrap.alg).toBe("p256-hkdf-sha256-aes256gcm");
+    expect(body.bundleKey).not.toBe(env.BUNDLE_KEY);
+    expect(unwrapForTest(body.bundleKey, body.bundleKeyWrap, device.privateKey)).toBe(env.BUNDLE_KEY);
+  });
+
+  it("falls back to a plaintext bundleKey when the device public key is malformed", async () => {
+    const fetchImpl = fakeFetch({ status: 201, body: { id: "lki_1" } });
+    const handler = handlerWith(fetchImpl);
+
+    const res = await handler(post("/activate", { license_key: "lic_1", name: "my-mac", device_public_key: "!!!" }));
+
+    await expect(res.json()).resolves.toEqual({ id: "lki_1", bundleKey: env.BUNDLE_KEY, keyId: env.BUNDLE_KEY_ID });
+  });
 });
 
 describe("license-worker validate", () => {
@@ -88,6 +144,32 @@ describe("license-worker validate", () => {
     const res = await handler(post("/validate", { license_key: "lic_1", license_key_instance_id: "lki_1" }));
 
     await expect(res.json()).resolves.toEqual({ valid: false });
+  });
+
+  it("wraps the bundleKey on validate when the client uploads its device key", async () => {
+    const device = deviceKeyPair();
+    const fetchImpl = fakeFetch({ status: 200, body: { valid: true } });
+    const handler = handlerWith(fetchImpl);
+
+    const res = await handler(
+      post("/validate", {
+        license_key: "lic_1",
+        license_key_instance_id: "lki_1",
+        device_public_key: device.publicKey,
+      }),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://test.dodopayments.com/licenses/validate",
+      expect.objectContaining({
+        body: JSON.stringify({ license_key: "lic_1", license_key_instance_id: "lki_1" }),
+      }),
+    );
+    const body = (await res.json()) as {
+      bundleKey: string;
+      bundleKeyWrap: { alg: string; eph: string; iv: string };
+    };
+    expect(unwrapForTest(body.bundleKey, body.bundleKeyWrap, device.privateKey)).toBe(env.BUNDLE_KEY);
   });
 });
 

--- a/apps/server/test/license-routes.test.ts
+++ b/apps/server/test/license-routes.test.ts
@@ -6,6 +6,7 @@ function fakeManager(overrides: Partial<LicenseManager> = {}): LicenseManager {
   return {
     getLicenseSnapshot: () => ({ state: "unlicensed" }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => {},
     revalidate: async () => {},

--- a/apps/server/test/proPresent.test.ts
+++ b/apps/server/test/proPresent.test.ts
@@ -38,6 +38,7 @@ function fakeLicenseManager(overrides: Partial<LicenseManager> = {}): LicenseMan
   return {
     getLicenseSnapshot: () => ({ state: 'licensed', deviceName: 'test', maskedKey: '••••1234' }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => ({}) as never,
     revalidate: async () => {},

--- a/docs/pro-overlay.md
+++ b/docs/pro-overlay.md
@@ -73,8 +73,8 @@ node 侧构建还给 `ssr.noExternal: true`（只有 `electron`、`better-sqlite
 - **`packEnc.mjs`**：把 node/web 两份 `__pro__` 文件收集成一个 manifest（`node/` / `web/` 前缀 + base64 内容），注入 `bundle.json`（`formatVersion`、`buildId`、`publicCommit`、`proCommit`，只做诊断用，不再有 ABI 版本字段），用 `KANSOKU_BUNDLE_KEY`（64 位十六进制、32 字节）+ `KANSOKU_BUNDLE_KEY_ID` 做 AES-256-GCM 加密，字节格式是 `MAGIC("KPRO1") + 12 字节 IV + 16 字节 authTag + gzip(JSON) 密文`——这个格式被公开仓的 golden fixture 钉死，改格式要重新生成 fixture。web 侧 chunk 还会被扫一遍，确认没有引用 `electron` 或 `node:` 内置模块（浏览器侧代码不能有 Node/Electron 专属引用）。
 - **运行时解密**（`packages/core/src/pro/loader.ts` 的 `loadPro`）：
   - 找不到 `pro.enc` → 直接返回 `null`（免费）。
-  - 找到但没 key（`getActiveBundleKey()` 和 `process.env.KANSOKU_BUNDLE_KEY` 都拿不到）→ 打日志说明，返回 `null`（免费）。
-  - 有 key 但解密/校验失败（错 key、被篡改）→ `catch` 住，打警告日志，返回 `null`（免费）。**永远不抛出去让宿主崩溃。**
+  - 找到但没 key（`getActiveBundleKey()` 拿不到，且非打包环境下 `process.env.KANSOKU_BUNDLE_KEY` 也拿不到）→ 打日志说明，返回 `null`（免费）。`KANSOKU_BUNDLE_KEY` 环境变量只在非打包构建里生效（`isBundleKeyEnvAllowed`，和 `KANSOKU_LICENSE_BYPASS` 同一套 `isPackaged` 判断）——打包版不认这个变量，堵住「设个环境变量就用泄漏 key」的后门。
+  - 有 key 但解密/校验失败（错 key、被篡改、**manifest.keyId 与当前 key 的 keyId 不一致**）→ `catch` 住，打警告日志，返回 `null`（免费）。**永远不抛出去让宿主崩溃。** keyId 一致性是每版轮换 key 的 enforcement：旧 key 解不开新包，revalidate 领到新 key 后旧包也会因为 keyId 对不上而停在免费模式，直到 App 更新到配套版本。
   - 成功：node 侧文件被注册成虚拟模块，路径映射回它们在 `dist-main/__pro__` 下**原本的位置**（`packages/core/src/pro/encLoader.ts` 的 `registerVirtualModules`），所以 pro chunk 之间的相对 import（`../chunk-x.mjs`）能落到正确的虚拟文件上；web 侧文件保留在内存 `Map<string, Buffer>` 里，交给协议层。
 - **泄漏闸门**：pro 入口链（`apps/pro/src/entries/canary.ts`）埋了一个 canary 常量；`apps/desktop/scripts/afterPack.cjs` 在打包后扫描 `app.asar` 原始字节找这个常量，命中就让打包失败——这是 `proLeakGuard` 之外的第二道独立防线，专门防明文 pro 代码混进最终产物。
 

--- a/packages/core/src/license/bundleKeyWrap.ts
+++ b/packages/core/src/license/bundleKeyWrap.ts
@@ -1,0 +1,88 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  randomBytes,
+} from "node:crypto";
+
+// Device-bound bundle key wrapping. The client generates an ECDH P-256
+// keypair per activation and uploads the public key; the license Worker
+// wraps the bundle key to it (ephemeral ECDH → HKDF-SHA256 → AES-256-GCM).
+// The stored license record then holds a bundle key that only this device's
+// private key can unwrap, and that private key lives inside the
+// safeStorage-encrypted record — copying the record to another machine no
+// longer carries a usable bundle key.
+export const BUNDLE_KEY_WRAP_ALG = "p256-hkdf-sha256-aes256gcm";
+
+// Must match the HKDF info string in apps/license-worker/src/bundleKeyWrap.ts.
+const HKDF_INFO = "kansoku-bundle-key-wrap-v1";
+
+export interface BundleKeyWrap {
+  alg: string;
+  /** base64 SPKI (DER) ephemeral public key */
+  eph: string;
+  /** base64 12-byte AES-GCM IV */
+  iv: string;
+}
+
+export interface DeviceKeyPair {
+  /** base64 SPKI (DER) public key, uploaded as device_public_key */
+  publicKey: string;
+  /** base64 PKCS8 (DER) private key, never leaves the license record */
+  privateKey: string;
+}
+
+export function generateDeviceKeyPair(): DeviceKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  return {
+    publicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+    privateKey: privateKey.export({ format: "der", type: "pkcs8" }).toString("base64"),
+  };
+}
+
+function deriveWrapKey(privateKeyB64: string, peerPublicKeyB64: string): Buffer {
+  const privateKey = createPrivateKey({ key: Buffer.from(privateKeyB64, "base64"), format: "der", type: "pkcs8" });
+  const publicKey = createPublicKey({ key: Buffer.from(peerPublicKeyB64, "base64"), format: "der", type: "spki" });
+  const shared = diffieHellman({ privateKey, publicKey });
+  return Buffer.from(hkdfSync("sha256", shared, "", HKDF_INFO, 32));
+}
+
+/**
+ * Unwrap a server-wrapped bundle key. `wrappedB64` is the response's
+ * bundleKey field (base64 ciphertext+tag); returns the 64-char hex key.
+ */
+export function unwrapBundleKey(wrappedB64: string, wrap: BundleKeyWrap, devicePrivateKeyB64: string): string {
+  if (wrap.alg !== BUNDLE_KEY_WRAP_ALG) {
+    throw new Error(`unsupported bundleKey wrap alg: ${wrap.alg}`);
+  }
+  const key = deriveWrapKey(devicePrivateKeyB64, wrap.eph);
+  const blob = Buffer.from(wrappedB64, "base64");
+  const tag = blob.subarray(blob.length - 16);
+  const ciphertext = blob.subarray(0, blob.length - 16);
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(wrap.iv, "base64"));
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}
+
+/**
+ * Node-side twin of the Worker's wrapping routine — used by tests to
+ * simulate server responses (the deployed wrapper runs on WebCrypto in
+ * apps/license-worker; both must stay byte-compatible via the shared
+ * HKDF info / alg contract).
+ */
+export function wrapBundleKey(bundleKeyHex: string, devicePublicKeyB64: string): { wrapped: string; wrap: BundleKeyWrap } {
+  const eph = generateDeviceKeyPair();
+  const key = deriveWrapKey(eph.privateKey, devicePublicKeyB64);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(Buffer.from(bundleKeyHex, "utf8")), cipher.final()]);
+  const blob = Buffer.concat([ciphertext, cipher.getAuthTag()]);
+  return {
+    wrapped: blob.toString("base64"),
+    wrap: { alg: BUNDLE_KEY_WRAP_ALG, eph: eph.publicKey, iv: iv.toString("base64") },
+  };
+}

--- a/packages/core/src/license/dodoClient.ts
+++ b/packages/core/src/license/dodoClient.ts
@@ -1,7 +1,10 @@
+import type { BundleKeyWrap } from "./bundleKeyWrap.js";
+
 export interface DodoInstance {
   id: string;
   bundleKey?: string;
   keyId?: string;
+  bundleKeyWrap?: BundleKeyWrap;
   [key: string]: unknown;
 }
 
@@ -9,13 +12,18 @@ export interface DodoValidateResult {
   valid: boolean;
   bundleKey?: string;
   keyId?: string;
+  bundleKeyWrap?: BundleKeyWrap;
 }
 
 export type DodoResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
 export interface DodoClient {
-  activate(input: { licenseKey: string; name: string }): Promise<DodoResult<DodoInstance>>;
-  validate(input: { licenseKey: string; instanceId?: string }): Promise<DodoResult<DodoValidateResult>>;
+  activate(input: { licenseKey: string; name: string; devicePublicKey?: string }): Promise<DodoResult<DodoInstance>>;
+  validate(input: {
+    licenseKey: string;
+    instanceId?: string;
+    devicePublicKey?: string;
+  }): Promise<DodoResult<DodoValidateResult>>;
   deactivate(input: { licenseKey: string; instanceId: string }): Promise<DodoResult<void>>;
 }
 
@@ -60,12 +68,24 @@ export function createDodoClient(opts: DodoClientOptions = {}): DodoClient {
   }
 
   return {
-    activate: ({ licenseKey, name }) =>
-      request<DodoInstance>("/licenses/activate", { license_key: licenseKey, name }, true),
-    validate: ({ licenseKey, instanceId }) =>
+    activate: ({ licenseKey, name, devicePublicKey }) =>
+      request<DodoInstance>(
+        "/licenses/activate",
+        {
+          license_key: licenseKey,
+          name,
+          ...(devicePublicKey ? { device_public_key: devicePublicKey } : {}),
+        },
+        true,
+      ),
+    validate: ({ licenseKey, instanceId, devicePublicKey }) =>
       request<DodoValidateResult>(
         "/licenses/validate",
-        { license_key: licenseKey, license_key_instance_id: instanceId },
+        {
+          license_key: licenseKey,
+          license_key_instance_id: instanceId,
+          ...(devicePublicKey ? { device_public_key: devicePublicKey } : {}),
+        },
         true,
       ),
     deactivate: ({ licenseKey, instanceId }) =>

--- a/packages/core/src/license/licenseState.ts
+++ b/packages/core/src/license/licenseState.ts
@@ -1,6 +1,7 @@
 import { hostname as osHostname } from "node:os";
 import type { Db } from "../db/index.js";
 import type { SecretBox } from "../ai/settings/secretBox.js";
+import { generateDeviceKeyPair, unwrapBundleKey } from "./bundleKeyWrap.js";
 import { createDodoClient, type DodoClient } from "./dodoClient.js";
 import { createLicenseStore, type LicenseRecord, type LicenseStore } from "./licenseStore.js";
 
@@ -18,6 +19,7 @@ export type ActivateResult = { activated: true } | { activated: false; error: st
 export interface LicenseManager {
   getLicenseSnapshot(): LicenseSnapshot;
   getBundleKey(): string | undefined;
+  getBundleKeyId(): string | undefined;
   activate(key: string): Promise<ActivateResult>;
   deactivate(): Promise<void>;
   revalidate(): Promise<void>;
@@ -57,12 +59,28 @@ export function createLicenseManager(deps: LicenseManagerDeps): LicenseManager {
     },
 
     getBundleKey(): string | undefined {
-      return deps.store.read()?.bundleKey;
+      const record = deps.store.read();
+      if (!record?.bundleKey) return undefined;
+      if (!record.bundleKeyWrap) return record.bundleKey;
+      // Device-bound key: only unwraps with this device's private key, which
+      // lives inside this same (safeStorage-encrypted) record.
+      if (!record.devicePrivateKey) return undefined;
+      try {
+        return unwrapBundleKey(record.bundleKey, record.bundleKeyWrap, record.devicePrivateKey);
+      } catch (error) {
+        console.warn("licenseState: failed to unwrap device-bound bundle key:", error instanceof Error ? error.message : error);
+        return undefined;
+      }
+    },
+
+    getBundleKeyId(): string | undefined {
+      return deps.store.read()?.keyId;
     },
 
     async activate(key: string): Promise<ActivateResult> {
       const deviceName = deps.hostname();
-      const result = await deps.client.activate({ licenseKey: key, name: deviceName });
+      const device = generateDeviceKeyPair();
+      const result = await deps.client.activate({ licenseKey: key, name: deviceName, devicePublicKey: device.publicKey });
       if (!result.ok) return { activated: false, error: result.error };
       deps.store.write({
         key,
@@ -72,6 +90,9 @@ export function createLicenseManager(deps: LicenseManagerDeps): LicenseManager {
         lastOutcome: "success",
         bundleKey: result.data.bundleKey,
         keyId: result.data.keyId,
+        bundleKeyWrap: result.data.bundleKeyWrap,
+        devicePublicKey: device.publicKey,
+        devicePrivateKey: device.privateKey,
       });
       return { activated: true };
     },
@@ -91,13 +112,17 @@ export function createLicenseManager(deps: LicenseManagerDeps): LicenseManager {
     async revalidate(): Promise<void> {
       const record = deps.store.read();
       if (!record) return;
-      const result = await deps.client.validate({ licenseKey: record.key, instanceId: record.instanceId ?? undefined });
+      const result = await deps.client.validate({
+        licenseKey: record.key,
+        instanceId: record.instanceId ?? undefined,
+        devicePublicKey: record.devicePublicKey,
+      });
       if (!result.ok) {
         if (record.lastOutcome !== "invalid") deps.store.write({ ...record, lastOutcome: "network_fail" });
         return;
       }
       if (!result.data.valid) {
-        deps.store.write({ ...record, lastOutcome: "invalid", bundleKey: undefined, keyId: undefined });
+        deps.store.write({ ...record, lastOutcome: "invalid", bundleKey: undefined, keyId: undefined, bundleKeyWrap: undefined });
         return;
       }
       deps.store.write({
@@ -106,6 +131,7 @@ export function createLicenseManager(deps: LicenseManagerDeps): LicenseManager {
         lastOutcome: "success",
         bundleKey: result.data.bundleKey ?? record.bundleKey,
         keyId: result.data.keyId ?? record.keyId,
+        bundleKeyWrap: result.data.bundleKeyWrap ?? record.bundleKeyWrap,
       });
     },
   };
@@ -130,6 +156,10 @@ export function initLicenseManager(
 
 export function getActiveBundleKey(): string | undefined {
   return active?.getBundleKey();
+}
+
+export function getActiveBundleKeyId(): string | undefined {
+  return active?.getBundleKeyId();
 }
 
 export function getLicenseManager(): LicenseManager {

--- a/packages/core/src/license/licenseStore.ts
+++ b/packages/core/src/license/licenseStore.ts
@@ -3,6 +3,7 @@ import type { Db } from "../db/index.js";
 import { providerCredentials } from "../db/schema.js";
 import { LICENSE_PROVIDER_KEY } from "../ai/settings/credentialStore.js";
 import type { SecretBox } from "../ai/settings/secretBox.js";
+import type { BundleKeyWrap } from "./bundleKeyWrap.js";
 
 const LICENSE_PROVIDER = LICENSE_PROVIDER_KEY;
 
@@ -14,8 +15,13 @@ export interface LicenseRecord {
   deviceName: string;
   lastValidatedAt: string;
   lastOutcome: LicenseOutcome;
+  /** plaintext hex from a legacy Worker, or base64 ciphertext when bundleKeyWrap is set */
   bundleKey?: string;
   keyId?: string;
+  bundleKeyWrap?: BundleKeyWrap;
+  /** base64 SPKI/PKCS8 device keypair uploaded at activate; private key never leaves this record */
+  devicePublicKey?: string;
+  devicePrivateKey?: string;
 }
 
 export interface LicenseStore {

--- a/packages/core/src/pro/loader.ts
+++ b/packages/core/src/pro/loader.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getActiveBundleKey } from '../license/licenseState.js';
+import { isBundleKeyEnvAllowed } from '../license/licenseGate.js';
+import { getActiveBundleKey, getActiveBundleKeyId } from '../license/licenseState.js';
 import { setEncBundlePresent } from './bundleState.js';
 import { decryptProBlob, registerVirtualModules } from './encLoader.js';
 
@@ -10,6 +11,21 @@ export interface ProPayload {
 
 const NODE_PREFIX = 'node/';
 const WEB_PREFIX = 'web/';
+
+function resolveBundleKey(): { keyHex: string; expectedKeyId?: string } | null {
+  const licenseKey = getActiveBundleKey();
+  if (licenseKey) {
+    // The bundle must have been packed for exactly the key the server issued
+    // — a keyId mismatch means a stale key is decrypting a newer bundle (or
+    // vice versa), which is exactly what per-version key rotation relies on
+    // being caught.
+    return { keyHex: licenseKey, expectedKeyId: getActiveBundleKeyId() };
+  }
+  if (!isBundleKeyEnvAllowed()) return null;
+  const envKey = process.env.KANSOKU_BUNDLE_KEY;
+  if (!envKey) return null;
+  return { keyHex: envKey, expectedKeyId: process.env.KANSOKU_BUNDLE_KEY_ID };
+}
 
 export async function loadPro(appDir?: string): Promise<ProPayload | null> {
   if (!appDir) {
@@ -21,14 +37,19 @@ export async function loadPro(appDir?: string): Promise<ProPayload | null> {
   setEncBundlePresent(present);
   if (!present) return null;
 
-  const keyHex = getActiveBundleKey() ?? process.env.KANSOKU_BUNDLE_KEY;
-  if (!keyHex) {
+  const resolved = resolveBundleKey();
+  if (!resolved) {
     console.info('pro slot: encrypted bundle present but no key, running free');
     return null;
   }
 
   try {
-    const manifest = decryptProBlob(readFileSync(encPath), keyHex);
+    const manifest = decryptProBlob(readFileSync(encPath), resolved.keyHex);
+    if (resolved.expectedKeyId && manifest.keyId !== resolved.expectedKeyId) {
+      throw new Error(
+        `pro.enc keyId mismatch: bundle was packed for keyId=${manifest.keyId}, active key is keyId=${resolved.expectedKeyId}`,
+      );
+    }
     const nodeFiles = new Map<string, string>();
     const webFiles = new Map<string, Buffer>();
     for (const [rel, base64] of Object.entries(manifest.files)) {

--- a/packages/core/test/capabilities.test.ts
+++ b/packages/core/test/capabilities.test.ts
@@ -13,6 +13,7 @@ function fakeLicenseManager(licensed: boolean): LicenseManager {
   return {
     getLicenseSnapshot: () => ({ state: licensed ? 'licensed' : 'unlicensed' }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => ({}) as never,
     revalidate: async () => {},

--- a/packages/core/test/dodoClient.test.ts
+++ b/packages/core/test/dodoClient.test.ts
@@ -34,6 +34,28 @@ describe("dodoClient", () => {
     expect(JSON.parse(init.body)).toEqual({ license_key: "lic_1", name: "my-mac" });
   });
 
+  it("activate/validate include device_public_key only when provided", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(201, { id: "lki_abc" }))
+      .mockResolvedValueOnce(jsonResponse(200, { valid: true }));
+    const client = createDodoClient({ fetch: fetchMock, baseUrl: "https://worker.example" });
+
+    await client.activate({ licenseKey: "lic_1", name: "my-mac", devicePublicKey: "PUBKEY_B64" });
+    await client.validate({ licenseKey: "lic_1", instanceId: "lki_abc", devicePublicKey: "PUBKEY_B64" });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      license_key: "lic_1",
+      name: "my-mac",
+      device_public_key: "PUBKEY_B64",
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      license_key: "lic_1",
+      license_key_instance_id: "lki_abc",
+      device_public_key: "PUBKEY_B64",
+    });
+  });
+
   it("validate returns ok:true with valid:false as a normal (non-network) result", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { valid: false }));
     const client = createDodoClient({ fetch: fetchMock, baseUrl: "https://test.dodopayments.com" });

--- a/packages/core/test/features.test.ts
+++ b/packages/core/test/features.test.ts
@@ -16,6 +16,7 @@ function fakeLicenseManager(licensed: boolean): LicenseManager {
   return {
     getLicenseSnapshot: () => ({ state: licensed ? 'licensed' : 'unlicensed' }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => ({}) as never,
     revalidate: async () => {},

--- a/packages/core/test/licenseSchedule.test.ts
+++ b/packages/core/test/licenseSchedule.test.ts
@@ -6,6 +6,7 @@ function fakeManager(revalidate: () => Promise<void>): LicenseManager {
   return {
     getLicenseSnapshot: () => ({ state: "unlicensed" }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => {},
     revalidate,

--- a/packages/core/test/licenseState.test.ts
+++ b/packages/core/test/licenseState.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { generateDeviceKeyPair, wrapBundleKey } from "../src/license/bundleKeyWrap.js";
 import type { DodoClient, DodoResult } from "../src/license/dodoClient.js";
 import { createLicenseManager, type LicenseManagerDeps } from "../src/license/licenseState.js";
 import type { LicenseRecord, LicenseStore } from "../src/license/licenseStore.js";
@@ -142,16 +143,22 @@ describe("licenseState activate", () => {
     const result = await manager.activate("lic_1234567890");
 
     expect(result).toEqual({ activated: true });
-    expect(client.activate).toHaveBeenCalledWith({ licenseKey: "lic_1234567890", name: "my-mac" });
-    expect(store.read()).toEqual({
+    expect(client.activate).toHaveBeenCalledWith({
+      licenseKey: "lic_1234567890",
+      name: "my-mac",
+      devicePublicKey: expect.any(String),
+    });
+    const stored = store.read();
+    expect(stored).toMatchObject({
       key: "lic_1234567890",
       instanceId: "lki_new",
       deviceName: "my-mac",
       lastValidatedAt: new Date(now()).toISOString(),
       lastOutcome: "success",
-      bundleKey: undefined,
-      keyId: undefined,
     });
+    expect(stored?.bundleKey).toBeUndefined();
+    expect(stored?.devicePublicKey).toEqual(expect.any(String));
+    expect(stored?.devicePrivateKey).toEqual(expect.any(String));
     expect(manager.getLicenseSnapshot().state).toBe("licensed");
   });
 
@@ -367,5 +374,97 @@ describe("licenseState revalidate", () => {
     await manager.revalidate();
 
     expect(store.read()).toMatchObject({ bundleKey: "b".repeat(64), keyId: "key-1" });
+  });
+});
+
+
+describe("licenseState device-bound bundleKey", () => {
+  const BUNDLE_KEY_HEX = "b".repeat(64);
+
+  it("activate stores the wrapped key + device keypair and getBundleKey unwraps it", async () => {
+    // Simulate the Worker: wrap the bundle key to whatever device public key
+    // the client uploaded.
+    const client = fakeClient({
+      activate: vi.fn(async (input: { devicePublicKey?: string }) => {
+        const { wrapped, wrap } = wrapBundleKey(BUNDLE_KEY_HEX, input.devicePublicKey!);
+        return { ok: true, data: { id: "lki_new", bundleKey: wrapped, keyId: "key-1", bundleKeyWrap: wrap } };
+      }) as DodoClient["activate"],
+    });
+    const { manager, store } = harness({ client });
+
+    await manager.activate("lic_1234567890");
+
+    const stored = store.read();
+    expect(stored?.bundleKeyWrap?.alg).toBe("p256-hkdf-sha256-aes256gcm");
+    expect(stored?.bundleKey).not.toBe(BUNDLE_KEY_HEX);
+    expect(manager.getBundleKey()).toBe(BUNDLE_KEY_HEX);
+    expect(manager.getBundleKeyId()).toBe("key-1");
+  });
+
+  it("getBundleKey is undefined when the record carries a wrapped key but no device private key", () => {
+    const device = generateDeviceKeyPair();
+    const { wrapped, wrap } = wrapBundleKey(BUNDLE_KEY_HEX, device.publicKey);
+    const { manager } = harness({
+      store: fakeStore({
+        key: "lic_1234567890",
+        instanceId: "lki_abc",
+        deviceName: "my-mac",
+        lastValidatedAt: "2026-07-14T00:00:00.000Z",
+        lastOutcome: "success",
+        bundleKey: wrapped,
+        bundleKeyWrap: wrap,
+        keyId: "key-1",
+        // no devicePrivateKey — simulates a record copied off this device
+      }),
+    });
+
+    expect(manager.getBundleKey()).toBeUndefined();
+  });
+
+  it("getBundleKey returns the plaintext key for legacy (unwrapped) records", () => {
+    const { manager } = harness({
+      store: fakeStore({
+        key: "lic_1234567890",
+        instanceId: "lki_abc",
+        deviceName: "my-mac",
+        lastValidatedAt: "2026-07-14T00:00:00.000Z",
+        lastOutcome: "success",
+        bundleKey: BUNDLE_KEY_HEX,
+        keyId: "key-1",
+      }),
+    });
+
+    expect(manager.getBundleKey()).toBe(BUNDLE_KEY_HEX);
+  });
+
+  it("revalidate uploads the stored device public key and refreshes the wrapped key", async () => {
+    const device = generateDeviceKeyPair();
+    const record: LicenseRecord = {
+      key: "lic_1234567890",
+      instanceId: "lki_abc",
+      deviceName: "my-mac",
+      lastValidatedAt: "2026-07-01T00:00:00.000Z",
+      lastOutcome: "success",
+      devicePublicKey: device.publicKey,
+      devicePrivateKey: device.privateKey,
+    };
+    const client = fakeClient({
+      validate: vi.fn(async (input: { devicePublicKey?: string }) => {
+        const { wrapped, wrap } = wrapBundleKey(BUNDLE_KEY_HEX, input.devicePublicKey!);
+        return { ok: true, data: { valid: true, bundleKey: wrapped, keyId: "key-2", bundleKeyWrap: wrap } };
+      }) as DodoClient["validate"],
+    });
+    const { manager, store } = harness({ store: fakeStore(record), client });
+
+    await manager.revalidate();
+
+    expect(client.validate).toHaveBeenCalledWith({
+      licenseKey: "lic_1234567890",
+      instanceId: "lki_abc",
+      devicePublicKey: device.publicKey,
+    });
+    expect(store.read()?.bundleKeyWrap?.alg).toBe("p256-hkdf-sha256-aes256gcm");
+    expect(manager.getBundleKey()).toBe(BUNDLE_KEY_HEX);
+    expect(manager.getBundleKeyId()).toBe("key-2");
   });
 });

--- a/packages/core/test/pro-loader.test.ts
+++ b/packages/core/test/pro-loader.test.ts
@@ -1,13 +1,19 @@
+import { createCipheriv, randomBytes } from 'node:crypto';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, it } from 'vitest';
+import { setLicenseManagerForTests, type LicenseManager } from '../src/license/licenseState.js';
 import { loadPro } from '../src/pro/loader.js';
 import { hasEncBundle } from '../src/pro/bundleState.js';
 
 const roots: string[] = [];
 afterEach(() => {
   while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+  setLicenseManagerForTests(null);
+  delete process.env.KANSOKU_BUNDLE_KEY;
+  delete process.env.KANSOKU_BUNDLE_KEY_ID;
 });
 
 function stageAppDir(): string {
@@ -15,6 +21,31 @@ function stageAppDir(): string {
   roots.push(root);
   mkdirSync(join(root, 'pro'), { recursive: true });
   return root;
+}
+
+const ENV_KEY_HEX = '00'.repeat(32);
+
+function packEnc(keyId: string, keyHex: string): Buffer {
+  const manifest = {
+    keyId,
+    files: { 'web/entry.mjs': Buffer.from('export const marker = 1;\n').toString('base64') },
+  };
+  const gz = gzipSync(Buffer.from(JSON.stringify(manifest)));
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', Buffer.from(keyHex, 'hex'), iv);
+  const ct = Buffer.concat([cipher.update(gz), cipher.final()]);
+  return Buffer.concat([Buffer.from('KPRO1', 'utf8'), iv, cipher.getAuthTag(), ct]);
+}
+
+function fakeLicenseManager(keyHex: string, keyId?: string): LicenseManager {
+  return {
+    getLicenseSnapshot: () => ({ state: 'licensed' }),
+    getBundleKey: () => keyHex,
+    getBundleKeyId: () => keyId,
+    activate: async () => ({ activated: true }),
+    deactivate: async () => {},
+    revalidate: async () => {},
+  };
 }
 
 describe('loadPro', () => {
@@ -47,5 +78,53 @@ describe('loadPro', () => {
 
     await loadPro();
     expect(hasEncBundle()).toBe(false);
+  });
+
+  it('loads a bundle whose keyId matches KANSOKU_BUNDLE_KEY_ID', async () => {
+    const root = stageAppDir();
+    writeFileSync(join(root, 'pro', 'pro.enc'), packEnc('key-1', ENV_KEY_HEX));
+    process.env.KANSOKU_BUNDLE_KEY = ENV_KEY_HEX;
+    process.env.KANSOKU_BUNDLE_KEY_ID = 'key-1';
+
+    const payload = await loadPro(root);
+
+    expect(payload?.webFiles.get('entry.mjs')?.toString('utf8')).toBe('export const marker = 1;\n');
+  });
+
+  it('runs free when the env keyId does not match the bundle keyId', async () => {
+    const root = stageAppDir();
+    writeFileSync(join(root, 'pro', 'pro.enc'), packEnc('key-2', ENV_KEY_HEX));
+    process.env.KANSOKU_BUNDLE_KEY = ENV_KEY_HEX;
+    process.env.KANSOKU_BUNDLE_KEY_ID = 'key-1';
+
+    await expect(loadPro(root)).resolves.toBeNull();
+  });
+
+  it('runs free when the license-record keyId does not match the bundle keyId', async () => {
+    const root = stageAppDir();
+    writeFileSync(join(root, 'pro', 'pro.enc'), packEnc('key-2', ENV_KEY_HEX));
+    setLicenseManagerForTests(fakeLicenseManager(ENV_KEY_HEX, 'key-1'));
+
+    await expect(loadPro(root)).resolves.toBeNull();
+  });
+
+  it('loads via the license-record key when its keyId matches the bundle', async () => {
+    const root = stageAppDir();
+    writeFileSync(join(root, 'pro', 'pro.enc'), packEnc('key-1', ENV_KEY_HEX));
+    setLicenseManagerForTests(fakeLicenseManager(ENV_KEY_HEX, 'key-1'));
+
+    const payload = await loadPro(root);
+
+    expect(payload?.webFiles.get('entry.mjs')?.toString('utf8')).toBe('export const marker = 1;\n');
+  });
+
+  it('still loads a legacy license record without a keyId (no mismatch to check)', async () => {
+    const root = stageAppDir();
+    writeFileSync(join(root, 'pro', 'pro.enc'), packEnc('key-1', ENV_KEY_HEX));
+    setLicenseManagerForTests(fakeLicenseManager(ENV_KEY_HEX, undefined));
+
+    const payload = await loadPro(root);
+
+    expect(payload).not.toBeNull();
   });
 });

--- a/packages/core/test/symbolsProHooksRouting.test.ts
+++ b/packages/core/test/symbolsProHooksRouting.test.ts
@@ -16,6 +16,7 @@ function fakeLicenseManager(): LicenseManager {
   return {
     getLicenseSnapshot: () => ({ state: 'licensed' }),
     getBundleKey: () => undefined,
+    getBundleKeyId: () => undefined,
     activate: async () => ({ activated: true }),
     deactivate: async () => ({}) as never,
     revalidate: async () => {},


### PR DESCRIPTION
Cherry-pick of `670bbce` (feat(license): per-version bundle key rotation with keyId verification), which existed on the previous main lineage (`ee6ddc2`, CI green) but was dropped when main was force-moved to the `ccb6700` lineage before #69 merged.

This is why main CI is red since #69: the #67 seam tests construct `LicenseManager` fakes with `getBundleKeyId`, which only exists with this commit.

Clean cherry-pick, zero conflicts. Verified locally: core/server typecheck green, core 898 tests, license-worker and desktop suites pass.