### PR TITLE
feat(bench): audit the citations models put in their reasons

### DIFF
--- a/packages/bench/src/episode/reasonAudit.ts
+++ b/packages/bench/src/episode/reasonAudit.ts
@@ -1,0 +1,136 @@
+import type { RawBar } from '@kansoku/shared/types';
+import type { EpisodeActionRecord } from '../schema/episode.js';
+import type { Question } from '../schema/question.js';
+
+// Findings are review candidates, not violations. A reason legitimately names prices the tape has
+// never printed — targets, stops, invalidation levels, resting order prices — and legitimately
+// looks ahead to bars it has not seen. Free text cannot be separated into retrospective claims and
+// forward plans by pattern matching, so treat a finding as "worth a human read", and read the
+// unaudited counts as the honest measure: how much of a reason is checkable at all.
+export interface ReasonFinding {
+  step: number;
+  kind: 'future_bar' | 'impossible_price';
+  cited: number;
+  visible: string;
+  summary: string;
+}
+
+export interface ReasonAudit {
+  reasons: number;
+  reasonsWithCitation: number;
+  priceCitations: number;
+  barCitations: number;
+  findings: ReasonFinding[];
+}
+
+// A cited bar index may legitimately be off by one: the runtime status line numbers bars from 1
+// while the prompt talks about B0, and models mix the two. Only a reference beyond that slack can
+// be a claim about a bar the model has not been shown.
+const BAR_INDEX_SLACK = 2;
+
+// Prices are only checkable when they are recognisably prices. A bare integer is far more often a
+// period length, a bar count or a percentage, so decimals are required, and the value must sit in
+// the same order of magnitude as the tape. Anything outside that is left unaudited rather than
+// guessed at.
+const PRICE_BAND_LOW = 0.3;
+const PRICE_BAND_HIGH = 3;
+
+// Models quote prices rounded to one or two decimals, so an exact range test reports the tape's
+// own extremes as impossible: 146.23 for a 146.232051 high, 94.3 for a 94.32 low. The tolerance
+// covers one-decimal rounding and nothing wider.
+const ROUNDING_TOLERANCE = 0.05;
+
+const NUMBER_WITH_UNIT = /(\d+(?:\.\d+)?)\s*(r\b|%|％|根|倍|日|周|月|天|次|笔|bars?\b|k\b|m\b)/gi;
+const DATE_LIKE = /\d{4}(?:-\d{2}){1,2}|\d{1,2}[/月-]\d{1,2}/g;
+const DECIMAL = /\d+\.\d+/g;
+const BAR_REF = /\bb(\d{1,3})\b/gi;
+
+function numberOf(value: string | number): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function visibleBars(question: Question, at: string): { bars: RawBar[]; cursor: number } {
+  const replay = question.replay.bars;
+  const cursor = replay.findIndex((bar) => bar.time === at);
+  const pre = question.fixtures.kline['1h'] ?? [];
+  if (cursor < 0) return { bars: [...pre], cursor: -1 };
+  return { bars: [...pre, ...replay.slice(0, cursor + 1)], cursor };
+}
+
+function priceCandidates(summary: string, reference: number): number[] {
+  const masked = summary.replaceAll(DATE_LIKE, ' ').replaceAll(NUMBER_WITH_UNIT, ' ');
+  const out: number[] = [];
+  for (const token of masked.match(DECIMAL) ?? []) {
+    const value = Number(token);
+    if (!Number.isFinite(value)) continue;
+    if (value < reference * PRICE_BAND_LOW || value > reference * PRICE_BAND_HIGH) continue;
+    out.push(value);
+  }
+  return out;
+}
+
+function barCandidates(summary: string): number[] {
+  const out: number[] = [];
+  for (const match of summary.matchAll(BAR_REF)) {
+    const value = Number(match[1]);
+    if (Number.isFinite(value)) out.push(value);
+  }
+  return out;
+}
+
+export function auditEpisodeReasons(
+  question: Question,
+  actions: readonly EpisodeActionRecord[],
+): ReasonAudit {
+  const audit: ReasonAudit = {
+    reasons: 0,
+    reasonsWithCitation: 0,
+    priceCitations: 0,
+    barCitations: 0,
+    findings: [],
+  };
+
+  for (const record of actions) {
+    const action = record.action as { reason?: { summary?: string } };
+    const summary = action.reason?.summary;
+    if (!summary) continue;
+    audit.reasons += 1;
+
+    const { bars, cursor } = visibleBars(question, record.at);
+    if (bars.length === 0) continue;
+    const lows = bars.map((bar) => numberOf(bar.low));
+    const highs = bars.map((bar) => numberOf(bar.high));
+    const low = Math.min(...lows);
+    const high = Math.max(...highs);
+    const reference = numberOf(bars.at(-1)!.close);
+
+    const prices = priceCandidates(summary, reference);
+    const barRefs = barCandidates(summary);
+    audit.priceCitations += prices.length;
+    audit.barCitations += barRefs.length;
+    if (prices.length > 0 || barRefs.length > 0) audit.reasonsWithCitation += 1;
+
+    for (const price of prices) {
+      if (price >= low - ROUNDING_TOLERANCE && price <= high + ROUNDING_TOLERANCE) continue;
+      audit.findings.push({
+        step: record.step,
+        kind: 'impossible_price',
+        cited: price,
+        visible: `${low.toFixed(2)}–${high.toFixed(2)}`,
+        summary,
+      });
+    }
+    for (const barRef of barRefs) {
+      if (barRef <= cursor + 1 + BAR_INDEX_SLACK) continue;
+      audit.findings.push({
+        step: record.step,
+        kind: 'future_bar',
+        cited: barRef,
+        visible: `B0–B${cursor + 1}`,
+        summary,
+      });
+    }
+  }
+
+  return audit;
+}

