### PR TITLE
fix(bench): give advance_trade an object-shaped tool schema

### DIFF
--- a/packages/bench/src/schema/episode.ts
+++ b/packages/bench/src/schema/episode.ts
@@ -47,6 +47,29 @@ export const episodeTradeActionSchema = Type.Union([
 
 export type EpisodeTradeAction = Static<typeof episodeTradeActionSchema>;
 
+// Wire shape for the advance_trade tool. OpenAI-compatible function schemas must have a single
+// top-level `type: "object"` — DeepSeek rejects the union above outright — so the variants are
+// flattened into one discriminated object. Per-variant constraints are still enforced: the runner
+// re-checks every call against episodeTradeActionSchema, so any new variant must land in both.
+export const episodeTradeActionToolSchema = Type.Object(
+  {
+    type: Type.Union([
+      Type.Literal('hold'),
+      Type.Literal('amend'),
+      Type.Literal('cancel'),
+      Type.Literal('exit_next_open'),
+    ]),
+    bars: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
+    period: Type.Optional(
+      Type.Union([Type.Literal('h1'), Type.Literal('day'), Type.Literal('week')]),
+    ),
+    stop: Type.Optional(Type.Number()),
+    target: Type.Optional(Type.Number()),
+    ...optionalReason,
+  },
+  { additionalProperties: false },
+);
+
 export const episodeActionSchema = Type.Union([
   Type.Object({ type: Type.Literal('observe') }, { additionalProperties: false }),
   Type.Object(

--- a/packages/bench/src/schema/index.ts
+++ b/packages/bench/src/schema/index.ts
@@ -21,6 +21,7 @@ export {
   episodeActionSchema,
   episodeSubmissionSchema,
   episodeTradeActionSchema,
+  episodeTradeActionToolSchema,
   episodeAnswerSchema,
   episodeClosedTradeSchema,
   episodeTradeResultSchema,

--- a/packages/bench/test/schema/episode.test.ts
+++ b/packages/bench/test/schema/episode.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { TSchema } from 'typebox';
+import { Value } from 'typebox/value';
+import {
+  episodeTradeActionSchema,
+  episodeTradeActionToolSchema,
+} from '../../src/schema/episode.js';
+
+const variants = (
+  episodeTradeActionSchema as unknown as {
+    anyOf: Array<{ properties: Record<string, { const?: string }> }>;
+  }
+).anyOf;
+const tool = episodeTradeActionToolSchema as unknown as {
+  type: string;
+  properties: Record<string, TSchema>;
+};
+
+describe('episodeTradeActionToolSchema', () => {
+  it('is a single top-level object, as OpenAI-compatible function schemas require', () => {
+    expect(tool.type).toBe('object');
+  });
+
+  it('exposes every field and every action of the strict union', () => {
+    for (const variant of variants) {
+      for (const field of Object.keys(variant.properties)) {
+        expect(Object.keys(tool.properties)).toContain(field);
+      }
+      expect(Value.Check(tool.properties.type, variant.properties.type.const)).toBe(true);
+    }
+  });
+
+  it('accepts a hold batch and an amend the strict union also accepts', () => {
+    const hold = { type: 'hold', bars: 4, period: 'day' };
+    const amend = {
+      type: 'amend',
+      stop: 98.4,
+      reason: { category: 'profit_protection', summary: 'trail stop to breakeven at B37' },
+    };
+    for (const action of [hold, amend]) {
+      expect(Value.Check(episodeTradeActionToolSchema, action)).toBe(true);
+      expect(Value.Check(episodeTradeActionSchema, action)).toBe(true);
+    }
+  });
+
+  it('leaves cross-action field mixing for the runtime union check to reject', () => {
+    const mixed = { type: 'cancel', bars: 3 };
+    expect(Value.Check(episodeTradeActionToolSchema, mixed)).toBe(true);
+    expect(Value.Check(episodeTradeActionSchema, mixed)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Running the episode bench against `deepseek/deepseek-v4-pro` failed on every cell before the first tool call:

```
400: Invalid schema for function 'advance_trade':
schema must be a JSON Schema of 'type: "object"', got 'type: null'.
```

`advance_trade` passed `episodeTradeActionSchema` — a top-level `Type.Union` — straight through as its parameter schema, which renders as `{"anyOf": [...]}` with no `type`. OpenAI-compatible function calling requires a single top-level `type: "object"`. The OpenAI/codex endpoint tolerates the union; DeepSeek does not, and any other provider with a strict validator will reject it too.

## What

- `episodeTradeActionToolSchema`: the four action variants flattened into one discriminated object (`type` + all fields optional).
- `packages/bench/test/schema/episode.test.ts` guards against drift — every field and every action literal of the strict union must be present in the tool schema, and cross-action mixing must still fail the union check.

The strict union is untouched and still the enforcement point: the runner calls `Value.Check(episodeTradeActionSchema, action)` on every tool call, so `{"type":"cancel","bars":3}` or an `amend` without a `reason` is rejected exactly as before.

## Note for benchmark comparability

Models now see a different `advance_trade` schema and a slightly expanded description (which field belongs to which action). Runs recorded before this change are not strictly the same condition as runs after it.

## Verification

- `packages/bench`: `tsc --noEmit` clean, new schema test passes (4/4)
- `apps/pro`: `tsc --noEmit` clean, `vitest run test/bench` passes (84/84)
- End to end: `deepseek/deepseek-v4-pro` on `v2-blind-pilot` / `swing-ASSET001-2026-02-05-01` now completes the full 280-bar episode (66 tool calls, `completed/horizon`) instead of dying at `api_error`.

The runner-side counterpart is kansoku-pro `feat/bench-dotenv-and-tool-schema`, which imports the new export — merge this one first.