### PR TITLE
fix(bench): only judge entry-bar exits on provably post-fill price

### DIFF
--- a/packages/bench/src/episode/engine.ts
+++ b/packages/bench/src/episode/engine.ts
@@ -451,6 +451,19 @@ function updateExcursions(position: PositionState, bar: RawBar): PositionState {
   };
 }
 
+// An intrabar fill splits its own bar: everything before the fill belongs to the pending order,
+// not to the position, and OHLC cannot say when inside the bar the extremes happened. Only the
+// extreme on the far side of the approach is provably post-fill — price had to travel through the
+// entry to reach it — so the near-side extreme collapses to the fill price or the close, whichever
+// is worse for the side it replaces. Without this, a breakout order that filled after a dip is
+// stopped out on its own entry bar, and a limit order that filled after a spike takes profit on it.
+function postFillBar(bar: RawBar, entryPrice: number, roseIntoFill: boolean): RawBar {
+  const close = numberOf(bar.close);
+  return roseIntoFill
+    ? { ...bar, low: Math.min(entryPrice, close) }
+    : { ...bar, high: Math.max(entryPrice, close) };
+}
+
 function stopHit(position: PositionState, bar: RawBar): boolean {
   return position.direction === 'long'
     ? numberOf(bar.low) <= position.stop
@@ -670,10 +683,13 @@ function advanceEpisodeSingle(
   }
 
   let fillTiming: EntryFill['timing'] | null = null;
+  let roseIntoFill = false;
   if (working.phase === 'pending' && working.order) {
     const order = { ...working.order, waitedBars: working.order.waitedBars + 1 };
-    const fill = entryFill(order, visibleReferencePrice(question, state), bar);
+    const reference = visibleReferencePrice(question, state);
+    const fill = entryFill(order, reference, bar);
     if (fill !== null) {
+      roseIntoFill = order.entry >= reference;
       const fillPrice = fill.price;
       const initialRisk = Math.abs(fillPrice - order.initialStop);
       if (initialRisk === 0) throw new Error('filled entry equals the initial stop');
@@ -749,15 +765,19 @@ function advanceEpisodeSingle(
       return { state: working, asOf: bar.time, bar, event, terminal: false, result: null };
     }
   }
-  const position = updateExcursions(working.position, bar);
-  working = { ...working, position };
   const allowOpenGap = fillTiming !== 'intrabar';
+  const exitBar =
+    fillTiming === 'intrabar'
+      ? postFillBar(bar, working.position.entryPrice, roseIntoFill)
+      : bar;
+  const position = updateExcursions(working.position, exitBar);
+  working = { ...working, position };
 
-  if (stopHit(position, bar)) {
+  if (stopHit(position, exitBar)) {
     working = closePosition(
       working,
       'stop',
-      { time: bar.time, price: stopExitPrice(position, bar, allowOpenGap) },
+      { time: bar.time, price: stopExitPrice(position, exitBar, allowOpenGap) },
       options,
     );
     if (remainingEpisodeBars(working, question) === 0) {
@@ -772,11 +792,11 @@ function advanceEpisodeSingle(
       result: null,
     };
   }
-  if (targetHit(position, bar)) {
+  if (targetHit(position, exitBar)) {
     working = closePosition(
       working,
       'target',
-      { time: bar.time, price: targetExitPrice(position, bar, allowOpenGap) },
+      { time: bar.time, price: targetExitPrice(position, exitBar, allowOpenGap) },
       options,
     );
     if (remainingEpisodeBars(working, question) === 0) {

--- a/packages/bench/test/episode/engine.test.ts
+++ b/packages/bench/test/episode/engine.test.ts
@@ -116,6 +116,34 @@ describe('episode engine', () => {
     expect(finished.result!.trades!.map((trade) => trade.direction)).toEqual(['long', 'short']);
   });
 
+  it('does not stop out on the entry bar using a low the order could only have reached before filling', () => {
+    // Stop entry at 103 fills only on the way up from a 99 open, so the 96 low belongs to the
+    // pending window, not to the position. Only the close is provably after the fill.
+    const q = question([
+      bar('2026-03-23T14:30:00Z', 99, 104, 96, 103.5),
+      bar('2026-03-23T15:30:00Z', 103.5, 105, 103, 104),
+    ]);
+    const submitted = submitEpisode(createEpisodeState(), q, prediction('long', 103, 97, 110));
+    const filled = advanceEpisode(submitted.state, q, reasoned({ type: 'hold' }));
+    expect(filled.event).not.toBe('stop_hit');
+    expect(filled.state.phase).toBe('open');
+    expect(filled.state.trades).toHaveLength(0);
+  });
+
+  it('does not take profit on the entry bar using a high the order could only have reached before filling', () => {
+    // Limit entry at 98 fills on the way down from a 99.5 open, so the 105 high precedes the fill.
+    const q = question([
+      bar('2026-03-23T14:30:00Z', 99.5, 105, 97.5, 98.5),
+      bar('2026-03-23T15:30:00Z', 98.5, 99, 98, 98.5),
+    ]);
+    const submitted = submitEpisode(createEpisodeState(), q, prediction('long', 98, 95, 104));
+    const filled = advanceEpisode(submitted.state, q, reasoned({ type: 'hold' }));
+    expect(filled.event).not.toBe('target_hit');
+    expect(filled.state.phase).toBe('open');
+    // Favourable excursion on the entry bar may only count the close, not the pre-fill high.
+    expect(filled.state.position!.mfeR).toBeCloseTo(0.5 / 3, 6);
+  });
+
   it('keeps observation optional and only activates a delayed order on the following hidden bar', () => {
     const q = question();
     const observed = observeEpisode(createEpisodeState(), q);
@@ -219,7 +247,9 @@ describe('episode engine', () => {
   });
 
   it('prices a same-bar stop from an intrabar entry at the stop instead of the earlier open', () => {
-    const q = question([bar('2026-02-06T14:30:00Z', 98.147166, 100.917579, 97.989683, 100.284433)]);
+    // The close sits below the stop so the stop is provably reached after the intrabar fill; the
+    // 97.99 low alone would not trigger it, since a breakout order only fills on the way up.
+    const q = question([bar('2026-02-06T14:30:00Z', 98.147166, 100.917579, 97.989683, 98.4)]);
     const result = advanceEpisode(
       submitEpisode(createEpisodeState(), q, prediction('long', 100.1, 98.6, 101.8)).state,
       q,


### PR DESCRIPTION
## The defect

An intrabar fill splits its own bar. Everything before the fill belongs to the pending order, not to the position — and OHLC cannot say when inside the bar the extremes happened. The engine used the whole bar regardless, so the pending window's price action was charged to the position:

- **Phantom stop-outs.** A breakout order only fills on the way *up* through its entry, so the bar's low is very likely from before the fill. `swing-ASSET001`'s first replay bar (open 98.15, high 100.92, low 97.99) filled a 100.1 stop-entry and immediately closed it at a 98.6 stop — a level the position was never in the market for.
- **Phantom targets.** The mirror case: a limit order fills on the way *down*, so the bar's high precedes the fill and could hand it a free target hit.
- **Inflated excursions.** `mfeR` / `maeR` counted the pre-fill range too.

Across the current result set **33 of 220 trades exited on their entry bar — 25 stops and 8 targets.** This is not a corner case, and it is not conservative: it invents losses for breakout entries and gifts wins to limit entries.

## The fix

Restrict the entry bar to what the fill proves. Price had to travel through the entry to reach the far-side extreme, so that extreme stands; the near-side extreme collapses to the fill price or the close, whichever is worse for the side it replaces. Exit detection, exit pricing and excursions all read the restricted bar. Only intrabar fills are affected — an open fill already owns its whole bar.

No data is invented: the restricted bar contains only prices the position provably traded through.

## The existing test

`prices a same-bar stop from an intrabar entry at the stop instead of the earlier open` was written from this exact ASSET001 bar and locked the old behaviour in. Its subject — an intrabar fill exits at the stop, not at the earlier open — is preserved; the bar's close moved below the stop, which is what makes the stop provably post-fill.

Two new tests cover the two phantom cases directly.

## Consequences

**Results recorded before this change are not comparable with results after it.** Every existing run under `packages/bench/results/` needs re-running before its numbers are quoted again. The aggregate across the current set is −18.0R; removing 25 phantom stops and 8 phantom targets is likely to move that by more than ten R, plausibly changing its sign.

Considered and rejected: flagging same-bar fill-and-exit as ambiguous and reporting optimistic and conservative results side by side. That is the more rigorous treatment and it belongs on the roadmap, but it changes the report and score surfaces; this PR is the minimal correctness fix.

## Verification

`pnpm --filter @kansoku/bench test` — 285/285 pass. `tsc --noEmit` and `eslint` clean on both changed files.