--- a/packages/bench/test/episode/reasonAudit.test.ts
+++ b/packages/bench/test/episode/reasonAudit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { auditEpisodeReasons } from '../../src/episode/reasonAudit.js';
+import type { EpisodeActionRecord } from '../../src/schema/episode.js';
+import type { Question } from '../../src/schema/question.js';
+
+function bar(time: string, open: number, high: number, low: number, close: number) {
+  return { time, open, high, low, close, volume: 1_000 };
+}
+
+const REPLAY = [
+  bar('2026-03-23T14:30:00Z', 100, 103, 99, 102),
+  bar('2026-03-23T15:30:00Z', 102, 105, 101, 104),
+  bar('2026-03-23T16:30:00Z', 104, 106, 103, 105),
+];
+
+function question(): Question {
+  return {
+    id: 'swing-TEST-01',
+    bank: 'swing',
+    symbol: 'MU.US',
+    cutoff: '2026-03-20T20:00:00-04:00',
+    layer: 'high-vol-tech',
+    adversarial: false,
+    fixtures: {
+      kline: { '1h': [bar('2026-03-20T19:30:00Z', 99, 101, 98, 100)], day: [], week: [] },
+      indicators: {},
+      quote: { last: 100 },
+      capitalFlow: {},
+      news: [],
+      fundamentals: {},
+      calendar: {},
+    },
+    replay: { basePeriod: '1h', entryExpiryBars: 3, horizonBars: REPLAY.length, bars: REPLAY },
+  };
+}
+
+function record(step: number, at: string, summary: string): EpisodeActionRecord {
+  return {
+    step,
+    at,
+    effectiveBarTime: null,
+    action: { type: 'hold', reason: { category: 'trend_following', summary } },
+  } as EpisodeActionRecord;
+}
+
+describe('auditEpisodeReasons', () => {
+  it('accepts a price that traded inside the visible window', () => {
+    const audit = auditEpisodeReasons(question(), [
+      record(1, REPLAY[1].time, '价格回踩 101.50 后企稳，结构未破。'),
+    ]);
+    expect(audit.priceCitations).toBe(1);
+    expect(audit.findings).toHaveLength(0);
+  });
+
+  it('flags a price the tape never printed', () => {
+    const audit = auditEpisodeReasons(question(), [
+      record(1, REPLAY[0].time, '在 97.20 获得支撑，反弹确认。'),
+    ]);
+    expect(audit.findings).toEqual([
+      expect.objectContaining({ kind: 'impossible_price', cited: 97.2, step: 1 }),
+    ]);
+  });
+
+  it('flags a bar index the model has not been shown', () => {
+    const audit = auditEpisodeReasons(question(), [
+      record(1, REPLAY[0].time, 'B57 跳空跌破前低，趋势反转。'),
+    ]);
+    expect(audit.findings).toEqual([
+      expect.objectContaining({ kind: 'future_bar', cited: 57, step: 1 }),
+    ]);
+  });
+
+  it('leaves R multiples, percentages, counts and dates unaudited', () => {
+    const audit = auditEpisodeReasons(question(), [
+      record(
+        1,
+        REPLAY[2].time,
+        '本笔亏损 1.50R，回撤 3.20%，持有 2.00 根，20 日均线走平，参考 2026-03-13 低点。',
+      ),
+    ]);
+    expect(audit.findings).toHaveLength(0);
+    expect(audit.priceCitations).toBe(0);
+  });
+
+  it('counts reasons that carry no checkable citation at all', () => {
+    const audit = auditEpisodeReasons(question(), [
+      record(1, REPLAY[0].time, '继续观察，等待更好的机会。'),
+      record(2, REPLAY[1].time, '价格在 104.00 遇阻。'),
+    ]);
+    expect(audit.reasons).toBe(2);
+    expect(audit.reasonsWithCitation).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

`TD-REASON-01` requires every decision to carry a concretely checkable item — a specific price, a bar index, a named structure — and forbids empty phrases. Nothing has ever checked that the item is *real*. The suspicion was citation theatre: prose is cheap, and a model that learns the rule can satisfy it by writing "day EMA20 rising" whether or not that drove anything, or by quoting a price it never saw.

The app does not auto-trade; it advises. So "is the analysis checkable and true" matters more to the product than "did this 40-session replay make money" — and unlike net R, it is measurable without market noise.

## What

`auditEpisodeReasons(question, actions)` resolves each reason against the bars visible at that step and reports:

- how many reasons carry at least one checkable citation, and how many carry none
- price and bar citation counts
- candidates where a cited price never traded in the visible window, or a cited bar has not been shown

## Result on real data

36 `gpt-5.4-mini` episodes on `v2-blind-pilot` (12 cases × 3 reps), post-engine-fix:

| | |
|---|---|
| reasons | 1617 |
| carrying ≥1 checkable citation | 1545 (95.5%) |
| carrying none | 72 (4.5%) |
| price citations | 3554 |
| bar citations | 1240 |
| **fabricated prices** | **0** |

Every candidate the audit raised resolved to something legitimate on inspection: a target or invalidation level the tape has not printed yet ("推进到 102.95 的 T1"), a resting order price outside the current range, or one-decimal rounding of a real extreme (94.3 for a 94.32 low, 146.23 for 146.232051). The tolerance covers that rounding and nothing wider.

So the citation-theatre hypothesis is not supported for numbers: these models quote the tape accurately. The only `TD-REASON-01` signal in the batch is the 4.5% of reasons with nothing checkable in them at all.

## What this cannot do

Findings are review candidates, not violations, and the module header says so. A reason legitimately names prices that have never traded and legitimately looks ahead to bars it has not seen; separating a retrospective claim from a forward plan is beyond pattern matching. Making fabrication itself measurable needs a structured evidence field the engine can verify — not a better regex. The honest measure this ships with is how much of a reason is checkable at all.

## Verification

5 unit tests covering an in-range price, an off-tape price, an unseen bar index, unit-suffixed numbers and dates left unaudited, and the no-citation count. `tsc --noEmit` and `eslint` clean.

Independent of #75, #76 and #77 — reads results and question JSON only.