### PR TITLE
feat(bench): reject amendments that widen an open position's stop

### DIFF
--- a/packages/bench/src/episode/engine.ts
+++ b/packages/bench/src/episode/engine.ts
@@ -419,6 +419,17 @@ function visibleReferencePrice(question: Question, state: EpisodeState): number 
   return numberOf(last.close);
 }
 
+// A guardrail refusal is a legal move the risk boundary forbids, not a malformed call. Runners
+// must be able to tell the two apart: a malformed call says the model cannot drive the protocol,
+// while a guardrail hit says it tried something the engine exists to prevent. Conflating them
+// throws away an otherwise complete episode over a single rejected amendment.
+export class EpisodeGuardrailError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EpisodeGuardrailError';
+  }
+}
+
 function applyAmendment(
   position: PositionState,
   action: Extract<EpisodeTradeAction, { type: 'amend' }>,
@@ -433,7 +444,7 @@ function applyAmendment(
   const widensStop = position.direction === 'long' ? stop < position.stop : stop > position.stop;
   if (wrongStop) throw new Error(`amended ${position.direction} stop crosses the visible price`);
   if (widensStop)
-    throw new Error(
+    throw new EpisodeGuardrailError(
       `amended ${position.direction} stop increases the risk already committed; an open position's stop may only tighten`,
     );
   if (wrongTarget)

--- a/packages/bench/src/episode/engine.ts
+++ b/packages/bench/src/episode/engine.ts
@@ -430,7 +430,12 @@ function applyAmendment(
   const target = action.target == null ? position.target : finite(action.target, 'target');
   const wrongStop = position.direction === 'long' ? stop >= reference : stop <= reference;
   const wrongTarget = position.direction === 'long' ? target <= reference : target >= reference;
+  const widensStop = position.direction === 'long' ? stop < position.stop : stop > position.stop;
   if (wrongStop) throw new Error(`amended ${position.direction} stop crosses the visible price`);
+  if (widensStop)
+    throw new Error(
+      `amended ${position.direction} stop increases the risk already committed; an open position's stop may only tighten`,
+    );
   if (wrongTarget)
     throw new Error(`amended ${position.direction} target crosses the visible price`);
   return { ...position, stop, target };

--- a/packages/bench/src/schema/episode.ts
+++ b/packages/bench/src/schema/episode.ts
@@ -208,6 +208,7 @@ const metricsSchema = Type.Object(
     toolCalls: Type.Integer({ minimum: 0 }),
     inputTokens: Type.Integer({ minimum: 0 }),
     outputTokens: Type.Integer({ minimum: 0 }),
+    guardrailHits: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/packages/bench/test/episode/engine.test.ts
+++ b/packages/bench/test/episode/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   advanceEpisode,
   createEpisodeState,
+  EpisodeGuardrailError,
   observeEpisode,
   submitEpisode,
 } from '../../src/episode/engine.js';
@@ -183,7 +184,7 @@ describe('episode engine', () => {
       reasoned({ type: 'hold' }),
     );
     expect(() => advanceEpisode(longFilled.state, q, reasoned({ type: 'amend', stop: 94 }))).toThrow(
-      /may only tighten/,
+      EpisodeGuardrailError,
     );
 
     const shortFilled = advanceEpisode(
@@ -193,7 +194,11 @@ describe('episode engine', () => {
     );
     expect(() =>
       advanceEpisode(shortFilled.state, q, reasoned({ type: 'amend', stop: 111 })),
-    ).toThrow(/may only tighten/);
+    ).toThrow(EpisodeGuardrailError);
+    // A malformed call must stay distinguishable from a guardrail refusal.
+    expect(() => advanceEpisode(longFilled.state, q, reasoned({ type: 'amend' }))).not.toThrow(
+      EpisodeGuardrailError,
+    );
   });
 
   it('still accepts a tightening amendment and an unchanged stop', () => {

--- a/packages/bench/test/episode/engine.test.ts
+++ b/packages/bench/test/episode/engine.test.ts
@@ -175,6 +175,40 @@ describe('episode engine', () => {
     expect(stopped.state.trades[0]).toMatchObject({ exitReason: 'stop', grossR: 0.2 });
   });
 
+  it('rejects an amendment that moves the stop away from entry, in either direction', () => {
+    const q = question();
+    const longFilled = advanceEpisode(
+      submitEpisode(createEpisodeState(), q, prediction('long', 100, 95, 120)).state,
+      q,
+      reasoned({ type: 'hold' }),
+    );
+    expect(() => advanceEpisode(longFilled.state, q, reasoned({ type: 'amend', stop: 94 }))).toThrow(
+      /may only tighten/,
+    );
+
+    const shortFilled = advanceEpisode(
+      submitEpisode(createEpisodeState(), q, prediction('short', 105, 110, 90)).state,
+      q,
+      reasoned({ type: 'hold' }),
+    );
+    expect(() =>
+      advanceEpisode(shortFilled.state, q, reasoned({ type: 'amend', stop: 111 })),
+    ).toThrow(/may only tighten/);
+  });
+
+  it('still accepts a tightening amendment and an unchanged stop', () => {
+    const q = question();
+    const filled = advanceEpisode(
+      submitEpisode(createEpisodeState(), q, prediction('long', 100, 95, 120)).state,
+      q,
+      reasoned({ type: 'hold' }),
+    );
+    expect(advanceEpisode(filled.state, q, reasoned({ type: 'amend', stop: 97 })).state.position)
+      .toMatchObject({ stop: 97 });
+    expect(advanceEpisode(filled.state, q, reasoned({ type: 'amend', target: 118 })).state.position)
+      .toMatchObject({ stop: 95, target: 118 });
+  });
+
   it('executes a manual exit at the next bar open and keeps the episode active', () => {
     const q = question();
     const filled = advanceEpisode(


### PR DESCRIPTION
## Why

`applyAmendment` only checked that an amended stop had not crossed the visible price. A position could therefore move its stop *away* from entry and enlarge the loss it had already committed to — the one stop rule every trading desk enforces in its risk system rather than in prose, and the one the episode discipline never states. `TD-EXIT-01` governs only give-back after +1R, which implicitly leaves widening before +1R wide open.

This is a hard risk boundary, not a strategy assumption: it does not need benchmark evidence to justify, and it is the kind of rule that belongs in the engine rather than in a prompt, since a prompt-level limit with a justification clause is not a limit at all.

## What

An open position's stop may only tighten. `long` stops may not move down, `short` stops may not move up. The amendment is rejected with a message the model can act on, exactly as a stop crossing the visible price already is. Targets are unaffected.

## Blast radius

Measured across the current result set: **2 of 220 trades ever widened a stop** — and both records are the same trade captured in two runs, widening by 0.03%. Models already comply, so enforcement changes essentially no existing behaviour; it closes the hole before a model finds it.

Rejected amendments surface through the runner's existing protocol-error path, so an episode that attempts one is recorded as `protocol_violation`. Given the measured rate that is acceptable today. If a future rule set makes guardrail hits common, they should become a counted metric instead of invalidating the episode — that belongs with the trade-budget work, not here.

## Verification

`pnpm --filter @kansoku/bench test` — 281/281 pass, including two new tests covering rejection in both directions and continued acceptance of tightening and target-only amendments. `tsc --noEmit` and `eslint` clean.

Independent of #75 and #76; all three touch different code paths.