### PR TITLE
feat(marketdata): provider abstraction with free Yahoo datasource

### DIFF
--- a/apps/desktop/src/kernel/ipc/settingsIpc.ts
+++ b/apps/desktop/src/kernel/ipc/settingsIpc.ts
@@ -62,6 +62,16 @@ export class SettingsIpc extends IpcService implements WrapEnvelope<SettingsApi>
   }
 
   @IpcMethod()
+  getLocalWatchlist() {
+    return toEnvelope('settings.getLocalWatchlist', () => settingsService.getLocalWatchlist());
+  }
+
+  @IpcMethod()
+  putLocalWatchlist(input: Parameters<SettingsApi['putLocalWatchlist']>[0]) {
+    return toEnvelope('settings.putLocalWatchlist', () => settingsService.putLocalWatchlist(input));
+  }
+
+  @IpcMethod()
   getSubscribeUrl() {
     return toEnvelope('settings.getSubscribeUrl', () => settingsService.getSubscribeUrl());
   }

--- a/apps/desktop/src/shell/onboarding/ipc.ts
+++ b/apps/desktop/src/shell/onboarding/ipc.ts
@@ -20,4 +20,9 @@ export class OnboardingIpc extends IpcService {
   complete() {
     return this.store.complete();
   }
+
+  @IpcMethod()
+  skipLongbridge() {
+    return this.store.skipLongbridge();
+  }
 }

--- a/apps/desktop/src/shell/onboarding/store.ts
+++ b/apps/desktop/src/shell/onboarding/store.ts
@@ -4,11 +4,13 @@ import { app } from 'electron';
 
 export interface OnboardingState {
   completed: boolean;
+  longbridgeSkipped: boolean;
 }
 
 export interface OnboardingStore {
   getState(): Promise<OnboardingState>;
   complete(): Promise<OnboardingState>;
+  skipLongbridge(): Promise<OnboardingState>;
 }
 
 export function createOnboardingFileStore(filePath: string): OnboardingStore {
@@ -16,19 +18,30 @@ export function createOnboardingFileStore(filePath: string): OnboardingStore {
     try {
       const raw = await readFile(filePath, 'utf8');
       const parsed = JSON.parse(raw) as Partial<OnboardingState>;
-      return { completed: parsed.completed === true };
+      return {
+        completed: parsed.completed === true,
+        longbridgeSkipped: parsed.longbridgeSkipped === true,
+      };
     } catch {
-      return { completed: false };
+      return { completed: false, longbridgeSkipped: false };
     }
+  }
+
+  async function write(state: OnboardingState): Promise<OnboardingState> {
+    await writeFile(filePath, JSON.stringify(state), { mode: 0o600 });
+    await chmod(filePath, 0o600);
+    return state;
   }
 
   return {
     getState: read,
     async complete() {
-      const state: OnboardingState = { completed: true };
-      await writeFile(filePath, JSON.stringify(state), { mode: 0o600 });
-      await chmod(filePath, 0o600);
-      return state;
+      const current = await read();
+      return write({ ...current, completed: true });
+    },
+    async skipLongbridge() {
+      const current = await read();
+      return write({ ...current, longbridgeSkipped: true });
     },
   };
 }

--- a/apps/desktop/test/boot/kernel.compositionOrdering.test.ts
+++ b/apps/desktop/test/boot/kernel.compositionOrdering.test.ts
@@ -51,6 +51,9 @@ vi.mock('@kansoku/core/marketdata/localWatchlistStore', () => ({
   setActiveLocalWatchlistStore,
 }));
 
+const stampDefaultProvider = vi.hoisted(() => vi.fn(async () => 'longbridge' as const));
+vi.mock('@kansoku/core/marketdata/defaultProvider', () => ({ stampDefaultProvider }));
+
 const initAuthUrlOpener = vi.hoisted(() => vi.fn());
 vi.mock('@kansoku/core/credentials/authUrlOpener', () => ({ initAuthUrlOpener }));
 

--- a/apps/desktop/test/boot/kernel.compositionOrdering.test.ts
+++ b/apps/desktop/test/boot/kernel.compositionOrdering.test.ts
@@ -44,6 +44,13 @@ vi.mock('@kansoku/core/marketdata/watchedMarketsStore', () => ({
   setActiveWatchedMarketsStore,
 }));
 
+const createLocalWatchlistStore = vi.hoisted(() => vi.fn(() => ({})));
+const setActiveLocalWatchlistStore = vi.hoisted(() => vi.fn());
+vi.mock('@kansoku/core/marketdata/localWatchlistStore', () => ({
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+}));
+
 const initAuthUrlOpener = vi.hoisted(() => vi.fn());
 vi.mock('@kansoku/core/credentials/authUrlOpener', () => ({ initAuthUrlOpener }));
 

--- a/apps/desktop/test/boot/kernel.singleActivation.test.ts
+++ b/apps/desktop/test/boot/kernel.singleActivation.test.ts
@@ -35,6 +35,13 @@ vi.mock('@kansoku/core/marketdata/watchedMarketsStore', () => ({
   setActiveWatchedMarketsStore,
 }));
 
+const createLocalWatchlistStore = vi.hoisted(() => vi.fn(() => ({})));
+const setActiveLocalWatchlistStore = vi.hoisted(() => vi.fn());
+vi.mock('@kansoku/core/marketdata/localWatchlistStore', () => ({
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+}));
+
 const initAuthUrlOpener = vi.hoisted(() => vi.fn());
 vi.mock('@kansoku/core/credentials/authUrlOpener', () => ({ initAuthUrlOpener }));
 

--- a/apps/desktop/test/boot/kernel.singleActivation.test.ts
+++ b/apps/desktop/test/boot/kernel.singleActivation.test.ts
@@ -42,6 +42,9 @@ vi.mock('@kansoku/core/marketdata/localWatchlistStore', () => ({
   setActiveLocalWatchlistStore,
 }));
 
+const stampDefaultProvider = vi.hoisted(() => vi.fn(async () => 'longbridge' as const));
+vi.mock('@kansoku/core/marketdata/defaultProvider', () => ({ stampDefaultProvider }));
+
 const initAuthUrlOpener = vi.hoisted(() => vi.fn());
 vi.mock('@kansoku/core/credentials/authUrlOpener', () => ({ initAuthUrlOpener }));
 
@@ -170,7 +173,9 @@ describe('bootKernel pro composition activation (real seam, not mocked away)', (
     expect(setProPresent).toHaveBeenCalledWith(true);
     expect(registerProHooks).toHaveBeenCalledTimes(1);
     expect(registerProAiExtension).toHaveBeenCalledTimes(1);
-    expect(registerProAiExtension).toHaveBeenCalledWith(expect.objectContaining({ tag: 'desktop' }));
+    expect(registerProAiExtension).toHaveBeenCalledWith(
+      expect.objectContaining({ tag: 'desktop' }),
+    );
     expect(registerProChannels).toHaveBeenCalledTimes(1);
     expect(registerProChannels).toHaveBeenCalledWith(['desktop-channel']);
 

--- a/apps/desktop/test/onboarding/store.test.ts
+++ b/apps/desktop/test/onboarding/store.test.ts
@@ -17,19 +17,44 @@ describe('createOnboardingFileStore', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it('reports not-completed when the file is absent', async () => {
+  it('reports not-completed and not-skipped when the file is absent', async () => {
     const store = createOnboardingFileStore(path);
-    expect(await store.getState()).toEqual({ completed: false });
+    expect(await store.getState()).toEqual({ completed: false, longbridgeSkipped: false });
   });
 
   it('persists completion and reads it back', async () => {
     const store = createOnboardingFileStore(path);
-    expect(await store.complete()).toEqual({ completed: true });
-    expect(await createOnboardingFileStore(path).getState()).toEqual({ completed: true });
+    expect(await store.complete()).toEqual({ completed: true, longbridgeSkipped: false });
+    expect(await createOnboardingFileStore(path).getState()).toEqual({
+      completed: true,
+      longbridgeSkipped: false,
+    });
   });
 
-  it('treats a corrupt file as not-completed', async () => {
+  it('treats a corrupt file as not-completed and not-skipped', async () => {
     await writeFile(path, 'not json');
-    expect(await createOnboardingFileStore(path).getState()).toEqual({ completed: false });
+    expect(await createOnboardingFileStore(path).getState()).toEqual({
+      completed: false,
+      longbridgeSkipped: false,
+    });
+  });
+
+  it('persists the longbridge skip and reads it back', async () => {
+    const store = createOnboardingFileStore(path);
+    expect(await store.skipLongbridge()).toEqual({ completed: false, longbridgeSkipped: true });
+    expect(await createOnboardingFileStore(path).getState()).toEqual({
+      completed: false,
+      longbridgeSkipped: true,
+    });
+  });
+
+  it('keeps each flag independent — completing does not clear a prior skip, and skipping does not clear completion', async () => {
+    const store = createOnboardingFileStore(path);
+    await store.skipLongbridge();
+    expect(await store.complete()).toEqual({ completed: true, longbridgeSkipped: true });
+
+    const other = createOnboardingFileStore(path);
+    await other.complete();
+    expect(await other.skipLongbridge()).toEqual({ completed: true, longbridgeSkipped: true });
   });
 });

--- a/apps/server/src/modules/settings/settings.controller.ts
+++ b/apps/server/src/modules/settings/settings.controller.ts
@@ -71,6 +71,18 @@ export class SettingsController {
     return { ok: true, data };
   }
 
+  @Get('/local-watchlist')
+  async getLocalWatchlist() {
+    const data = await settingsService.getLocalWatchlist();
+    return { ok: true, data };
+  }
+
+  @Put('/local-watchlist')
+  async putLocalWatchlist(@Body() body: { symbols?: unknown } | null) {
+    const data = await settingsService.putLocalWatchlist({ symbols: body?.symbols });
+    return { ok: true, data };
+  }
+
   @Get('/subscribe-url')
   async getSubscribeUrl() {
     const data = await settingsService.getSubscribeUrl();

--- a/apps/server/src/runtimeInit.ts
+++ b/apps/server/src/runtimeInit.ts
@@ -8,6 +8,7 @@ import {
   createLocalWatchlistStore,
   setActiveLocalWatchlistStore,
 } from '@kansoku/core/marketdata/localWatchlistStore';
+import { stampDefaultProvider } from '@kansoku/core/marketdata/defaultProvider';
 import {
   createWatchedMarketsStore,
   setActiveWatchedMarketsStore,
@@ -50,6 +51,7 @@ export async function initServerHostRuntime(opts?: ServerRuntimeOptions): Promis
   setActiveWatchedMarketsStore(createWatchedMarketsStore(getDb()));
   setActiveLocalWatchlistStore(createLocalWatchlistStore(getDb()));
   initAiSettings(getDb(), { secretBox: opts?.secretBox });
+  await stampDefaultProvider();
 
   const productionHost = opts?.productionHost ?? process.env.NODE_ENV === 'production';
   setProductionHost(productionHost);

--- a/apps/server/src/runtimeInit.ts
+++ b/apps/server/src/runtimeInit.ts
@@ -5,6 +5,10 @@ import { setProductionHost } from '@kansoku/core/license/dodoEnv';
 import { startLicenseRevalidation } from '@kansoku/core/license/licenseSchedule';
 import { initLicenseManager } from '@kansoku/core/license/licenseState';
 import {
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+} from '@kansoku/core/marketdata/localWatchlistStore';
+import {
   createWatchedMarketsStore,
   setActiveWatchedMarketsStore,
 } from '@kansoku/core/marketdata/watchedMarketsStore';
@@ -44,6 +48,7 @@ export async function initServerHostRuntime(opts?: ServerRuntimeOptions): Promis
   initCredentialProvider(opts?.credentialProvider);
   initAuthUrlOpener(opts?.openAuthUrl);
   setActiveWatchedMarketsStore(createWatchedMarketsStore(getDb()));
+  setActiveLocalWatchlistStore(createLocalWatchlistStore(getDb()));
   initAiSettings(getDb(), { secretBox: opts?.secretBox });
 
   const productionHost = opts?.productionHost ?? process.env.NODE_ENV === 'production';

--- a/apps/server/test/capabilities.test.ts
+++ b/apps/server/test/capabilities.test.ts
@@ -46,6 +46,7 @@ describe('GET /capabilities', () => {
       license: { state: 'unlicensed' },
       features: allFeatures('absent'),
       hasEncBundle: false,
+      datasources: [{ market: 'US', name: 'longbridge', realtime: true }],
     });
   });
 
@@ -61,6 +62,7 @@ describe('GET /capabilities', () => {
       license: { state: 'unlicensed' },
       features: allFeatures('locked'),
       hasEncBundle: true,
+      datasources: [{ market: 'US', name: 'longbridge', realtime: true }],
     });
   });
 
@@ -77,6 +79,7 @@ describe('GET /capabilities', () => {
       license: { state: 'unlicensed' },
       features: allFeatures('locked'),
       hasEncBundle: false,
+      datasources: [{ market: 'US', name: 'longbridge', realtime: true }],
     });
   });
 
@@ -99,6 +102,7 @@ describe('GET /capabilities', () => {
       license: { state: 'licensed', deviceName: 'my-mac', maskedKey: '••••7890' },
       features: allFeatures('active'),
       hasEncBundle: false,
+      datasources: [{ market: 'US', name: 'longbridge', realtime: true }],
     });
   });
 

--- a/apps/server/test/host-proModules.test.ts
+++ b/apps/server/test/host-proModules.test.ts
@@ -43,6 +43,9 @@ vi.mock('@kansoku/core/realtime/charts', () => ({ subscribeChart: vi.fn(() => ()
 vi.mock('@kansoku/core/realtime/position', () => ({ subscribePosition: vi.fn(() => () => {}) }));
 vi.mock('@kansoku/core/realtime/quotes', () => ({ subscribeQuotes: vi.fn(() => () => {}) }));
 
+const stampDefaultProvider = vi.hoisted(() => vi.fn(async () => 'longbridge' as const));
+vi.mock('@kansoku/core/marketdata/defaultProvider', () => ({ stampDefaultProvider }));
+
 const loadProComposition = vi.hoisted(() =>
   vi.fn(async () => ({
     modules: [FakeProProbeModule],

--- a/apps/server/test/proAbsent.test.ts
+++ b/apps/server/test/proAbsent.test.ts
@@ -37,6 +37,7 @@ describe('pro-absent HTTP surface', () => {
         'options-walls': 'absent',
       },
       hasEncBundle: false,
+      datasources: [{ market: 'US', name: 'longbridge', realtime: true }],
     });
   });
 });

--- a/apps/server/test/proPresent.test.ts
+++ b/apps/server/test/proPresent.test.ts
@@ -4,12 +4,12 @@ import { resetProHooksForTests } from '@kansoku/core/pro/hooks';
 import { setProPresent } from '@kansoku/core/pro/bundleState';
 import { setAiRuntimeForTests } from '@kansoku/core/ai/settings/initAiSettings';
 import { setModelsRuntimeForTests } from '@kansoku/core/ai/runtime/modelsRuntime';
-import {
-  setLicenseManagerForTests,
-  type LicenseManager,
-} from '@kansoku/core/license/licenseState';
+import { setLicenseManagerForTests, type LicenseManager } from '@kansoku/core/license/licenseState';
 import type { ServerProComposition } from '../src/edition/types.js';
 import { tsukiRequest } from './helpers.js';
+
+const stampDefaultProvider = vi.hoisted(() => vi.fn(async () => 'longbridge' as const));
+vi.mock('@kansoku/core/marketdata/defaultProvider', () => ({ stampDefaultProvider }));
 
 const startDeepDiveForNote = vi.hoisted(() => vi.fn(() => ({ started: true as const })));
 const deepDiveStatus = vi.hoisted(() => vi.fn(() => ({ running: true })));

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,8 +5,15 @@ import { Onboarding } from './features/onboarding/Onboarding';
 import { useCredentialsGate } from './features/onboarding/useCredentialsGate';
 import { CommandPalette } from './features/palette/CommandPalette';
 import { RestrictedBanner } from './features/edition/RestrictedBanner';
+import { DelayedQuotesBanner } from './features/quotes/DelayedQuotesBanner';
 import { isDesktopRealtime } from './lib/portTransport';
-import { getBrowserRouter, matchPopoutSymbolRoute, navigate, routePathname, useRoute } from './lib/router';
+import {
+  getBrowserRouter,
+  matchPopoutSymbolRoute,
+  navigate,
+  routePathname,
+  useRoute,
+} from './lib/router';
 import { ContextMenuHost, ModalHost } from './ui';
 import { RoutedGlobalNotifications } from './features/notifications/GlobalNotifications';
 
@@ -43,6 +50,7 @@ export function App() {
   return (
     <>
       <RestrictedBanner />
+      <DelayedQuotesBanner />
       <RoutedGlobalNotifications />
       <RouterProvider router={browserRouter} />
       <CommandPalette onOpenRoute={navigate} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,6 +35,7 @@ export function App() {
         status={gate.details}
         onRecheck={gate.recheck}
         onComplete={gate.completeOnboarding}
+        onSkipLongbridge={gate.skipLongbridge}
       />
     );
   }

--- a/apps/web/src/features/desktop/DesktopShell.tsx
+++ b/apps/web/src/features/desktop/DesktopShell.tsx
@@ -4,6 +4,7 @@ import { GlobalNotifications } from '../notifications/GlobalNotifications';
 import { symbolFromRoute } from '../../lib/symbol';
 import { CommandPalette } from '../palette/CommandPalette';
 import { RestrictedBanner } from '../edition/RestrictedBanner';
+import { DelayedQuotesBanner } from '../quotes/DelayedQuotesBanner';
 import { ContextMenuHost, ModalHost } from '../../ui';
 import { clearActiveSymbol, setActiveSymbol } from '../cockpit/analystRunsStore';
 import { DesktopTitlebar } from './DesktopTitlebar';
@@ -27,6 +28,7 @@ export function DesktopShell() {
       <GlobalNotifications route={controller.activeTab.route} />
       <div className="desktop-content" key={controller.activeTab.id}>
         <RestrictedBanner />
+        <DelayedQuotesBanner />
         <RouterProvider router={controller.activeRouter} />
       </div>
       <CommandPalette onOpenRoute={controller.openTab} />

--- a/apps/web/src/features/edition/capabilitiesStore.ts
+++ b/apps/web/src/features/edition/capabilitiesStore.ts
@@ -10,6 +10,7 @@ export interface Capabilities {
   license?: LicenseSnapshot;
   features?: Record<FeatureKey, FeatureState>;
   hasEncBundle?: boolean;
+  datasources?: { market: string; name: string; realtime: boolean }[];
 }
 
 const DEFAULT: Capabilities = { pro: null, licensed: false };

--- a/apps/web/src/features/home/SymbolGrid.tsx
+++ b/apps/web/src/features/home/SymbolGrid.tsx
@@ -9,6 +9,7 @@ import type {
 import { fmt, signed } from '@web/lib/format';
 import { Badge, Card, Dot, Empty, MarketTime, Num } from '@web/ui';
 import { directionTone } from '@web/features/charts/intraday/directionLabels';
+import { DelayedBadge } from '@web/features/quotes/DelayedBadge';
 import { fmtFlow, flowTone } from './flowFormat';
 import { INDEX_SYMBOLS } from './HomeTopStrip';
 import { FollowToggle, ReassessButton } from './SymbolActions';
@@ -78,9 +79,9 @@ export function buildGridEntries({
       }
     }
   }
-  const symbols = [
-    ...new Set([...quoteBySymbol.keys(), ...rowBySymbol.keys(), ...owned]),
-  ].filter((s) => !indexSet.has(s) && isCardWorthySymbol(s));
+  const symbols = [...new Set([...quoteBySymbol.keys(), ...rowBySymbol.keys(), ...owned])].filter(
+    (s) => !indexSet.has(s) && isCardWorthySymbol(s),
+  );
   const flows = board?.flows ?? {};
   const entries = symbols.map((symbol) => ({
     symbol,
@@ -119,6 +120,7 @@ function GridCard({ entry }: { entry: GridEntry }) {
             )}
           </span>
         )}
+        <DelayedBadge symbol={symbol} />
         {quote && quote.session !== '日盘' && <Badge className="qc-session">{quote.session}</Badge>}
         {owned && <Badge className="hold-badge">持仓</Badge>}
         {earningsDate && (
@@ -205,16 +207,11 @@ function MoverTail({ movers, quiet }: { movers: GridEntry[]; quiet: GridEntry[] 
         <TailCell key={entry.symbol} entry={entry} />
       ))}
       {quiet.length > 0 && (
-        <button
-          type="button"
-          className="watch-tail-fold"
-          onClick={() => setExpanded((v) => !v)}
-        >
+        <button type="button" className="watch-tail-fold" onClick={() => setExpanded((v) => !v)}>
           {expanded ? '收起 ▴' : `+ ${quiet.length} 只平静 ▾`}
         </button>
       )}
-      {expanded &&
-        quiet.map((entry) => <TailCell key={entry.symbol} entry={entry} />)}
+      {expanded && quiet.map((entry) => <TailCell key={entry.symbol} entry={entry} />)}
     </div>
   );
 }

--- a/apps/web/src/features/onboarding/Onboarding.tsx
+++ b/apps/web/src/features/onboarding/Onboarding.tsx
@@ -60,11 +60,13 @@ export function Onboarding({
   status,
   onRecheck,
   onComplete,
+  onSkipLongbridge,
 }: {
   step: OnboardingStep;
   status: CredentialsGetResult | null;
   onRecheck: () => void;
   onComplete: () => Promise<void>;
+  onSkipLongbridge: () => Promise<void>;
 }) {
   const [localStep, setLocalStep] = useState<OnboardingStep>(step === 'longbridge' ? 'ai' : step);
   const renderStep = resolveRenderStep(step, localStep);
@@ -82,7 +84,7 @@ export function Onboarding({
           <Brand />
           <Progress step={renderStep} steps={steps} />
           {renderStep === 'longbridge' ? (
-            <StepLongbridge status={status} onRecheck={onRecheck} />
+            <StepLongbridge status={status} onRecheck={onRecheck} onSkip={onSkipLongbridge} />
           ) : renderStep === 'ai' ? (
             <StepAi onNext={() => setLocalStep('twitter')} />
           ) : renderStep === 'twitter' ? (

--- a/apps/web/src/features/onboarding/StepLongbridge.test.tsx
+++ b/apps/web/src/features/onboarding/StepLongbridge.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StepLongbridge } from './StepLongbridge';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('StepLongbridge', () => {
+  it('renders the skip action and its hint line under the primary connect flow', () => {
+    render(<StepLongbridge status={null} onRecheck={vi.fn()} onSkip={vi.fn()} />);
+
+    expect(screen.getByText('暂时跳过，先用免费行情')).toBeTruthy();
+    expect(
+      screen.getByText('免费行情为轮询更新，可能有延迟；之后可以在设置里接入长桥。'),
+    ).toBeTruthy();
+  });
+
+  it('persists the skip via the bridge callback when clicked', async () => {
+    const onSkip = vi.fn().mockResolvedValue(undefined);
+    render(<StepLongbridge status={null} onRecheck={vi.fn()} onSkip={onSkip} />);
+
+    fireEvent.click(screen.getByText('暂时跳过，先用免费行情'));
+
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+  });
+
+  it('shows an error and re-enables the action when persisting the skip fails', async () => {
+    const onSkip = vi.fn().mockRejectedValue(new Error('磁盘写入失败'));
+    render(<StepLongbridge status={null} onRecheck={vi.fn()} onSkip={onSkip} />);
+
+    const button = screen.getByText('暂时跳过，先用免费行情') as HTMLButtonElement;
+    fireEvent.click(button);
+
+    expect(await screen.findByText('磁盘写入失败')).toBeTruthy();
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/apps/web/src/features/onboarding/StepLongbridge.tsx
+++ b/apps/web/src/features/onboarding/StepLongbridge.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { errorMessage } from '../../lib/api';
 import { Button, Card } from '../../ui';
 import type { CredentialsGetResult } from '../settings/desktopCredentials';
 
@@ -6,10 +8,26 @@ const INSTALL_URL = 'https://open.longbridge.com/docs/cli/install';
 export function StepLongbridge({
   status,
   onRecheck,
+  onSkip,
 }: {
   status: CredentialsGetResult | null;
   onRecheck: () => void;
+  onSkip: () => Promise<void>;
 }) {
+  const [skipBusy, setSkipBusy] = useState(false);
+  const [skipError, setSkipError] = useState<string | null>(null);
+
+  const skip = async () => {
+    setSkipBusy(true);
+    setSkipError(null);
+    try {
+      await onSkip();
+    } catch (err) {
+      setSkipError(errorMessage(err));
+      setSkipBusy(false);
+    }
+  };
+
   const state = status?.state ?? 'cli_missing';
   const title =
     state === 'cli_missing'
@@ -50,6 +68,19 @@ export function StepLongbridge({
           重新检测
         </Button>
       </div>
+
+      {skipError ? (
+        <div className="settings-test-result settings-test-result--fail">{skipError}</div>
+      ) : null}
+
+      <div className="onboarding-skip-row">
+        <button className="onboarding-skip-link" disabled={skipBusy} onClick={() => void skip()}>
+          暂时跳过，先用免费行情
+        </button>
+      </div>
+      <p className="onboarding-skip-hint">
+        免费行情为轮询更新，可能有延迟；之后可以在设置里接入长桥。
+      </p>
     </Card>
   );
 }

--- a/apps/web/src/features/onboarding/desktopOnboarding.ts
+++ b/apps/web/src/features/onboarding/desktopOnboarding.ts
@@ -2,11 +2,13 @@ import { getShellRpc } from '../desktop/shellRpc';
 
 export interface OnboardingState {
   completed: boolean;
+  longbridgeSkipped: boolean;
 }
 
 export interface DesktopOnboardingBridge {
   getState(): Promise<OnboardingState>;
   complete(): Promise<OnboardingState>;
+  skipLongbridge(): Promise<OnboardingState>;
 }
 
 export function getDesktopOnboardingBridge(
@@ -17,5 +19,6 @@ export function getDesktopOnboardingBridge(
   return {
     getState: () => rpc.invoke('onboarding.getState') as Promise<OnboardingState>,
     complete: () => rpc.invoke('onboarding.complete') as Promise<OnboardingState>,
+    skipLongbridge: () => rpc.invoke('onboarding.skipLongbridge') as Promise<OnboardingState>,
   };
 }

--- a/apps/web/src/features/onboarding/gateStatus.test.ts
+++ b/apps/web/src/features/onboarding/gateStatus.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { computeGateStatus } from './gateStatus';
+import { computeGateStatus, computeStatusLoading } from './gateStatus';
 
 const base = {
   hasDesktopBridge: true,
   statusLoading: false,
   configured: true,
   onboardingCompleted: true,
+  longbridgeSkipped: false,
 };
 
 describe('computeGateStatus', () => {
@@ -35,7 +36,7 @@ describe('computeGateStatus', () => {
     });
   });
 
-  it('onboards at the longbridge step when the CLI is not ready', () => {
+  it('onboards at the longbridge step when the CLI is not ready and skip was never used', () => {
     expect(computeGateStatus({ ...base, configured: false, onboardingCompleted: true })).toEqual({
       status: 'onboarding',
       step: 'longbridge',
@@ -81,5 +82,109 @@ describe('computeGateStatus', () => {
       { ...base, configured: true, onboardingCompleted: null },
     ];
     for (const params of cases) expect(computeGateStatus(params).step).not.toBe('twitter');
+  });
+
+  describe('longbridgeSkipped (third track)', () => {
+    it('unskipped + unconfigured still onboards at the longbridge step (existing behavior)', () => {
+      expect(
+        computeGateStatus({ ...base, configured: false, longbridgeSkipped: false }),
+      ).toEqual({ status: 'onboarding', step: 'longbridge' });
+    });
+
+    it('skipped + unconfigured falls through to the ai step when onboarding is not completed', () => {
+      expect(
+        computeGateStatus({
+          ...base,
+          configured: false,
+          longbridgeSkipped: true,
+          onboardingCompleted: false,
+        }),
+      ).toEqual({ status: 'onboarding', step: 'ai' });
+    });
+
+    it('skipped + unconfigured is ready once onboarding is completed', () => {
+      expect(
+        computeGateStatus({
+          ...base,
+          configured: false,
+          longbridgeSkipped: true,
+          onboardingCompleted: true,
+        }),
+      ).toEqual({ status: 'ready', step: null });
+    });
+
+    it('skipped + configured is identical to the unskipped configured behavior', () => {
+      expect(
+        computeGateStatus({
+          ...base,
+          configured: true,
+          longbridgeSkipped: true,
+          onboardingCompleted: false,
+        }),
+      ).toEqual({ status: 'onboarding', step: 'ai' });
+      expect(
+        computeGateStatus({
+          ...base,
+          configured: true,
+          longbridgeSkipped: true,
+          onboardingCompleted: true,
+        }),
+      ).toEqual({ status: 'ready', step: null });
+    });
+
+    it('skipped + null-configured still fails open to ready (fail-open preserved)', () => {
+      expect(
+        computeGateStatus({ ...base, configured: null, longbridgeSkipped: true }),
+      ).toEqual({ status: 'ready', step: null });
+    });
+
+    it('an unknown skip flag (null) does not skip the longbridge step (fail-closed for the skip itself)', () => {
+      expect(
+        computeGateStatus({ ...base, configured: false, longbridgeSkipped: null }),
+      ).toEqual({ status: 'onboarding', step: 'longbridge' });
+    });
+
+    it('a later dropped CLI login does not re-trap a skipped user (skip stays persisted)', () => {
+      expect(
+        computeGateStatus({
+          ...base,
+          configured: false,
+          longbridgeSkipped: true,
+          onboardingCompleted: true,
+        }),
+      ).toEqual({ status: 'ready', step: null });
+    });
+  });
+});
+
+describe('computeStatusLoading', () => {
+  it('is loading while the credentials request is in flight, regardless of anything else', () => {
+    expect(
+      computeStatusLoading({ credentialsLoading: true, configured: null, onboardingLoading: false }),
+    ).toBe(true);
+  });
+
+  it('does not wait on the onboarding state when configured could not be determined', () => {
+    expect(
+      computeStatusLoading({ credentialsLoading: false, configured: null, onboardingLoading: true }),
+    ).toBe(false);
+  });
+
+  it('waits on the onboarding state once unconfigured is known (the skip flag lives there)', () => {
+    expect(
+      computeStatusLoading({ credentialsLoading: false, configured: false, onboardingLoading: true }),
+    ).toBe(true);
+  });
+
+  it('waits on the onboarding state once configured is known true (the ai flag lives there)', () => {
+    expect(
+      computeStatusLoading({ credentialsLoading: false, configured: true, onboardingLoading: true }),
+    ).toBe(true);
+  });
+
+  it('is not loading once both requests have resolved', () => {
+    expect(
+      computeStatusLoading({ credentialsLoading: false, configured: false, onboardingLoading: false }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/features/onboarding/gateStatus.ts
+++ b/apps/web/src/features/onboarding/gateStatus.ts
@@ -6,21 +6,39 @@ export interface GateResult {
   step: OnboardingStep | null;
 }
 
-// Two-track gate: Longbridge is a live check (a dropped CLI login yanks the
-// user back to fix it at any time), while the AI step is a one-shot flag
-// (`onboardingCompleted`) so skipping AI doesn't re-trap the user every launch.
-// `configured === null` and `onboardingCompleted === null` both fail open to
-// ready — a failed/absent probe should never trap someone out of the app.
+// Three-track gate: Longbridge is a live check by default (a dropped CLI
+// login yanks the user back to fix it at any time). `longbridgeSkipped` mutes
+// that live check while unconfigured — once a user explicitly skips, a later
+// dropped CLI login does NOT re-trap them; the skip stays persisted even
+// across a future connect-then-disconnect cycle. The AI step is a one-shot
+// flag (`onboardingCompleted`) so skipping AI doesn't re-trap the user every
+// launch. `configured === null` and `onboardingCompleted === null` both fail
+// open to ready — a failed/absent probe should never trap someone out of the
+// app. `longbridgeSkipped === null` fails closed (treated as not skipped) —
+// an unknown skip flag must not silently bypass the live check.
 export function computeGateStatus(params: {
   hasDesktopBridge: boolean;
   statusLoading: boolean;
   configured: boolean | null;
   onboardingCompleted: boolean | null;
+  longbridgeSkipped: boolean | null;
 }): GateResult {
   if (!params.hasDesktopBridge) return { status: 'ready', step: null };
   if (params.statusLoading) return { status: 'loading', step: null };
-  if (params.configured === false) return { status: 'onboarding', step: 'longbridge' };
+  if (params.configured === false && params.longbridgeSkipped !== true) {
+    return { status: 'onboarding', step: 'longbridge' };
+  }
   if (params.configured === null) return { status: 'ready', step: null };
   if (params.onboardingCompleted === false) return { status: 'onboarding', step: 'ai' };
   return { status: 'ready', step: null };
+}
+
+export function computeStatusLoading(params: {
+  credentialsLoading: boolean;
+  configured: boolean | null;
+  onboardingLoading: boolean;
+}): boolean {
+  if (params.credentialsLoading) return true;
+  if (params.configured === null) return false;
+  return params.onboardingLoading;
 }

--- a/apps/web/src/features/onboarding/useCredentialsGate.ts
+++ b/apps/web/src/features/onboarding/useCredentialsGate.ts
@@ -5,6 +5,7 @@ import {
   getDesktopCredentialsBridge,
   type CredentialsGetResult,
 } from '../settings/desktopCredentials';
+import { refreshCapabilities } from '../edition/capabilitiesStore';
 import { clearRestricted } from '../edition/restrictedMode';
 import { getDesktopOnboardingBridge, type OnboardingState } from './desktopOnboarding';
 import { computeGateStatus, type GateStatus, type OnboardingStep } from './gateStatus';
@@ -34,7 +35,10 @@ export function useCredentialsGate(): {
   );
 
   useEffect(() => {
-    if (data?.configured) clearRestricted();
+    if (data?.configured) {
+      clearRestricted();
+      void refreshCapabilities();
+    }
   }, [data?.configured]);
 
   // Only block on the AI flag once Longbridge is actually connected — otherwise

--- a/apps/web/src/features/onboarding/useCredentialsGate.ts
+++ b/apps/web/src/features/onboarding/useCredentialsGate.ts
@@ -8,7 +8,12 @@ import {
 import { refreshCapabilities } from '../edition/capabilitiesStore';
 import { clearRestricted } from '../edition/restrictedMode';
 import { getDesktopOnboardingBridge, type OnboardingState } from './desktopOnboarding';
-import { computeGateStatus, type GateStatus, type OnboardingStep } from './gateStatus';
+import {
+  computeGateStatus,
+  computeStatusLoading,
+  type GateStatus,
+  type OnboardingStep,
+} from './gateStatus';
 
 export function useCredentialsGate(): {
   status: GateStatus;
@@ -17,6 +22,7 @@ export function useCredentialsGate(): {
   details: CredentialsGetResult | null;
   recheck: () => void;
   completeOnboarding: () => Promise<void>;
+  skipLongbridge: () => Promise<void>;
 } {
   const bridge = getDesktopCredentialsBridge();
   const onboardingBridge = getDesktopOnboardingBridge();
@@ -41,9 +47,11 @@ export function useCredentialsGate(): {
     }
   }, [data?.configured]);
 
-  // Only block on the AI flag once Longbridge is actually connected — otherwise
-  // a slow flag read would flash the main app before bouncing to the AI step.
-  const statusLoading = loading || (data?.configured === true && onboardingLoading);
+  const statusLoading = computeStatusLoading({
+    credentialsLoading: loading,
+    configured: data ? data.configured : null,
+    onboardingLoading,
+  });
 
   const { status, step } = computeGateStatus({
     hasDesktopBridge: bridge !== null,
@@ -54,6 +62,11 @@ export function useCredentialsGate(): {
         ? onboardingState.completed
         : null
       : true,
+    longbridgeSkipped: onboardingBridge
+      ? onboardingState
+        ? onboardingState.longbridgeSkipped
+        : null
+      : false,
   });
 
   const completeOnboarding = useCallback(async () => {
@@ -61,5 +74,18 @@ export function useCredentialsGate(): {
     reloadOnboarding();
   }, [onboardingBridge, reloadOnboarding]);
 
-  return { status, step, bridge, details: data ?? null, recheck: reload, completeOnboarding };
+  const skipLongbridge = useCallback(async () => {
+    if (onboardingBridge) await onboardingBridge.skipLongbridge();
+    reloadOnboarding();
+  }, [onboardingBridge, reloadOnboarding]);
+
+  return {
+    status,
+    step,
+    bridge,
+    details: data ?? null,
+    recheck: reload,
+    completeOnboarding,
+    skipLongbridge,
+  };
 }

--- a/apps/web/src/features/quotes/DelayedBadge.test.tsx
+++ b/apps/web/src/features/quotes/DelayedBadge.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let capabilities: { datasources?: { market: string; name: string; realtime: boolean }[] } = {};
+
+vi.mock('../edition/capabilitiesStore', () => ({
+  useCapabilities: () => capabilities,
+}));
+
+const { DelayedBadge } = await import('./DelayedBadge');
+
+afterEach(() => {
+  cleanup();
+  capabilities = {};
+});
+
+describe('DelayedBadge', () => {
+  it('renders for a symbol whose market is delayed', () => {
+    capabilities = { datasources: [{ market: 'HK', name: '轮询', realtime: false }] };
+
+    render(<DelayedBadge symbol="700.HK" />);
+
+    expect(screen.getByText('延迟')).toBeTruthy();
+  });
+
+  it('renders nothing for a symbol whose market is realtime', () => {
+    capabilities = { datasources: [{ market: 'US', name: 'Longbridge', realtime: true }] };
+
+    const { container } = render(<DelayedBadge symbol="MU.US" />);
+
+    expect(container.textContent).toBe('');
+  });
+});

--- a/apps/web/src/features/quotes/DelayedBadge.tsx
+++ b/apps/web/src/features/quotes/DelayedBadge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '../../ui';
+import { isDelayedSymbol, useDelayedMarkets } from './delayedDatasource';
+
+export function DelayedBadge({ symbol }: { symbol: string }) {
+  const delayedMarkets = useDelayedMarkets();
+  if (!isDelayedSymbol(delayedMarkets, symbol)) return null;
+
+  return (
+    <Badge tone="muted" className="delayed-badge">
+      延迟
+    </Badge>
+  );
+}

--- a/apps/web/src/features/quotes/DelayedQuotesBanner.test.tsx
+++ b/apps/web/src/features/quotes/DelayedQuotesBanner.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let capabilities: { datasources?: { market: string; name: string; realtime: boolean }[] } = {};
+const navigate = vi.fn();
+
+vi.mock('../edition/capabilitiesStore', () => ({
+  useCapabilities: () => capabilities,
+}));
+
+vi.mock('../../lib/router', () => ({
+  navigate: (...args: unknown[]) => navigate(...args),
+}));
+
+const { resetDelayedQuotesBannerDismissedForTests } =
+  await import('./delayedQuotesBannerDismissal');
+const { DelayedQuotesBanner } = await import('./DelayedQuotesBanner');
+
+afterEach(() => {
+  cleanup();
+  capabilities = {};
+  navigate.mockReset();
+  window.localStorage.clear();
+  resetDelayedQuotesBannerDismissedForTests();
+});
+
+describe('DelayedQuotesBanner', () => {
+  it('renders nothing when no market is delayed', () => {
+    capabilities = { datasources: [{ market: 'US', name: 'Longbridge', realtime: true }] };
+
+    const { container } = render(<DelayedQuotesBanner />);
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows the banner with a settings action when a market is delayed', () => {
+    capabilities = { datasources: [{ market: 'HK', name: '轮询', realtime: false }] };
+
+    render(<DelayedQuotesBanner />);
+
+    expect(screen.getByText(/当前行情为轮询更新/)).toBeTruthy();
+    fireEvent.click(screen.getByText('去设置'));
+    expect(navigate).toHaveBeenCalledWith('/settings');
+  });
+
+  it('hides once dismissed, and the dismissal persists to localStorage', () => {
+    capabilities = { datasources: [{ market: 'HK', name: '轮询', realtime: false }] };
+
+    render(<DelayedQuotesBanner />);
+    fireEvent.click(screen.getByLabelText('关闭'));
+
+    expect(screen.queryByText(/当前行情为轮询更新/)).toBeNull();
+    expect(window.localStorage.getItem('kansoku.delayed-quotes-banner-dismissed')).toBe('1');
+  });
+});

--- a/apps/web/src/features/quotes/DelayedQuotesBanner.tsx
+++ b/apps/web/src/features/quotes/DelayedQuotesBanner.tsx
@@ -1,0 +1,33 @@
+import { navigate } from '../../lib/router';
+import { useDelayedMarkets } from './delayedDatasource';
+import {
+  dismissDelayedQuotesBanner,
+  useDelayedQuotesBannerDismissed,
+} from './delayedQuotesBannerDismissal';
+
+export function DelayedQuotesBanner() {
+  const delayedMarkets = useDelayedMarkets();
+  const dismissed = useDelayedQuotesBannerDismissed();
+  if (delayedMarkets.size === 0 || dismissed) return null;
+
+  return (
+    <div className="delayed-quotes-banner">
+      <span>
+        当前行情为轮询更新,可能有延迟,不是实时行情。接入长桥可获得实时行情;后续计划支持 IBKR
+        等更多渠道。
+      </span>
+      <div className="delayed-quotes-banner-actions">
+        <button className="delayed-quotes-banner-link" onClick={() => navigate('/settings')}>
+          去设置
+        </button>
+        <button
+          className="delayed-quotes-banner-dismiss"
+          onClick={dismissDelayedQuotesBanner}
+          aria-label="关闭"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/quotes/QuoteBar.tsx
+++ b/apps/web/src/features/quotes/QuoteBar.tsx
@@ -3,6 +3,7 @@ import type { QuoteCell, QuoteSnapshot } from '@kansoku/shared/types';
 import { money, signed, upDown } from '../../lib/format';
 import { useWsChannel } from '../../lib/ws/useWsChannel';
 import { Badge, DataAgeBadge, Dot } from '../../ui';
+import { DelayedBadge } from './DelayedBadge';
 
 function pctTone(pct: number | null): string {
   return pct == null ? '' : upDown(pct);
@@ -16,10 +17,9 @@ function Cell({ q }: { q: QuoteCell }) {
   return (
     <a className="quote-cell" href={`/symbol/${encodeURIComponent(q.symbol)}`}>
       <span className="qc-symbol">{q.symbol.replace(/\.US$/, '')}</span>
-      <span className={`num qc-price ${pctTone(q.pct)}`}>
-        {money(q.last, q.last < 10 ? 3 : 2)}
-      </span>
+      <span className={`num qc-price ${pctTone(q.pct)}`}>{money(q.last, q.last < 10 ? 3 : 2)}</span>
       <span className={`num qc-pct ${pctTone(q.pct)}`}>{pctText(q.pct)}</span>
+      <DelayedBadge symbol={q.symbol} />
       {q.session !== '日盘' && <Badge className="qc-session">{q.session}</Badge>}
     </a>
   );
@@ -60,6 +60,7 @@ export function TopbarQuote({ quote }: { quote: QuoteCell | null }) {
     <span className="topbar-quote">
       <span className={`num qc-price ${pctTone(quote.pct)}`}>{money(quote.last)}</span>
       <span className={`num qc-pct ${pctTone(quote.pct)}`}>{pctText(quote.pct)}</span>
+      <DelayedBadge symbol={quote.symbol} />
       <Badge className="qc-session">{quote.session}</Badge>
     </span>
   );

--- a/apps/web/src/features/quotes/delayedDatasource.test.ts
+++ b/apps/web/src/features/quotes/delayedDatasource.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let capabilities: { datasources?: { market: string; name: string; realtime: boolean }[] } = {};
+
+vi.mock('../edition/capabilitiesStore', () => ({
+  useCapabilities: () => capabilities,
+}));
+
+const { isDelayedSymbol, useDelayedMarkets } = await import('./delayedDatasource');
+
+afterEach(() => {
+  capabilities = {};
+});
+
+describe('isDelayedSymbol', () => {
+  it('is true when the symbol market is in the delayed set', () => {
+    expect(isDelayedSymbol(new Set(['HK']), '700.HK')).toBe(true);
+  });
+
+  it('is false when the symbol market is not in the delayed set', () => {
+    expect(isDelayedSymbol(new Set(['HK']), 'MU.US')).toBe(false);
+  });
+
+  it('is false for an unknown market, which defaults to US', () => {
+    expect(isDelayedSymbol(new Set(['HK']), '700.SG')).toBe(false);
+  });
+});
+
+describe('useDelayedMarkets', () => {
+  it('derives the set of markets whose datasource is not realtime', () => {
+    capabilities = {
+      datasources: [
+        { market: 'US', name: 'Longbridge', realtime: true },
+        { market: 'HK', name: '轮询', realtime: false },
+      ],
+    };
+    const { result } = renderHook(() => useDelayedMarkets());
+    expect(result.current).toEqual(new Set(['HK']));
+  });
+
+  it('returns an empty set when datasources is missing', () => {
+    capabilities = {};
+    const { result } = renderHook(() => useDelayedMarkets());
+    expect(result.current).toEqual(new Set());
+  });
+
+  it('returns an empty set when every datasource is realtime', () => {
+    capabilities = { datasources: [{ market: 'US', name: 'Longbridge', realtime: true }] };
+    const { result } = renderHook(() => useDelayedMarkets());
+    expect(result.current).toEqual(new Set());
+  });
+});

--- a/apps/web/src/features/quotes/delayedDatasource.ts
+++ b/apps/web/src/features/quotes/delayedDatasource.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { marketOfSymbol } from '../../lib/market';
+import { useCapabilities } from '../edition/capabilitiesStore';
+
+export function isDelayedSymbol(
+  delayedMarkets: Set<string>,
+  symbol: string | null | undefined,
+): boolean {
+  return delayedMarkets.has(marketOfSymbol(symbol));
+}
+
+export function useDelayedMarkets(): Set<string> {
+  const { datasources } = useCapabilities();
+  return useMemo(() => {
+    const delayed = new Set<string>();
+    for (const source of datasources ?? []) {
+      if (!source.realtime) delayed.add(source.market);
+    }
+    return delayed;
+  }, [datasources]);
+}

--- a/apps/web/src/features/quotes/delayedQuotesBannerDismissal.test.ts
+++ b/apps/web/src/features/quotes/delayedQuotesBannerDismissal.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY,
+  dismissDelayedQuotesBanner,
+  getDelayedQuotesBannerDismissed,
+  readDelayedQuotesBannerDismissed,
+  resetDelayedQuotesBannerDismissedForTests,
+  subscribeForTests,
+} from './delayedQuotesBannerDismissal';
+
+describe('readDelayedQuotesBannerDismissed', () => {
+  it('defaults to not dismissed when no storage is available', () => {
+    expect(readDelayedQuotesBannerDismissed(null)).toBe(false);
+  });
+
+  it('reads a dismissed flag from storage', () => {
+    const storage = {
+      getItem: (key: string) => (key === DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY ? '1' : null),
+    };
+    expect(readDelayedQuotesBannerDismissed(storage)).toBe(true);
+  });
+
+  it('treats anything other than "1" as not dismissed', () => {
+    expect(readDelayedQuotesBannerDismissed({ getItem: () => 'true' })).toBe(false);
+    expect(readDelayedQuotesBannerDismissed({ getItem: () => null })).toBe(false);
+  });
+});
+
+describe('dismissDelayedQuotesBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetDelayedQuotesBannerDismissedForTests();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    resetDelayedQuotesBannerDismissedForTests();
+  });
+
+  it('flips the in-memory flag and persists it to localStorage', () => {
+    expect(getDelayedQuotesBannerDismissed()).toBe(false);
+
+    dismissDelayedQuotesBanner();
+
+    expect(getDelayedQuotesBannerDismissed()).toBe(true);
+    expect(window.localStorage.getItem(DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY)).toBe('1');
+  });
+
+  it('notifies subscribers once, and is a no-op once already dismissed', () => {
+    let notified = 0;
+    const unsubscribe = subscribeForTests(() => notified++);
+
+    dismissDelayedQuotesBanner();
+    expect(notified).toBe(1);
+
+    dismissDelayedQuotesBanner();
+    expect(notified).toBe(1);
+
+    unsubscribe();
+  });
+});

--- a/apps/web/src/features/quotes/delayedQuotesBannerDismissal.ts
+++ b/apps/web/src/features/quotes/delayedQuotesBannerDismissal.ts
@@ -1,0 +1,79 @@
+import { useSyncExternalStore } from 'react';
+
+export const DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY =
+  'kansoku.delayed-quotes-banner-dismissed';
+
+type ReadableStorage = Pick<Storage, 'getItem'>;
+
+function browserStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readDelayedQuotesBannerDismissed(
+  storage: ReadableStorage | null = browserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+let dismissed = readDelayedQuotesBannerDismissed();
+const listeners = new Set<() => void>();
+let listeningForStorageChanges = false;
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function handleStorageChange(event: StorageEvent): void {
+  if (event.key !== DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY) return;
+  const next = event.newValue === '1';
+  if (next === dismissed) return;
+  dismissed = next;
+  emit();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!listeningForStorageChanges && typeof window !== 'undefined') {
+    window.addEventListener('storage', handleStorageChange);
+    listeningForStorageChanges = true;
+  }
+  return () => listeners.delete(listener);
+}
+
+export function getDelayedQuotesBannerDismissed(): boolean {
+  return dismissed;
+}
+
+export function dismissDelayedQuotesBanner(): void {
+  if (dismissed) return;
+  dismissed = true;
+  try {
+    browserStorage()?.setItem(DELAYED_QUOTES_BANNER_DISMISSED_STORAGE_KEY, '1');
+  } catch {
+    // The dismissal still applies for this session when storage is unavailable.
+  }
+  emit();
+}
+
+export function useDelayedQuotesBannerDismissed(): boolean {
+  return useSyncExternalStore(subscribe, getDelayedQuotesBannerDismissed, () => false);
+}
+
+export function resetDelayedQuotesBannerDismissedForTests(): void {
+  dismissed = false;
+  listeners.clear();
+}
+
+export function subscribeForTests(listener: () => void): () => void {
+  return subscribe(listener);
+}

--- a/apps/web/src/features/settings/LocalWatchlistCard.test.tsx
+++ b/apps/web/src/features/settings/LocalWatchlistCard.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const getLocalWatchlist = vi.fn();
+const putLocalWatchlist = vi.fn();
+
+vi.mock('@web/lib/client', () => ({
+  client: {
+    settings: {
+      getLocalWatchlist: (...args: unknown[]) => getLocalWatchlist(...args),
+      putLocalWatchlist: (...args: unknown[]) => putLocalWatchlist(...args),
+    },
+  },
+}));
+
+const { LocalWatchlistCard } = await import('./LocalWatchlistCard');
+
+function renderWithClient(children: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+}
+
+describe('LocalWatchlistCard', () => {
+  afterEach(() => {
+    cleanup();
+    getLocalWatchlist.mockReset();
+    putLocalWatchlist.mockReset();
+  });
+
+  it('renders the fetched symbols', async () => {
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'NVDA'] });
+
+    renderWithClient(<LocalWatchlistCard />);
+
+    expect(await screen.findByText('MU')).toBeTruthy();
+    expect(screen.getByText('NVDA')).toBeTruthy();
+  });
+
+  it('adding a symbol saves the updated list', async () => {
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU'] });
+    putLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'TSM'] });
+
+    renderWithClient(<LocalWatchlistCard />);
+    await screen.findByText('MU');
+
+    fireEvent.change(screen.getByPlaceholderText('输入代码，如 MU'), {
+      target: { value: 'tsm' },
+    });
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(await screen.findByText('TSM')).toBeTruthy();
+    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['MU', 'TSM'] });
+  });
+
+  it('removing a symbol saves the updated list', async () => {
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'NVDA'] });
+    putLocalWatchlist.mockResolvedValue({ symbols: ['NVDA'] });
+
+    renderWithClient(<LocalWatchlistCard />);
+    await screen.findByText('MU');
+
+    fireEvent.click(screen.getByLabelText('移除 MU'));
+
+    expect(screen.queryByText('MU')).toBeNull();
+    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['NVDA'] });
+  });
+});

--- a/apps/web/src/features/settings/LocalWatchlistCard.test.tsx
+++ b/apps/web/src/features/settings/LocalWatchlistCard.test.tsx
@@ -31,40 +31,40 @@ describe('LocalWatchlistCard', () => {
   });
 
   it('renders the fetched symbols', async () => {
-    getLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'NVDA'] });
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU.US', 'NVDA.US'] });
 
     renderWithClient(<LocalWatchlistCard />);
 
-    expect(await screen.findByText('MU')).toBeTruthy();
-    expect(screen.getByText('NVDA')).toBeTruthy();
+    expect(await screen.findByText('MU.US')).toBeTruthy();
+    expect(screen.getByText('NVDA.US')).toBeTruthy();
   });
 
-  it('adding a symbol saves the updated list', async () => {
-    getLocalWatchlist.mockResolvedValue({ symbols: ['MU'] });
-    putLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'TSM'] });
+  it('adding a symbol canonicalizes it to the server form before saving', async () => {
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU.US'] });
+    putLocalWatchlist.mockResolvedValue({ symbols: ['MU.US', 'TSM.US'] });
 
     renderWithClient(<LocalWatchlistCard />);
-    await screen.findByText('MU');
+    await screen.findByText('MU.US');
 
     fireEvent.change(screen.getByPlaceholderText('输入代码，如 MU'), {
       target: { value: 'tsm' },
     });
     fireEvent.click(screen.getByText('添加'));
 
-    expect(await screen.findByText('TSM')).toBeTruthy();
-    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['MU', 'TSM'] });
+    expect(await screen.findByText('TSM.US')).toBeTruthy();
+    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['MU.US', 'TSM.US'] });
   });
 
   it('removing a symbol saves the updated list', async () => {
-    getLocalWatchlist.mockResolvedValue({ symbols: ['MU', 'NVDA'] });
-    putLocalWatchlist.mockResolvedValue({ symbols: ['NVDA'] });
+    getLocalWatchlist.mockResolvedValue({ symbols: ['MU.US', 'NVDA.US'] });
+    putLocalWatchlist.mockResolvedValue({ symbols: ['NVDA.US'] });
 
     renderWithClient(<LocalWatchlistCard />);
-    await screen.findByText('MU');
+    await screen.findByText('MU.US');
 
-    fireEvent.click(screen.getByLabelText('移除 MU'));
+    fireEvent.click(screen.getByLabelText('移除 MU.US'));
 
-    expect(screen.queryByText('MU')).toBeNull();
-    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['NVDA'] });
+    expect(screen.queryByText('MU.US')).toBeNull();
+    expect(putLocalWatchlist).toHaveBeenCalledWith({ symbols: ['NVDA.US'] });
   });
 });

--- a/apps/web/src/features/settings/LocalWatchlistCard.tsx
+++ b/apps/web/src/features/settings/LocalWatchlistCard.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useQuery } from '@web/lib/apiHooks';
+import { client } from '@web/lib/client';
+import { Button, Card, Input, SectionTitle } from '@web/ui';
+import { addSymbol, removeSymbol } from './localWatchlist';
+import { useSaveQueue } from './useSaveQueue';
+
+export function LocalWatchlistCard() {
+  const { data, error, reload } = useQuery<{ symbols: string[] }>(
+    'settings.getLocalWatchlist',
+    () => client.settings.getLocalWatchlist(),
+  );
+
+  if (!data) return null;
+  return <LocalWatchlistCardLoaded initial={data.symbols} onReload={reload} error={error} />;
+}
+
+function LocalWatchlistCardLoaded({
+  initial,
+  onReload,
+  error,
+}: {
+  initial: string[];
+  onReload: () => void;
+  error: string | null;
+}) {
+  const [symbols, setSymbols] = useState<string[]>(initial);
+  const [draft, setDraft] = useState('');
+
+  const queue = useSaveQueue<string[]>({
+    initial,
+    save: async (snapshot) => {
+      const res = await client.settings.putLocalWatchlist({ symbols: snapshot });
+      return res.symbols;
+    },
+    onError: (_err, rolledBackTo) => {
+      setSymbols(rolledBackTo ?? initial);
+      onReload();
+    },
+  });
+
+  const handleAdd = () => {
+    const next = addSymbol(symbols, draft);
+    if (next === symbols) return;
+    setSymbols(next);
+    setDraft('');
+    queue.push(next);
+  };
+
+  const handleRemove = (sym: string) => {
+    const next = removeSymbol(symbols, sym);
+    setSymbols(next);
+    queue.push(next);
+  };
+
+  return (
+    <Card className="settings-display-card">
+      <div className="settings-card-heading">
+        <SectionTitle>本地自选</SectionTitle>
+      </div>
+      <div className="settings-time-preference">
+        <div className="settings-preference-copy">
+          <div className="settings-preference-description">
+            没有长桥账户时,行情关注列表来自这里。
+          </div>
+        </div>
+      </div>
+      {symbols.length > 0 && (
+        <div className="local-watchlist-chips">
+          {symbols.map((sym) => (
+            <span className="local-watchlist-chip" key={sym}>
+              {sym}
+              <button
+                type="button"
+                className="local-watchlist-chip-remove"
+                aria-label={`移除 ${sym}`}
+                onClick={() => handleRemove(sym)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="local-watchlist-add-row">
+        <Input
+          placeholder="输入代码，如 MU"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleAdd();
+          }}
+        />
+        <Button onClick={handleAdd}>添加</Button>
+      </div>
+      {error ? (
+        <div className="settings-time-preference">
+          <div className="settings-preference-copy">
+            <div className="settings-preference-description">{error}</div>
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/web/src/features/settings/SettingsPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsPage.test.tsx
@@ -11,6 +11,7 @@ const getAi = vi.fn();
 const getCatalog = vi.fn();
 const getUsageToday = vi.fn();
 const getWatchedMarkets = vi.fn();
+const getLocalWatchlist = vi.fn();
 const getSubscribeUrl = vi.fn();
 const credentialsStatus = vi.fn();
 const capabilitiesGet = vi.fn();
@@ -24,6 +25,7 @@ vi.mock('@web/lib/client', () => ({
       getCatalog: (...args: unknown[]) => getCatalog(...args),
       getUsageToday: (...args: unknown[]) => getUsageToday(...args),
       getWatchedMarkets: (...args: unknown[]) => getWatchedMarkets(...args),
+      getLocalWatchlist: (...args: unknown[]) => getLocalWatchlist(...args),
       getSubscribeUrl: (...args: unknown[]) => getSubscribeUrl(...args),
     },
     credentials: {
@@ -41,7 +43,13 @@ vi.mock('@web/lib/client', () => ({
 
 const { SettingsPage } = await import('./SettingsPage');
 
-const disabled: RoleSetting = { mode: 'disabled', provider: null, modelId: null, thinkingLevel: null, stale: false };
+const disabled: RoleSetting = {
+  mode: 'disabled',
+  provider: null,
+  modelId: null,
+  thinkingLevel: null,
+  stale: false,
+};
 
 // The 'memory' role shipped 2026-07-20 (aa9bb43). A settings.getAi response
 // restored from react-query's localStorage persistence (queryClient.ts) can
@@ -75,6 +83,7 @@ describe('SettingsPage', () => {
       getCatalog,
       getUsageToday,
       getWatchedMarkets,
+      getLocalWatchlist,
       getSubscribeUrl,
       credentialsStatus,
       capabilitiesGet,
@@ -99,9 +108,14 @@ describe('SettingsPage', () => {
       total: { calls: 0, cost: 0 },
     });
     getWatchedMarkets.mockResolvedValue({ markets: ['US'] });
+    getLocalWatchlist.mockResolvedValue({ symbols: [] });
     getSubscribeUrl.mockResolvedValue({ subscribeUrl: null });
     credentialsStatus.mockResolvedValue({ configured: false, path: null });
-    capabilitiesGet.mockResolvedValue({ pro: false, licensed: false, license: { state: 'unlicensed' } });
+    capabilitiesGet.mockResolvedValue({
+      pro: false,
+      licensed: false,
+      license: { state: 'unlicensed' },
+    });
     lobehubGetAccount.mockResolvedValue({
       status: 'disconnected',
       email: null,

--- a/apps/web/src/features/settings/SettingsPage.tsx
+++ b/apps/web/src/features/settings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useTitle } from '@web/lib/useTitle';
 import { DataRootSection } from './DataRootSection';
 import { DiagnosticsSection } from './DiagnosticsSection';
 import { LicenseSection } from './LicenseSection';
+import { LocalWatchlistCard } from './LocalWatchlistCard';
 import { LongbridgeSection } from './LongbridgeSection';
 import { ProviderCredentialsSection } from './ProviderCredentialsSection';
 import { RoleModelsCard } from './RoleModelsCard';
@@ -94,6 +95,7 @@ function SettingsWorkspace({
           <LicenseSection />
           <TimeDisplaySettingsCard />
           <WatchedMarketsCard />
+          <LocalWatchlistCard />
           <Card className="settings-connections-card">
             <div className="settings-card-heading">
               <SectionTitle>连接</SectionTitle>

--- a/apps/web/src/features/settings/localWatchlist.test.ts
+++ b/apps/web/src/features/settings/localWatchlist.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { addSymbol, removeSymbol } from './localWatchlist';
+
+describe('addSymbol', () => {
+  it('trims and uppercases the input', () => {
+    expect(addSymbol([], '  mu  ')).toEqual(['MU']);
+  });
+
+  it('rejects an empty or whitespace-only input', () => {
+    expect(addSymbol(['MU'], '   ')).toEqual(['MU']);
+    expect(addSymbol(['MU'], '')).toEqual(['MU']);
+  });
+
+  it('rejects a duplicate already in the list, case-insensitively', () => {
+    expect(addSymbol(['MU'], 'mu')).toEqual(['MU']);
+    expect(addSymbol(['MU'], 'MU')).toEqual(['MU']);
+  });
+
+  it('appends a new symbol to the end of the list', () => {
+    expect(addSymbol(['MU'], 'nvda')).toEqual(['MU', 'NVDA']);
+  });
+});
+
+describe('removeSymbol', () => {
+  it('removes the matching symbol', () => {
+    expect(removeSymbol(['MU', 'NVDA'], 'MU')).toEqual(['NVDA']);
+  });
+
+  it('is a no-op when the symbol is absent', () => {
+    expect(removeSymbol(['MU'], 'NVDA')).toEqual(['MU']);
+  });
+});

--- a/apps/web/src/features/settings/localWatchlist.test.ts
+++ b/apps/web/src/features/settings/localWatchlist.test.ts
@@ -2,31 +2,39 @@ import { describe, expect, it } from 'vitest';
 import { addSymbol, removeSymbol } from './localWatchlist';
 
 describe('addSymbol', () => {
-  it('trims and uppercases the input', () => {
-    expect(addSymbol([], '  mu  ')).toEqual(['MU']);
+  it('trims, uppercases and canonicalizes to the server form', () => {
+    expect(addSymbol([], '  mu  ')).toEqual(['MU.US']);
+  });
+
+  it('keeps an explicit market suffix as-is', () => {
+    expect(addSymbol([], '700.hk')).toEqual(['700.HK']);
   });
 
   it('rejects an empty or whitespace-only input', () => {
-    expect(addSymbol(['MU'], '   ')).toEqual(['MU']);
-    expect(addSymbol(['MU'], '')).toEqual(['MU']);
+    expect(addSymbol(['MU.US'], '   ')).toEqual(['MU.US']);
+    expect(addSymbol(['MU.US'], '')).toEqual(['MU.US']);
   });
 
-  it('rejects a duplicate already in the list, case-insensitively', () => {
-    expect(addSymbol(['MU'], 'mu')).toEqual(['MU']);
-    expect(addSymbol(['MU'], 'MU')).toEqual(['MU']);
+  it('rejects an invalid input', () => {
+    expect(addSymbol([], '!!!')).toEqual([]);
   });
 
-  it('appends a new symbol to the end of the list', () => {
-    expect(addSymbol(['MU'], 'nvda')).toEqual(['MU', 'NVDA']);
+  it('rejects a duplicate already in the list, case- and suffix-insensitively', () => {
+    expect(addSymbol(['MU.US'], 'mu')).toEqual(['MU.US']);
+    expect(addSymbol(['MU.US'], 'MU.US')).toEqual(['MU.US']);
+  });
+
+  it('appends a new canonicalized symbol to the end of the list', () => {
+    expect(addSymbol(['MU.US'], 'nvda')).toEqual(['MU.US', 'NVDA.US']);
   });
 });
 
 describe('removeSymbol', () => {
   it('removes the matching symbol', () => {
-    expect(removeSymbol(['MU', 'NVDA'], 'MU')).toEqual(['NVDA']);
+    expect(removeSymbol(['MU.US', 'NVDA.US'], 'MU.US')).toEqual(['NVDA.US']);
   });
 
   it('is a no-op when the symbol is absent', () => {
-    expect(removeSymbol(['MU'], 'NVDA')).toEqual(['MU']);
+    expect(removeSymbol(['MU.US'], 'NVDA.US')).toEqual(['MU.US']);
   });
 });

--- a/apps/web/src/features/settings/localWatchlist.ts
+++ b/apps/web/src/features/settings/localWatchlist.ts
@@ -1,0 +1,10 @@
+export function addSymbol(list: string[], raw: string): string[] {
+  const normalized = raw.trim().toUpperCase();
+  if (!normalized) return list;
+  if (list.includes(normalized)) return list;
+  return [...list, normalized];
+}
+
+export function removeSymbol(list: string[], sym: string): string[] {
+  return list.filter((s) => s !== sym);
+}

--- a/apps/web/src/features/settings/localWatchlist.ts
+++ b/apps/web/src/features/settings/localWatchlist.ts
@@ -1,5 +1,7 @@
+import { normalizeSymbol } from '@web/lib/symbol';
+
 export function addSymbol(list: string[], raw: string): string[] {
-  const normalized = raw.trim().toUpperCase();
+  const normalized = normalizeSymbol(raw);
   if (!normalized) return list;
   if (list.includes(normalized)) return list;
   return [...list, normalized];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2362,8 +2362,12 @@ a.zone-item:hover {
   font-variant-numeric: tabular-nums;
   cursor: pointer;
 }
-.recap-cell:hover { color: var(--text-primary); }
-.recap-cell:hover .recap-label { text-decoration: underline; }
+.recap-cell:hover {
+  color: var(--text-primary);
+}
+.recap-cell:hover .recap-label {
+  text-decoration: underline;
+}
 .recap-cell .recap-label {
   color: var(--accent);
   font-weight: 600;
@@ -2371,8 +2375,12 @@ a.zone-item:hover {
 .recap-cell .recap-stat {
   color: var(--text-secondary);
 }
-.recap-cell .recap-stat.up { color: var(--up); }
-.recap-cell .recap-stat.down { color: var(--down); }
+.recap-cell .recap-stat.up {
+  color: var(--up);
+}
+.recap-cell .recap-stat.down {
+  color: var(--down);
+}
 .index-placeholder {
   color: var(--text-muted);
   font-size: var(--fs-base);
@@ -4726,6 +4734,48 @@ a.zone-item:hover {
   grid-template-columns: 1fr 1fr;
 }
 
+.local-watchlist-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 11px 11px;
+}
+.local-watchlist-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+}
+.local-watchlist-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+.local-watchlist-chip-remove:hover {
+  color: var(--text-primary);
+}
+.local-watchlist-add-row {
+  display: flex;
+  gap: 8px;
+  padding: 0 11px 11px;
+}
+.local-watchlist-add-row .input {
+  min-width: 0;
+  flex: 1;
+}
+
 .settings-primary-row {
   padding: 11px;
   border-bottom: 1px solid var(--border);
@@ -6891,6 +6941,44 @@ a.zone-item:hover {
   padding: 0 4px;
 }
 .restricted-banner-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.delayed-quotes-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--bg-element);
+  border-bottom: 1px solid var(--accent);
+  color: var(--text-secondary);
+  padding: 8px 16px;
+  font-size: var(--fs-base);
+}
+.delayed-quotes-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+.delayed-quotes-banner-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: var(--fs-base);
+  cursor: pointer;
+  padding: 0;
+  white-space: nowrap;
+}
+.delayed-quotes-banner-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--fs-base);
+  cursor: pointer;
+  padding: 0 4px;
+}
+.delayed-quotes-banner-dismiss:hover {
   color: var(--text-primary);
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6703,6 +6703,13 @@ a.zone-item:hover {
   justify-content: center;
   margin-top: 14px;
 }
+.onboarding-skip-hint {
+  margin: 6px 0 0;
+  text-align: center;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+}
 
 .onboarding-shell {
   max-width: 480px;

--- a/docs/superpowers/specs/2026-07-22-marketdata-provider-abstraction-design.md
+++ b/docs/superpowers/specs/2026-07-22-marketdata-provider-abstraction-design.md
@@ -1,0 +1,127 @@
+# 行情数据源抽象:Yahoo 免费默认源 + 可插拔注册表
+
+日期:2026-07-22
+状态:已批准,待实现
+
+## 背景与动机
+
+app 内核的行情数据目前只有长桥一个来源。开源免费版没有长桥账户时,图表、报价、实时流全部无数据,「开箱即用」不成立。
+
+动机排序:
+
+1. **开源用户门槛(主)**——免费版要有一个无需注册的默认数据源,装完就能看行情。
+2. **风险对冲(次)**——长桥接口变动或服务不可用时,内核能整体切换到别的源。
+3. **多源路由(次)**——不同市场路由到不同源。现有 `MARKET_PROVIDER_<market>` env 机制已支持,本次做实。
+
+## 现状
+
+抽象层已存在一半,本次是「把缝做实」而不是从零建:
+
+- `packages/core/src/marketdata/types.ts` 已定义 `MarketDataProvider` 接口:`getKline` / `getQuotes` / `getNews` 必选,其余(flow、持仓、组合、自选单、财报日历、市场温度、行业榜等)是可选方法 + `capabilities` 集合。
+- `packages/core/src/marketdata/registry.ts` 已支持按市场解析 provider(`MARKET_PROVIDER_US` 等 env),但注册表里只有 `longbridge`。
+- 实时流已有 `QuoteStream` 接口(`retain` / `release` / `subscribeCandlesticks` / `onUpdate` / `getSnapshot`)+ 按 provider 的流工厂。
+- 消费端纪律良好:20+ 消费文件全部走 `getProvider()` / `getStream()`,可选能力都用 `provider.getPositions?.() ?? []` 形式调用,缺失即静默降级。
+- 直连长桥模块、绕开注册表的只有 3 个文件:`packages/bench/src/generate/source.ts`、`packages/core/src/ai/agents/agentTools/execTool.ts`、`packages/core/src/credentials/credentials.service.ts`,均不在本次范围(见「边界」)。
+
+关键空洞:实时推送的标的集 = 自选单 ∪ 持仓,两者都来自长桥。免费模式下两者皆空,首页与实时流会是白板——必须补本地自选单。
+
+## 目标
+
+1. 新增 `yahoo` provider:无 key、开箱可用,覆盖美股报价 + 多周期 K 线 + 基本新闻。
+2. 免费模式(无长桥凭证)下 app 自动落到 `yahoo`,无需用户改 env。
+3. 本地自选单,免费模式下实时流和首页有内容。
+4. 非实时行情在 UI 上诚实标注,并引导用户接入实时源(长桥,将来 IBKR 等)。
+5. 接口按「注册即插」保持:以后加官方付费/免费 key 源、IBKR,只新增文件不动消费端。
+
+## 非目标
+
+- 不动 `.claude/skills/` 层(`longbridge-*`、`stock-deep-dive` 等 CLI 调用),那是 Claude Code 侧个人工作流。
+- 不做多源按能力合成(报价走 A、资金流走 B)。现有按市场整体路由已够,出现真实需求再议。
+- 不做要 key 的官方源(Finnhub / Alpha Vantage / Tiingo)和 IBKR,本期只留好插槽。
+- Yahoo 第一期只启用 US 市场映射,HK/CN 留表结构不启用。
+- 不实现 Yahoo 的 flow、资金分布、持仓、组合、市场温度、行业榜——依赖现有可选降级。
+
+## 设计
+
+### 1. Yahoo provider(`packages/core/src/marketdata/yahoo/`)
+
+新目录,四个文件,均不超过现有单文件体量惯例:
+
+- **`client.ts`** —— Yahoo 非官方接口的最小 HTTP 客户端。共享 cookie jar + crumb 缓存(Yahoo 2023 起要求 cookie+crumb 握手);401 时刷新 crumb 重试一次;429 指数退避;同 host 请求间隔下限,避免触发风控。非官方接口随时可能变,变更修复集中在这一个文件。
+- **`provider.ts`** —— 实现 `MarketDataProvider`,`name: 'yahoo'`:
+  - `getKline(symbol, period, count, session)`:v8 chart API,`5m/15m/1h/day` 全周期,`session` 映射 `includePrePost`。Yahoo 分钟线历史约 60 天、小时线约 730 天:超出范围时在 provider 内截断请求、返回可得部分,不报错。
+  - `getQuotes(symbols)`:quote 批量接口,映射进现有 `RawQuote`(含盘前盘后字段,Yahoo 有则填、无则缺省)。
+  - `getNews(symbol, limit)`:search 接口新闻段,尽力而为;拿不到返回空数组。
+  - 可选实现:`getSecurityName`(quote 里白拿)、`getMarketCaps`(同上)、`getEarningsCalendar`(quoteSummary calendarEvents;短线预测的事件风险门需要它)。
+  - 其余可选方法一概不实现。
+- **`symbolMap.ts`** —— 符号翻译,见下节。
+- **`stream.ts`** —— 轮询流,见第 3 节。
+
+### 2. 符号规范与翻译
+
+**声明现有长桥风格符号(`AAPL.US`、`700.HK`、`.SOX.US`)为全 app 规范格式。** 翻译只发生在 provider 边缘,内核其余代码零改动:
+
+- 出站:`AAPL.US → AAPL`,指数替身 `.SOX.US → ^SOX`(沿用 TD-PROXY-01 的替身清单)。
+- 进站:Yahoo 返回的符号反翻译回规范格式。
+- 第一期只启用 US 映射;表结构留 HK/CN 位(如 `700.HK → 0700.HK`),不启用。
+- 未映射符号:抛 `ClientError`,提示该市场当前源不支持。
+
+### 3. 轮询流(`yahoo/stream.ts`)
+
+`YahooQuoteStream` 实现 `QuoteStream` 五方法:
+
+- 对 retained 集合定时批量 `getQuotes`,节奏按现有 `session.ts` 盘段分档:盘中 5 秒,盘前/盘后 30 秒,休市暂停。
+- `subscribeCandlesticks` 复用现有 `candleAggregator.ts`,从轮询报价聚合 K 线。
+- `getSnapshot` 读内存缓存;`onUpdate` 在每轮轮询有变化时触发。
+- 注册进 `registry.ts` 的 `streamFactories`。
+
+### 4. 本地自选单
+
+- 照 `watchedMarketsSettings` 模式加 Drizzle 单行表 `localWatchlist`(符号数组 + updatedAt)+ store(`localWatchlistStore.ts`,含内存缓存与 revision)。
+- 读取链:`provider.getWatchlistSymbols?.() ?? localWatchlistStore.get()`。长桥用户行为完全不变(provider 命中在前)。
+- 设置页提供最小增删 UI(输入符号添加、列表删除),走现有 settings 路由模式。
+
+### 5. 默认 provider 解析
+
+`registry.ts` 的解析顺序升级为:
+
+1. 显式 env(`MARKET_PROVIDER_<market>` > `MARKET_PROVIDER`)永远最高优先。
+2. 未设置时用**启动时盖章的默认值**:boot 阶段调 `credentialsService.status()`,长桥 `ready` → 默认 `longbridge`,否则 → `yahoo`;结果写入 registry 模块级状态(新增 `setDefaultProvider(name)`),`getProvider` / `getStream` 保持同步签名。
+3. 长桥凭证状态变化(登录/登出)时重新探测并盖章。
+
+### 6. 非实时行情提示
+
+- **接口**:`MarketDataProvider` 加 `readonly realtime: boolean`(长桥 `true`,Yahoo `false`)。提示逻辑由元数据驱动,不硬编码具体 provider 名,以后 IBKR 等直接继承。
+- **暴露**:`GET /api/capabilities` 响应加 `datasource: { name: string; realtime: boolean }`(按当前活跃 provider;多市场时报 watched markets 各自的)。
+- **UI 两个点位**:
+  1. 全局横幅(可关闭,关闭状态持久化):活跃 provider 非实时时显示——「当前行情为轮询更新,不是实时行情。接入长桥可获得实时行情;后续计划支持 IBKR 等渠道。」点击跳设置页凭证接入。
+  2. 报价角标:行情数字旁常驻小「延迟」标记,不可关闭——横幅可以关,看价格的地方始终诚实。
+- 文案遵守 TD-LANG-02:白话说清「轮询、可能有延迟」,不用行话。
+
+### 7. 错误处理
+
+- Yahoo 接口失败沿用现有 `ClientError` 通道,hint 里说明是免费源限制还是网络问题。
+- 轮询流单轮失败:记录、跳过本轮、下轮重试;连续失败进入退避,不炸整个流。
+- crumb 失效自动刷新一次;仍失败按普通错误上抛。
+
+## 测试
+
+- 解析器单测:chart / quote / search 响应用录制 fixture,不打网络(符合仓库现有测试风格)。
+- `symbolMap` 双向翻译 + 未映射符号报错。
+- registry 解析:env 覆盖 > 盖章默认;盖章切换。
+- 轮询流:fake timer + 注入 fetch,验证盘段节奏、retain/release、快照与聚合。
+- 本地自选单 store:读写 + 回退链。
+
+## 边界(明确不动)
+
+- `packages/bench/src/generate/source.ts`:生成集需要真实数据,本来就要账户。
+- `execTool.ts` 的 longbridge CLI 白名单:免费模式下 CLI 缺失,agent 工具本就降级。
+- `credentials.service.ts`:仍是长桥凭证专用;将来接 IBKR 时再泛化。
+- `.claude/skills/` 全部。
+
+## 后续(本期不做,插槽已留)
+
+- 官方 key 源(Finnhub / Tiingo 等)作为新 provider 注册。
+- IBKR 接入(行情 + 可能的账户数据),复用 `realtime: true` 提示链路。
+- Yahoo HK/CN 符号映射启用。
+- 多源按能力合成(如出现真实需求)。

--- a/packages/core/drizzle/0008_local_watchlist.sql
+++ b/packages/core/drizzle/0008_local_watchlist.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `local_watchlist_settings` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`symbols` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -56,6 +56,13 @@
       "when": 1784036000000,
       "tag": "0007_watched_markets",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784037000000,
+      "tag": "0008_local_watchlist",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/core/src/capabilities/capabilities.service.ts
+++ b/packages/core/src/capabilities/capabilities.service.ts
@@ -1,7 +1,22 @@
 import { currentSnapshotSafe, isLicensed } from '../license/licenseGate.js';
-import type { CapabilitiesApi } from '../contract/capabilities.js';
+import type { CapabilitiesApi, CapabilitiesOut } from '../contract/capabilities.js';
 import { featureStates } from '../pro/features.js';
 import { hasEncBundle, isProPresent } from '../pro/bundleState.js';
+import { getProvider } from '../marketdata/registry.js';
+import { getWatchedMarketsOrDefault } from '../marketdata/watchedMarketsStore.js';
+
+function collectDatasources(): CapabilitiesOut['datasources'] {
+  const datasources: CapabilitiesOut['datasources'] = [];
+  for (const market of getWatchedMarketsOrDefault()) {
+    try {
+      const provider = getProvider(market);
+      datasources.push({ market, name: provider.name, realtime: provider.realtime });
+    } catch {
+      continue;
+    }
+  }
+  return datasources;
+}
 
 export const capabilitiesService: CapabilitiesApi = {
   async get() {
@@ -11,6 +26,7 @@ export const capabilitiesService: CapabilitiesApi = {
       license: currentSnapshotSafe(),
       features: await featureStates(),
       hasEncBundle: hasEncBundle(),
+      datasources: collectDatasources(),
     };
   },
 };

--- a/packages/core/src/contract/capabilities.ts
+++ b/packages/core/src/contract/capabilities.ts
@@ -8,6 +8,7 @@ export interface CapabilitiesOut {
   license?: LicenseSnapshot;
   features: Record<FeatureKey, FeatureState>;
   hasEncBundle?: boolean;
+  datasources: { market: string; name: string; realtime: boolean }[];
 }
 
 export interface CapabilitiesApi {

--- a/packages/core/src/contract/settings.ts
+++ b/packages/core/src/contract/settings.ts
@@ -39,6 +39,8 @@ export interface SettingsApi {
   resetCredentials(): Promise<{ reset: true }>;
   getWatchedMarkets(): Promise<{ markets: Market[] }>;
   putWatchedMarkets(input: { markets: unknown }): Promise<{ markets: Market[] }>;
+  getLocalWatchlist(): Promise<{ symbols: string[] }>;
+  putLocalWatchlist(input: { symbols: unknown }): Promise<{ symbols: string[] }>;
   getSubscribeUrl(): Promise<{
     subscribeUrl: string | null;
     priceLabel: string | null;
@@ -64,5 +66,7 @@ export const settingsRoutes = defineRoutes<SettingsApi>('settings', {
   resetCredentials: { method: 'POST', path: '/ai/reset-credentials' },
   getWatchedMarkets: { method: 'GET', path: '/watched-markets' },
   putWatchedMarkets: { method: 'PUT', path: '/watched-markets' },
+  getLocalWatchlist: { method: 'GET', path: '/local-watchlist' },
+  putLocalWatchlist: { method: 'PUT', path: '/local-watchlist' },
   getSubscribeUrl: { method: 'GET', path: '/subscribe-url' },
 });

--- a/packages/core/src/credentials/credentials.service.ts
+++ b/packages/core/src/credentials/credentials.service.ts
@@ -1,6 +1,7 @@
 import type { CredentialsApi } from '../contract/credentials.js';
 import { locateLongbridgeCli } from '../marketdata/longbridgeCli.js';
 import { readLongbridgeToken, LongbridgeTokenError } from '../marketdata/longbridgeToken.js';
+import { setDefaultProviderName } from '../marketdata/registry.js';
 import { probeOpencli } from './opencli.js';
 
 export const credentialsService: CredentialsApi = {
@@ -10,6 +11,7 @@ export const credentialsService: CredentialsApi = {
       cliPath = await locateLongbridgeCli();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      setDefaultProviderName('yahoo');
       return {
         configured: false,
         method: 'cli',
@@ -20,6 +22,7 @@ export const credentialsService: CredentialsApi = {
     }
     try {
       await readLongbridgeToken();
+      setDefaultProviderName('longbridge');
       return { configured: true, method: 'cli', lastError: null, state: 'ready' as const, cliPath };
     } catch (error) {
       const state =
@@ -27,6 +30,7 @@ export const credentialsService: CredentialsApi = {
           ? ('login_required' as const)
           : ('token_unreadable' as const);
       const message = error instanceof Error ? error.message : String(error);
+      setDefaultProviderName('yahoo');
       return { configured: false, method: 'cli', lastError: message, state, cliPath };
     }
   },

--- a/packages/core/src/credentials/credentials.service.ts
+++ b/packages/core/src/credentials/credentials.service.ts
@@ -1,7 +1,7 @@
 import type { CredentialsApi } from '../contract/credentials.js';
 import { locateLongbridgeCli } from '../marketdata/longbridgeCli.js';
 import { readLongbridgeToken, LongbridgeTokenError } from '../marketdata/longbridgeToken.js';
-import { setDefaultProviderName } from '../marketdata/registry.js';
+import { restampFromCredentialStatus } from '../marketdata/defaultProvider.js';
 import { probeOpencli } from './opencli.js';
 
 export const credentialsService: CredentialsApi = {
@@ -11,7 +11,7 @@ export const credentialsService: CredentialsApi = {
       cliPath = await locateLongbridgeCli();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      setDefaultProviderName('yahoo');
+      restampFromCredentialStatus(false);
       return {
         configured: false,
         method: 'cli',
@@ -22,7 +22,7 @@ export const credentialsService: CredentialsApi = {
     }
     try {
       await readLongbridgeToken();
-      setDefaultProviderName('longbridge');
+      restampFromCredentialStatus(true);
       return { configured: true, method: 'cli', lastError: null, state: 'ready' as const, cliPath };
     } catch (error) {
       const state =
@@ -30,7 +30,7 @@ export const credentialsService: CredentialsApi = {
           ? ('login_required' as const)
           : ('token_unreadable' as const);
       const message = error instanceof Error ? error.message : String(error);
-      setDefaultProviderName('yahoo');
+      restampFromCredentialStatus(false);
       return { configured: false, method: 'cli', lastError: message, state, cliPath };
     }
   },

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -197,3 +197,9 @@ export const watchedMarketsSettings = sqliteTable('watched_markets_settings', {
   markets: text('markets', { mode: 'json' }).$type<Market[]>().notNull(),
   updatedAt: text('updated_at').notNull(),
 });
+
+export const localWatchlistSettings = sqliteTable('local_watchlist_settings', {
+  id: integer('id').primaryKey(),
+  symbols: text('symbols', { mode: 'json' }).$type<string[]>().notNull(),
+  updatedAt: text('updated_at').notNull(),
+});

--- a/packages/core/src/marketdata/defaultProvider.ts
+++ b/packages/core/src/marketdata/defaultProvider.ts
@@ -1,14 +1,27 @@
 import { credentialsService } from '../credentials/credentials.service.js';
-import { setDefaultProviderName } from './registry.js';
+import {
+  disposeMarketData,
+  emitProviderRoutingChanged,
+  getDefaultProviderName,
+  setDefaultProviderName,
+} from './registry.js';
+
+export function restampFromCredentialStatus(configured: boolean): 'longbridge' | 'yahoo' {
+  const name = configured ? 'longbridge' : 'yahoo';
+  const previous = getDefaultProviderName();
+  setDefaultProviderName(name);
+  if (name !== previous) {
+    disposeMarketData();
+    emitProviderRoutingChanged();
+  }
+  return name;
+}
 
 export async function stampDefaultProvider(): Promise<'longbridge' | 'yahoo'> {
   try {
     const { configured } = await credentialsService.status();
-    const name = configured ? 'longbridge' : 'yahoo';
-    setDefaultProviderName(name);
-    return name;
+    return restampFromCredentialStatus(configured);
   } catch {
-    setDefaultProviderName('yahoo');
-    return 'yahoo';
+    return restampFromCredentialStatus(false);
   }
 }

--- a/packages/core/src/marketdata/defaultProvider.ts
+++ b/packages/core/src/marketdata/defaultProvider.ts
@@ -1,0 +1,14 @@
+import { credentialsService } from '../credentials/credentials.service.js';
+import { setDefaultProviderName } from './registry.js';
+
+export async function stampDefaultProvider(): Promise<'longbridge' | 'yahoo'> {
+  try {
+    const { configured } = await credentialsService.status();
+    const name = configured ? 'longbridge' : 'yahoo';
+    setDefaultProviderName(name);
+    return name;
+  } catch {
+    setDefaultProviderName('yahoo');
+    return 'yahoo';
+  }
+}

--- a/packages/core/src/marketdata/localWatchlistStore.ts
+++ b/packages/core/src/marketdata/localWatchlistStore.ts
@@ -1,0 +1,84 @@
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/index.js';
+import { localWatchlistSettings } from '../db/schema.js';
+import { ClientError } from '../platform/errors.js';
+import { normalizeSymbol } from '../symbols/symbol.utils.js';
+
+export interface LocalWatchlistStore {
+  get(): string[];
+  set(symbols: string[]): void;
+  revision(): number;
+}
+
+export const DEFAULT_LOCAL_WATCHLIST: string[] = [];
+
+export function validateLocalWatchlist(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    throw new ClientError('"symbols" must be an array of tickers', 'e.g. ["MU", "NVDA"]');
+  }
+  const deduped: string[] = [];
+  for (const item of input) {
+    if (typeof item !== 'string') {
+      throw new ClientError(`invalid symbol: ${String(item)}`, 'e.g. MU or MU.US');
+    }
+    const normalized = normalizeSymbol(item);
+    if (!deduped.includes(normalized)) deduped.push(normalized);
+  }
+  return deduped;
+}
+
+export function createLocalWatchlistStore(db: Db): LocalWatchlistStore {
+  let rev = 0;
+
+  const row = db
+    .select()
+    .from(localWatchlistSettings)
+    .where(eq(localWatchlistSettings.id, 1))
+    .get();
+  let cache: string[] = row ? row.symbols : DEFAULT_LOCAL_WATCHLIST;
+
+  return {
+    get(): string[] {
+      return [...cache];
+    },
+
+    set(symbols: string[]): void {
+      const validated = validateLocalWatchlist(symbols);
+      const updatedAt = new Date().toISOString();
+
+      db.insert(localWatchlistSettings)
+        .values({ id: 1, symbols: validated, updatedAt })
+        .onConflictDoUpdate({
+          target: localWatchlistSettings.id,
+          set: { symbols: validated, updatedAt },
+        })
+        .run();
+
+      cache = validated;
+      rev += 1;
+    },
+
+    revision(): number {
+      return rev;
+    },
+  };
+}
+
+let active: LocalWatchlistStore | null = null;
+
+export function setActiveLocalWatchlistStore(store: LocalWatchlistStore | null): void {
+  active = store;
+}
+
+export function getActiveLocalWatchlistStore(): LocalWatchlistStore {
+  if (!active) {
+    throw new Error(
+      'localWatchlistStore: no active local-watchlist store; call setActiveLocalWatchlistStore before use',
+    );
+  }
+  return active;
+}
+
+export function getLocalWatchlistOrDefault(): string[] {
+  return active ? active.get() : DEFAULT_LOCAL_WATCHLIST;
+}

--- a/packages/core/src/marketdata/longbridge.ts
+++ b/packages/core/src/marketdata/longbridge.ts
@@ -175,6 +175,7 @@ export function createLongbridgeProvider(
 
   return {
     name: 'longbridge',
+    realtime: true,
     capabilities: new Set([
       'flow',
       'capital-distribution',

--- a/packages/core/src/marketdata/quoteNormalize.ts
+++ b/packages/core/src/marketdata/quoteNormalize.ts
@@ -1,0 +1,54 @@
+import type { QuoteCell } from '@kansoku/shared/types';
+import { classifySession, sessionLabel } from './session.js';
+import { marketOf } from '../symbols/symbol.utils.js';
+import type { ExtendedQuote, RawQuote } from './types.js';
+
+const EXTENDED_FRESH_MS = 15 * 60_000;
+
+export function normalizeQuote(q: RawQuote, nowMs: number): QuoteCell {
+  const regularLast = Number(q.last);
+  const regularPct = Number(q.change_percentage);
+  const market = marketOf(q.symbol);
+  const clock = classifySession(Math.floor(nowMs / 1000), market);
+  const turnoverNum = Number(q.turnover);
+  const turnover = Number.isFinite(turnoverNum) && turnoverNum > 0 ? { turnover: turnoverNum } : {};
+  if (clock === 'regular') {
+    return {
+      symbol: q.symbol,
+      session: '日盘',
+      last: regularLast,
+      pct: regularPct,
+      regularLast,
+      regularPct,
+      ...turnover,
+    };
+  }
+  const label = sessionLabel(clock, market);
+  const preferred: ExtendedQuote | undefined =
+    clock === 'pre' ? q.pre_market : clock === 'post' ? q.post_market : q.overnight;
+  if (preferred?.last && preferred.prev_close && preferred.timestamp) {
+    const ts = Date.parse(preferred.timestamp);
+    if (nowMs - ts <= EXTENDED_FRESH_MS) {
+      const last = Number(preferred.last);
+      const prev = Number(preferred.prev_close);
+      return {
+        symbol: q.symbol,
+        session: label,
+        last,
+        pct: prev ? (last / prev - 1) * 100 : null,
+        regularLast,
+        regularPct,
+        ...turnover,
+      };
+    }
+  }
+  return {
+    symbol: q.symbol,
+    session: market === 'US' ? '日盘' : label,
+    last: regularLast,
+    pct: regularPct,
+    regularLast,
+    regularPct,
+    ...turnover,
+  };
+}

--- a/packages/core/src/marketdata/registry.ts
+++ b/packages/core/src/marketdata/registry.ts
@@ -6,6 +6,7 @@ import type { QuoteStream } from './quoteStream.js';
 import { resetSharedQuoteSocket } from './sharedSocket.js';
 import type { MarketDataProvider } from './types.js';
 import { yahooProvider } from './yahoo/provider.js';
+import { getYahooStream, resetYahooStream } from './yahoo/stream.js';
 
 const providers: Record<string, MarketDataProvider> = {
   longbridge: longbridgeProvider,
@@ -14,6 +15,7 @@ const providers: Record<string, MarketDataProvider> = {
 
 const streamFactories: Record<string, () => QuoteStream> = {
   longbridge: getLongbridgeStream,
+  yahoo: getYahooStream,
 };
 
 function resolveProviderName(market: Market): string {
@@ -50,5 +52,6 @@ export function listProviders(): string[] {
 
 export function disposeMarketData(): void {
   resetLongbridgeStream();
+  resetYahooStream();
   resetSharedQuoteSocket();
 }

--- a/packages/core/src/marketdata/registry.ts
+++ b/packages/core/src/marketdata/registry.ts
@@ -5,9 +5,11 @@ import { getLongbridgeStream, resetLongbridgeStream } from './longbridgeStream.j
 import type { QuoteStream } from './quoteStream.js';
 import { resetSharedQuoteSocket } from './sharedSocket.js';
 import type { MarketDataProvider } from './types.js';
+import { yahooProvider } from './yahoo/provider.js';
 
 const providers: Record<string, MarketDataProvider> = {
   longbridge: longbridgeProvider,
+  yahoo: yahooProvider,
 };
 
 const streamFactories: Record<string, () => QuoteStream> = {

--- a/packages/core/src/marketdata/registry.ts
+++ b/packages/core/src/marketdata/registry.ts
@@ -18,8 +18,20 @@ const streamFactories: Record<string, () => QuoteStream> = {
   yahoo: getYahooStream,
 };
 
+let defaultProviderName = 'longbridge';
+
+export function setDefaultProviderName(name: string): void {
+  defaultProviderName = name;
+}
+
+export function getDefaultProviderName(): string {
+  return defaultProviderName;
+}
+
 function resolveProviderName(market: Market): string {
-  return process.env[`MARKET_PROVIDER_${market}`] || process.env.MARKET_PROVIDER || 'longbridge';
+  return (
+    process.env[`MARKET_PROVIDER_${market}`] || process.env.MARKET_PROVIDER || defaultProviderName
+  );
 }
 
 export function getProvider(market: Market = 'US'): MarketDataProvider {

--- a/packages/core/src/marketdata/registry.ts
+++ b/packages/core/src/marketdata/registry.ts
@@ -20,12 +20,25 @@ const streamFactories: Record<string, () => QuoteStream> = {
 
 let defaultProviderName = 'longbridge';
 
+const routingChangeListeners = new Set<() => void>();
+
 export function setDefaultProviderName(name: string): void {
   defaultProviderName = name;
 }
 
 export function getDefaultProviderName(): string {
   return defaultProviderName;
+}
+
+export function onProviderRoutingChanged(listener: () => void): () => void {
+  routingChangeListeners.add(listener);
+  return () => {
+    routingChangeListeners.delete(listener);
+  };
+}
+
+export function emitProviderRoutingChanged(): void {
+  for (const listener of routingChangeListeners) listener();
 }
 
 function resolveProviderName(market: Market): string {

--- a/packages/core/src/marketdata/types.ts
+++ b/packages/core/src/marketdata/types.ts
@@ -95,6 +95,7 @@ export type Capability =
 
 export interface MarketDataProvider {
   readonly name: string;
+  readonly realtime: boolean;
   readonly capabilities: ReadonlySet<Capability>;
   getKline(symbol: string, period: string, count: number, session?: string): Promise<RawBar[]>;
   getQuotes(symbols: string[]): Promise<RawQuote[]>;

--- a/packages/core/src/marketdata/watchlist.ts
+++ b/packages/core/src/marketdata/watchlist.ts
@@ -1,0 +1,9 @@
+import { getLocalWatchlistOrDefault } from './localWatchlistStore.js';
+import type { MarketDataProvider } from './types.js';
+
+export async function watchlistSymbols(provider: MarketDataProvider): Promise<string[]> {
+  if (provider.getWatchlistSymbols) {
+    return provider.getWatchlistSymbols();
+  }
+  return getLocalWatchlistOrDefault();
+}

--- a/packages/core/src/marketdata/yahoo/client.ts
+++ b/packages/core/src/marketdata/yahoo/client.ts
@@ -33,7 +33,9 @@ export function createYahooClient(opts: YahooClientOptions = {}): YahooClient {
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
   let cookie: string | undefined;
+  let cookiePromise: Promise<void> | null = null;
   let crumb: string | undefined;
+  let crumbPromise: Promise<void> | null = null;
   let lastStart: number | null = null;
   let queue: Promise<void> = Promise.resolve();
 
@@ -55,25 +57,15 @@ export function createYahooClient(opts: YahooClientOptions = {}): YahooClient {
 
   function invalidate(): void {
     cookie = undefined;
+    cookiePromise = null;
     crumb = undefined;
-  }
-
-  async function ensureCookie(): Promise<void> {
-    if (cookie !== undefined) return;
-    const response = await throttledFetch(COOKIE_URL, { 'User-Agent': USER_AGENT });
-    cookie = response.headers.get('set-cookie') ?? '';
+    crumbPromise = null;
   }
 
   function buildHeaders(): Record<string, string> {
     const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
     if (cookie) headers.Cookie = cookie;
     return headers;
-  }
-
-  async function ensureCrumb(): Promise<void> {
-    if (crumb !== undefined) return;
-    const response = await throttledFetch(CRUMB_URL, buildHeaders());
-    crumb = await response.text();
   }
 
   async function fetchWithBackoff(url: string): Promise<Response> {
@@ -88,6 +80,47 @@ export function createYahooClient(opts: YahooClientOptions = {}): YahooClient {
       waitMs *= 2;
     }
     throw new ClientError('yahoo request was rate limited', YAHOO_HINT, 429);
+  }
+
+  async function ensureCookie(): Promise<void> {
+    if (cookie !== undefined) return;
+    if (!cookiePromise) {
+      cookiePromise = (async () => {
+        const response = await fetchWithBackoff(COOKIE_URL);
+        cookie = response.headers.get('set-cookie') ?? '';
+      })();
+    }
+    try {
+      await cookiePromise;
+    } finally {
+      cookiePromise = null;
+    }
+  }
+
+  async function ensureCrumb(): Promise<void> {
+    if (crumb !== undefined) return;
+    if (!crumbPromise) {
+      crumbPromise = (async () => {
+        const response = await fetchWithBackoff(CRUMB_URL);
+        if (!response.ok) {
+          throw new ClientError(
+            `yahoo crumb request failed with status ${response.status}`,
+            YAHOO_HINT,
+            response.status,
+          );
+        }
+        const value = await response.text();
+        if (!value) {
+          throw new ClientError('yahoo crumb response was empty', YAHOO_HINT, response.status);
+        }
+        crumb = value;
+      })();
+    }
+    try {
+      await crumbPromise;
+    } finally {
+      crumbPromise = null;
+    }
   }
 
   async function attemptRequest(url: string, wantsCrumb: boolean): Promise<Response> {

--- a/packages/core/src/marketdata/yahoo/client.ts
+++ b/packages/core/src/marketdata/yahoo/client.ts
@@ -1,0 +1,136 @@
+import { ClientError } from '../../platform/errors.js';
+
+export interface YahooClient {
+  getJson(url: string, opts?: { crumb?: boolean }): Promise<unknown>;
+}
+
+export interface YahooClientOptions {
+  fetchImpl?: typeof fetch;
+  minIntervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const COOKIE_URL = 'https://fc.yahoo.com/';
+const CRUMB_URL = 'https://query1.finance.yahoo.com/v1/test/getcrumb';
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+const YAHOO_HINT =
+  'Yahoo Finance is a free, unofficial data source; it may throttle, block, or change behavior without notice.';
+const DEFAULT_MIN_INTERVAL_MS = 250;
+const MAX_ATTEMPTS_429 = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+function appendCrumb(url: string, crumb: string): string {
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}crumb=${encodeURIComponent(crumb)}`;
+}
+
+export function createYahooClient(opts: YahooClientOptions = {}): YahooClient {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const minIntervalMs = opts.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let cookie: string | undefined;
+  let crumb: string | undefined;
+  let lastStart: number | null = null;
+  let queue: Promise<void> = Promise.resolve();
+
+  async function throttledFetch(url: string, headers: Record<string, string>): Promise<Response> {
+    const prev = queue;
+    let release!: () => void;
+    queue = new Promise((resolve) => {
+      release = resolve;
+    });
+    await prev;
+    if (lastStart !== null) {
+      const elapsed = now() - lastStart;
+      if (elapsed < minIntervalMs) await sleep(minIntervalMs - elapsed);
+    }
+    lastStart = now();
+    release();
+    return fetchImpl(url, { headers });
+  }
+
+  function invalidate(): void {
+    cookie = undefined;
+    crumb = undefined;
+  }
+
+  async function ensureCookie(): Promise<void> {
+    if (cookie !== undefined) return;
+    const response = await throttledFetch(COOKIE_URL, { 'User-Agent': USER_AGENT });
+    cookie = response.headers.get('set-cookie') ?? '';
+  }
+
+  function buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+    if (cookie) headers.Cookie = cookie;
+    return headers;
+  }
+
+  async function ensureCrumb(): Promise<void> {
+    if (crumb !== undefined) return;
+    const response = await throttledFetch(CRUMB_URL, buildHeaders());
+    crumb = await response.text();
+  }
+
+  async function fetchWithBackoff(url: string): Promise<Response> {
+    let waitMs = INITIAL_BACKOFF_MS;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS_429; attempt++) {
+      const response = await throttledFetch(url, buildHeaders());
+      if (response.status !== 429) return response;
+      if (attempt >= MAX_ATTEMPTS_429) {
+        throw new ClientError('yahoo request was rate limited', YAHOO_HINT, 429);
+      }
+      await sleep(waitMs);
+      waitMs *= 2;
+    }
+    throw new ClientError('yahoo request was rate limited', YAHOO_HINT, 429);
+  }
+
+  async function attemptRequest(url: string, wantsCrumb: boolean): Promise<Response> {
+    await ensureCookie();
+    if (wantsCrumb) await ensureCrumb();
+    const finalUrl = wantsCrumb && crumb ? appendCrumb(url, crumb) : url;
+    return fetchWithBackoff(finalUrl);
+  }
+
+  return {
+    async getJson(url: string, opts: { crumb?: boolean } = {}): Promise<unknown> {
+      const wantsCrumb = opts.crumb === true;
+      let response = await attemptRequest(url, wantsCrumb);
+      if (response.status === 401 || response.status === 403) {
+        invalidate();
+        response = await attemptRequest(url, wantsCrumb);
+        if (response.status === 401 || response.status === 403) {
+          throw new ClientError(
+            `yahoo request failed with status ${response.status} after retrying`,
+            YAHOO_HINT,
+            response.status,
+          );
+        }
+      }
+      if (!response.ok) {
+        throw new ClientError(`yahoo request failed with status ${response.status}`, YAHOO_HINT, response.status);
+      }
+      try {
+        return await response.json();
+      } catch {
+        throw new ClientError('failed to parse yahoo response as JSON', YAHOO_HINT, response.status);
+      }
+    },
+  };
+}
+
+let instance: YahooClient | null = null;
+
+export function getYahooClient(): YahooClient {
+  if (!instance) instance = createYahooClient();
+  return instance;
+}
+
+export function resetYahooClient(): void {
+  instance = null;
+}

--- a/packages/core/src/marketdata/yahoo/provider.ts
+++ b/packages/core/src/marketdata/yahoo/provider.ts
@@ -1,0 +1,287 @@
+import type { NewsItem, RawBar } from '@kansoku/shared/types';
+import { ClientError } from '../../platform/errors.js';
+import { getYahooClient, type YahooClient } from './client.js';
+import { toYahooSymbol } from './symbolMap.js';
+import type { EarningsCalendarEntry, MarketDataProvider, RawQuote } from '../types.js';
+
+const CHART_BASE = 'https://query1.finance.yahoo.com/v8/finance/chart';
+const QUOTE_BASE = 'https://query1.finance.yahoo.com/v7/finance/quote';
+const SEARCH_BASE = 'https://query1.finance.yahoo.com/v1/finance/search';
+const QUOTE_SUMMARY_BASE = 'https://query1.finance.yahoo.com/v10/finance/quoteSummary';
+
+const YAHOO_INTERVALS: Record<string, string> = {
+  '1m': '1m', '5m': '5m', '15m': '15m', '30m': '30m', '1h': '60m', day: '1d', week: '1wk', month: '1mo',
+};
+const PERIOD_ALIASES: Record<string, string> = { '60m': '1h' };
+const HISTORY_LIMIT_DAYS: Record<string, number> = { '1m': 7, '5m': 60, '15m': 60, '30m': 60, '60m': 730 };
+const INTRADAY_MINUTES: Record<string, number> = { '1m': 1, '5m': 5, '15m': 15, '30m': 30, '60m': 60 };
+const MINUTES_PER_TRADING_DAY = 390;
+
+function toYahooInterval(period: string): string {
+  const normalized = PERIOD_ALIASES[period] ?? period;
+  if (normalized === 'year') {
+    throw new ClientError(
+      `getKline: unsupported period "${period}"`,
+      'yahoo has no yearly interval; use "month" instead',
+    );
+  }
+  const interval = YAHOO_INTERVALS[normalized];
+  if (!interval) {
+    throw new ClientError(
+      `getKline: unsupported period "${period}"`,
+      `supported periods: ${Object.keys(YAHOO_INTERVALS).join(', ')} (aliases: ${Object.keys(PERIOD_ALIASES).join(', ')})`,
+    );
+  }
+  return interval;
+}
+
+function calendarSecondsFor(interval: string, count: number): number {
+  const minutes = INTRADAY_MINUTES[interval];
+  if (minutes) {
+    const barsPerTradingDay = Math.max(1, Math.floor(MINUTES_PER_TRADING_DAY / minutes));
+    const tradingDays = Math.ceil(count / barsPerTradingDay) + 5;
+    return (Math.ceil((tradingDays * 7) / 5) + 10) * 86400;
+  }
+  if (interval === '1d') return (Math.ceil((count * 7) / 5) + 15) * 86400;
+  if (interval === '1wk') return (count * 7 + 21) * 86400;
+  return (count * 31 + 31) * 86400;
+}
+
+function clampPeriod1(interval: string, period1: number, period2: number): number {
+  const limitDays = HISTORY_LIMIT_DAYS[interval];
+  if (!limitDays) return period1;
+  return Math.max(period1, period2 - limitDays * 86400);
+}
+
+interface YahooChartQuote {
+  open?: Array<number | null>;
+  high?: Array<number | null>;
+  low?: Array<number | null>;
+  close?: Array<number | null>;
+  volume?: Array<number | null>;
+}
+
+interface YahooChartResponse {
+  chart?: {
+    error?: unknown;
+    result?: Array<{ timestamp?: number[]; indicators?: { quote?: YahooChartQuote[] } }> | null;
+  };
+}
+
+function parseChartBars(payload: YahooChartResponse, symbol: string, count: number): RawBar[] {
+  const result = payload.chart?.result?.[0];
+  if (payload.chart?.error || !result) {
+    throw new ClientError(
+      `yahoo getKline: malformed or empty chart response for ${symbol}`,
+      'yahoo may not carry history for this symbol/period combination',
+    );
+  }
+  const timestamps = result.timestamp ?? [];
+  const quote = result.indicators?.quote?.[0] ?? {};
+  const bars: RawBar[] = [];
+  for (let i = 0; i < timestamps.length; i++) {
+    const open = quote.open?.[i];
+    const high = quote.high?.[i];
+    const low = quote.low?.[i];
+    const close = quote.close?.[i];
+    if (open == null || high == null || low == null || close == null) continue;
+    bars.push({
+      time: new Date(timestamps[i] * 1000).toISOString(),
+      open,
+      high,
+      low,
+      close,
+      volume: quote.volume?.[i] ?? 0,
+    });
+  }
+  return bars.slice(-count);
+}
+
+interface YahooQuoteRow {
+  symbol?: string;
+  regularMarketPrice?: number;
+  regularMarketPreviousClose?: number;
+  regularMarketChangePercent?: number;
+  marketCap?: number;
+  longName?: string;
+  shortName?: string;
+  preMarketPrice?: number;
+  preMarketTime?: number;
+  postMarketPrice?: number;
+  postMarketTime?: number;
+}
+
+interface QuoteRowEntry {
+  canonical: string;
+  row: YahooQuoteRow;
+}
+
+async function fetchQuoteRows(client: YahooClient, symbols: string[]): Promise<QuoteRowEntry[]> {
+  const yahooToCanonical = new Map<string, string>();
+  for (const canonical of symbols) {
+    try {
+      const yahooSymbol = toYahooSymbol(canonical);
+      if (!yahooToCanonical.has(yahooSymbol)) yahooToCanonical.set(yahooSymbol, canonical);
+    } catch {
+      continue;
+    }
+  }
+  if (!yahooToCanonical.size) return [];
+  const url = `${QUOTE_BASE}?symbols=${encodeURIComponent([...yahooToCanonical.keys()].join(','))}`;
+  const payload = (await client.getJson(url, { crumb: true })) as {
+    quoteResponse?: { result?: YahooQuoteRow[] };
+  };
+  const entries: QuoteRowEntry[] = [];
+  for (const row of payload.quoteResponse?.result ?? []) {
+    const canonical = row.symbol ? yahooToCanonical.get(row.symbol) : undefined;
+    if (canonical) entries.push({ canonical, row });
+  }
+  return entries;
+}
+
+function changePercentage(row: YahooQuoteRow): string {
+  if (typeof row.regularMarketChangePercent === 'number') {
+    return row.regularMarketChangePercent.toFixed(3);
+  }
+  const last = row.regularMarketPrice;
+  const prev = row.regularMarketPreviousClose;
+  if (!prev || !Number.isFinite(last ?? NaN) || !Number.isFinite(prev)) return '0';
+  return (((last as number) / prev - 1) * 100).toFixed(3);
+}
+
+function toRawQuote(canonical: string, row: YahooQuoteRow): RawQuote {
+  const quote: RawQuote = {
+    symbol: canonical,
+    last: String(row.regularMarketPrice ?? 0),
+    prev_close: String(row.regularMarketPreviousClose ?? 0),
+    change_percentage: changePercentage(row),
+  };
+  if (typeof row.preMarketPrice === 'number') {
+    quote.pre_market = {
+      last: String(row.preMarketPrice),
+      prev_close: String(row.regularMarketPreviousClose ?? row.regularMarketPrice ?? 0),
+      ...(typeof row.preMarketTime === 'number'
+        ? { timestamp: new Date(row.preMarketTime * 1000).toISOString() }
+        : {}),
+    };
+  }
+  if (typeof row.postMarketPrice === 'number') {
+    quote.post_market = {
+      last: String(row.postMarketPrice),
+      prev_close: String(row.regularMarketPrice ?? row.regularMarketPreviousClose ?? 0),
+      ...(typeof row.postMarketTime === 'number'
+        ? { timestamp: new Date(row.postMarketTime * 1000).toISOString() }
+        : {}),
+    };
+  }
+  return quote;
+}
+
+interface YahooSearchResponse {
+  news?: Array<{ uuid?: string; title?: string; link?: string; providerPublishTime?: number }>;
+}
+
+interface YahooQuoteSummaryResponse {
+  quoteSummary?: {
+    result?: Array<{
+      calendarEvents?: {
+        earnings?: { earningsDate?: Array<{ raw?: number }>; isEarningsDateEstimate?: boolean };
+      };
+    }>;
+  };
+}
+
+export function createYahooProvider(client: YahooClient): MarketDataProvider {
+  return {
+    name: 'yahoo',
+    realtime: false,
+    capabilities: new Set(['earnings-calendar', 'market-cap']),
+
+    async getKline(symbol, period, count, session): Promise<RawBar[]> {
+      const interval = toYahooInterval(period);
+      const yahooSymbol = toYahooSymbol(symbol);
+      const period2 = Math.floor(Date.now() / 1000);
+      const rawPeriod1 = period2 - calendarSecondsFor(interval, count);
+      const period1 = clampPeriod1(interval, rawPeriod1, period2);
+      const includePrePost = session === 'all';
+      const url = `${CHART_BASE}/${encodeURIComponent(yahooSymbol)}?period1=${period1}&period2=${period2}&interval=${interval}&includePrePost=${includePrePost}`;
+      const payload = (await client.getJson(url)) as YahooChartResponse;
+      return parseChartBars(payload, symbol, count);
+    },
+
+    async getQuotes(symbols): Promise<RawQuote[]> {
+      if (!symbols.length) return [];
+      const entries = await fetchQuoteRows(client, symbols);
+      return entries.map(({ canonical, row }) => toRawQuote(canonical, row));
+    },
+
+    async getSecurityName(symbol): Promise<string | null> {
+      try {
+        const entries = await fetchQuoteRows(client, [symbol]);
+        const row = entries[0]?.row;
+        const name = row?.longName ?? row?.shortName;
+        return name || null;
+      } catch {
+        return null;
+      }
+    },
+
+    async getNews(symbol, limit = 10): Promise<NewsItem[]> {
+      try {
+        const yahooSymbol = toYahooSymbol(symbol);
+        const url = `${SEARCH_BASE}?q=${encodeURIComponent(yahooSymbol)}&newsCount=${limit}&quotesCount=0`;
+        const payload = (await client.getJson(url)) as YahooSearchResponse;
+        const rows = payload.news ?? [];
+        const items: NewsItem[] = [];
+        for (const row of rows.slice(0, limit)) {
+          if (!row.uuid || !row.title || !row.link || typeof row.providerPublishTime !== 'number') continue;
+          items.push({
+            id: row.uuid,
+            title: row.title,
+            published_at: new Date(row.providerPublishTime * 1000).toISOString(),
+            url: row.link,
+          });
+        }
+        return items;
+      } catch {
+        return [];
+      }
+    },
+
+    async getMarketCaps(symbols): Promise<Record<string, number>> {
+      if (!symbols.length) return {};
+      const entries = await fetchQuoteRows(client, symbols);
+      const caps: Record<string, number> = {};
+      for (const { canonical, row } of entries) {
+        if (typeof row.marketCap === 'number' && Number.isFinite(row.marketCap)) {
+          caps[canonical] = row.marketCap;
+        }
+      }
+      return caps;
+    },
+
+    async getEarningsCalendar(symbol, fromDate): Promise<EarningsCalendarEntry | null> {
+      try {
+        const yahooSymbol = toYahooSymbol(symbol);
+        const url = `${QUOTE_SUMMARY_BASE}/${encodeURIComponent(yahooSymbol)}?modules=calendarEvents`;
+        const payload = (await client.getJson(url, { crumb: true })) as YahooQuoteSummaryResponse;
+        const earnings = payload.quoteSummary?.result?.[0]?.calendarEvents?.earnings;
+        const candidates = (earnings?.earningsDate ?? [])
+          .map((d) => d.raw)
+          .filter((raw): raw is number => typeof raw === 'number')
+          .map((raw) => new Date(raw * 1000).toISOString().slice(0, 10))
+          .filter((date) => date >= fromDate)
+          .sort();
+        if (!candidates.length) return null;
+        return {
+          date: candidates[0],
+          title: earnings?.isEarningsDateEstimate === false ? 'earnings date' : 'earnings date (estimated)',
+        };
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+export const yahooProvider: MarketDataProvider = createYahooProvider(getYahooClient());

--- a/packages/core/src/marketdata/yahoo/provider.ts
+++ b/packages/core/src/marketdata/yahoo/provider.ts
@@ -42,7 +42,9 @@ function calendarSecondsFor(interval: string, count: number): number {
     const tradingDays = Math.ceil(count / barsPerTradingDay) + 5;
     return (Math.ceil((tradingDays * 7) / 5) + 10) * 86400;
   }
-  if (interval === '1d') return (Math.ceil((count * 7) / 5) + 15) * 86400;
+  if (interval === '1d') {
+    return (Math.ceil((count * 7) / 5) + 15 + Math.ceil(count * 0.06)) * 86400;
+  }
   if (interval === '1wk') return (count * 7 + 21) * 86400;
   return (count * 31 + 31) * 86400;
 }
@@ -159,7 +161,7 @@ function toRawQuote(canonical: string, row: YahooQuoteRow): RawQuote {
   if (typeof row.preMarketPrice === 'number') {
     quote.pre_market = {
       last: String(row.preMarketPrice),
-      prev_close: String(row.regularMarketPreviousClose ?? row.regularMarketPrice ?? 0),
+      prev_close: String(row.regularMarketPrice ?? row.regularMarketPreviousClose ?? 0),
       ...(typeof row.preMarketTime === 'number'
         ? { timestamp: new Date(row.preMarketTime * 1000).toISOString() }
         : {}),
@@ -275,7 +277,7 @@ export function createYahooProvider(client: YahooClient): MarketDataProvider {
         if (!candidates.length) return null;
         return {
           date: candidates[0],
-          title: earnings?.isEarningsDateEstimate === false ? 'earnings date' : 'earnings date (estimated)',
+          title: earnings?.isEarningsDateEstimate === false ? '财报日期' : '预计财报日期',
         };
       } catch {
         return null;

--- a/packages/core/src/marketdata/yahoo/stream.ts
+++ b/packages/core/src/marketdata/yahoo/stream.ts
@@ -1,0 +1,274 @@
+import type { QuoteCell, SessionKind } from '@kansoku/shared/types';
+import { CandleAggregator } from '../candleAggregator.js';
+import { normalizeQuote } from '../quoteNormalize.js';
+import type {
+  CandleBar,
+  CandleListener,
+  CandlePeriod,
+  QuoteListener,
+  QuoteStream,
+} from '../quoteStream.js';
+import { classifySession } from '../session.js';
+import type { Market } from '../../symbols/symbol.utils.js';
+import type { MarketDataProvider, RawQuote } from '../types.js';
+import { yahooProvider } from './provider.js';
+
+const REGULAR_CADENCE_MS = 5_000;
+const EXTENDED_CADENCE_MS = 30_000;
+const IDLE_RECHECK_MS = 60_000;
+const BACKOFF_CAP_MS = 300_000;
+
+const CANDLE_PERIOD_MS: Record<CandlePeriod, number> = {
+  '5m': 5 * 60_000,
+  '15m': 15 * 60_000,
+  '60m': 60 * 60_000,
+};
+
+function candleKey(symbol: string, period: CandlePeriod): string {
+  return `${symbol}\0${period}`;
+}
+
+export interface YahooQuoteStreamDeps {
+  provider?: Pick<MarketDataProvider, 'getQuotes'>;
+  classify?: (ts: number, market?: Market) => SessionKind;
+  now?: () => number;
+}
+
+export class YahooQuoteStream implements QuoteStream {
+  private readonly provider: Pick<MarketDataProvider, 'getQuotes'>;
+  private readonly classify: (ts: number, market?: Market) => SessionKind;
+  private readonly now: () => number;
+  private readonly aggregator: CandleAggregator;
+
+  private refs = new Map<string, number>();
+  private snapshots = new Map<string, QuoteCell>();
+  private listeners = new Set<QuoteListener>();
+  private candleRefs = new Map<string, number>();
+  private candleListeners = new Map<string, Set<CandleListener>>();
+  private candleSeeded = new Set<string>();
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private pollPromise: Promise<void> | null = null;
+  private consecutiveFailures = 0;
+  private tradeSequence = 0;
+
+  constructor(deps: YahooQuoteStreamDeps = {}) {
+    this.provider = deps.provider ?? yahooProvider;
+    this.classify = deps.classify ?? classifySession;
+    this.now = deps.now ?? Date.now;
+    this.aggregator = new CandleAggregator((bar) => this.dispatchCandle(bar));
+  }
+
+  private hasQuoteRef(symbol: string): boolean {
+    return (this.refs.get(symbol) ?? 0) > 0;
+  }
+
+  private hasCandleSubscription(symbol: string): boolean {
+    for (const key of this.candleRefs.keys()) {
+      if (key.startsWith(`${symbol}\0`)) return true;
+    }
+    return false;
+  }
+
+  private isActive(symbol: string): boolean {
+    return this.hasQuoteRef(symbol) || this.hasCandleSubscription(symbol);
+  }
+
+  private symbolsToPoll(): string[] {
+    const symbols = new Set(this.refs.keys());
+    for (const key of this.candleRefs.keys()) symbols.add(key.split('\0')[0]);
+    return [...symbols];
+  }
+
+  private periodsFor(symbol: string): CandlePeriod[] {
+    const periods: CandlePeriod[] = [];
+    for (const key of this.candleRefs.keys()) {
+      const [sym, period] = key.split('\0') as [string, CandlePeriod];
+      if (sym === symbol) periods.push(period);
+    }
+    return periods;
+  }
+
+  private scheduleNext(delayMs: number): void {
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.runPoll();
+    }, delayMs);
+  }
+
+  private runPoll(): Promise<void> {
+    if (this.pollPromise) return this.pollPromise;
+    this.pollPromise = this.doPoll().finally(() => {
+      this.pollPromise = null;
+    });
+    return this.pollPromise;
+  }
+
+  private pokeNow(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    return this.runPoll();
+  }
+
+  private async doPoll(): Promise<void> {
+    const symbols = this.symbolsToPoll();
+    if (!symbols.length) {
+      this.scheduleNext(IDLE_RECHECK_MS);
+      return;
+    }
+    const session = this.classify(Math.floor(this.now() / 1000));
+    if (session !== 'regular' && session !== 'pre' && session !== 'post') {
+      this.scheduleNext(IDLE_RECHECK_MS);
+      return;
+    }
+    const cadence = session === 'regular' ? REGULAR_CADENCE_MS : EXTENDED_CADENCE_MS;
+    try {
+      const rows = await this.provider.getQuotes(symbols);
+      this.consecutiveFailures = 0;
+      this.applyRows(rows);
+    } catch {
+      this.consecutiveFailures += 1;
+    }
+    if (!this.symbolsToPoll().length) {
+      this.scheduleNext(IDLE_RECHECK_MS);
+      return;
+    }
+    if (this.consecutiveFailures === 0) {
+      this.scheduleNext(cadence);
+    } else {
+      this.scheduleNext(Math.min(cadence * 2 ** this.consecutiveFailures, BACKOFF_CAP_MS));
+    }
+  }
+
+  private applyRows(rows: RawQuote[]): void {
+    const nowMs = this.now();
+    for (const row of rows) {
+      const cell = normalizeQuote(row, nowMs);
+      const prev = this.snapshots.get(cell.symbol);
+      this.snapshots.set(cell.symbol, cell);
+      if (
+        !prev ||
+        prev.last !== cell.last ||
+        prev.pct !== cell.pct ||
+        prev.session !== cell.session
+      ) {
+        for (const listener of this.listeners) listener(cell);
+      }
+      this.feedCandles(cell.symbol, cell.last, nowMs);
+    }
+  }
+
+  private feedCandles(symbol: string, price: number, nowMs: number): void {
+    for (const period of this.periodsFor(symbol)) {
+      const key = candleKey(symbol, period);
+      if (!this.candleSeeded.has(key)) {
+        this.candleSeeded.add(key);
+        const periodMs = CANDLE_PERIOD_MS[period];
+        const alignedTs = Math.floor(nowMs / periodMs) * periodMs;
+        this.aggregator.seed(symbol, period, {
+          time: new Date(alignedTs).toISOString(),
+          open: price,
+          high: price,
+          low: price,
+          close: price,
+          volume: 0,
+        });
+        continue;
+      }
+      this.aggregator.handleTrades({
+        symbol,
+        sequence: ++this.tradeSequence,
+        trades: [
+          { price, volume: 0, timestamp: Math.floor(nowMs / 1000), tradeSession: 0 },
+        ],
+      });
+    }
+  }
+
+  private dispatchCandle(bar: CandleBar): void {
+    for (const listener of this.candleListeners.get(candleKey(bar.symbol, bar.period)) ?? []) {
+      listener(bar);
+    }
+  }
+
+  async retain(symbols: string[]): Promise<void> {
+    let becameActive = false;
+    for (const symbol of symbols) {
+      if (!this.isActive(symbol)) becameActive = true;
+      this.refs.set(symbol, (this.refs.get(symbol) ?? 0) + 1);
+    }
+    if (becameActive) await this.pokeNow();
+  }
+
+  async release(symbols: string[]): Promise<void> {
+    for (const symbol of symbols) {
+      const count = (this.refs.get(symbol) ?? 0) - 1;
+      if (count <= 0) {
+        this.refs.delete(symbol);
+        if (!this.hasCandleSubscription(symbol)) this.snapshots.delete(symbol);
+      } else {
+        this.refs.set(symbol, count);
+      }
+    }
+  }
+
+  subscribeCandlesticks(symbol: string, period: CandlePeriod, cb: CandleListener): () => void {
+    const key = candleKey(symbol, period);
+    const becameActive = !this.isActive(symbol);
+    this.candleRefs.set(key, (this.candleRefs.get(key) ?? 0) + 1);
+    const listeners = this.candleListeners.get(key) ?? new Set<CandleListener>();
+    listeners.add(cb);
+    this.candleListeners.set(key, listeners);
+    if (becameActive) void this.pokeNow();
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      listeners.delete(cb);
+      const next = (this.candleRefs.get(key) ?? 0) - 1;
+      if (next <= 0) {
+        this.candleRefs.delete(key);
+        this.candleListeners.delete(key);
+        this.candleSeeded.delete(key);
+        this.aggregator.remove(symbol, period);
+      } else {
+        this.candleRefs.set(key, next);
+      }
+    };
+  }
+
+  onUpdate(listener: QuoteListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getSnapshot(symbol: string): QuoteCell | undefined {
+    return this.snapshots.get(symbol);
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+export function createYahooQuoteStream(deps: YahooQuoteStreamDeps = {}): YahooQuoteStream {
+  return new YahooQuoteStream(deps);
+}
+
+let instance: YahooQuoteStream | null = null;
+
+export function getYahooStream(): YahooQuoteStream {
+  if (!instance) instance = createYahooQuoteStream();
+  return instance;
+}
+
+export function resetYahooStream(): void {
+  instance?.dispose();
+  instance = null;
+}

--- a/packages/core/src/marketdata/yahoo/stream.ts
+++ b/packages/core/src/marketdata/yahoo/stream.ts
@@ -51,6 +51,7 @@ export class YahooQuoteStream implements QuoteStream {
   private pollPromise: Promise<void> | null = null;
   private consecutiveFailures = 0;
   private tradeSequence = 0;
+  private disposed = false;
 
   constructor(deps: YahooQuoteStreamDeps = {}) {
     this.provider = deps.provider ?? yahooProvider;
@@ -90,6 +91,7 @@ export class YahooQuoteStream implements QuoteStream {
   }
 
   private scheduleNext(delayMs: number): void {
+    if (this.disposed) return;
     this.timer = setTimeout(() => {
       this.timer = null;
       void this.runPoll();
@@ -97,6 +99,7 @@ export class YahooQuoteStream implements QuoteStream {
   }
 
   private runPoll(): Promise<void> {
+    if (this.disposed) return Promise.resolve();
     if (this.pollPromise) return this.pollPromise;
     this.pollPromise = this.doPoll().finally(() => {
       this.pollPromise = null;
@@ -126,9 +129,11 @@ export class YahooQuoteStream implements QuoteStream {
     const cadence = session === 'regular' ? REGULAR_CADENCE_MS : EXTENDED_CADENCE_MS;
     try {
       const rows = await this.provider.getQuotes(symbols);
+      if (this.disposed) return;
       this.consecutiveFailures = 0;
       this.applyRows(rows);
     } catch {
+      if (this.disposed) return;
       this.consecutiveFailures += 1;
     }
     if (!this.symbolsToPoll().length) {
@@ -145,6 +150,7 @@ export class YahooQuoteStream implements QuoteStream {
   private applyRows(rows: RawQuote[]): void {
     const nowMs = this.now();
     for (const row of rows) {
+      if (!this.isActive(row.symbol)) continue;
       const cell = normalizeQuote(row, nowMs);
       const prev = this.snapshots.get(cell.symbol);
       this.snapshots.set(cell.symbol, cell);
@@ -250,10 +256,16 @@ export class YahooQuoteStream implements QuoteStream {
   }
 
   dispose(): void {
+    this.disposed = true;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    this.refs.clear();
+    this.candleRefs.clear();
+    this.candleListeners.clear();
+    this.candleSeeded.clear();
+    this.snapshots.clear();
   }
 }
 

--- a/packages/core/src/marketdata/yahoo/symbolMap.ts
+++ b/packages/core/src/marketdata/yahoo/symbolMap.ts
@@ -2,36 +2,45 @@ import { ClientError } from '../../platform/errors.js';
 import { marketOf, normalizeSymbol, type Market } from '../../symbols/symbol.utils.js';
 
 interface YahooMarketMapping {
-  toYahoo(base: string): string;
+  toYahoo(normalized: string): string;
   fromYahoo(yahooSymbol: string): string;
 }
 
 const UNSUPPORTED_HINT = 'market not supported by the yahoo provider yet';
 
+function unsupported(symbol: string): ClientError {
+  return new ClientError(`symbol not supported by yahoo provider: ${symbol}`, UNSUPPORTED_HINT);
+}
+
 const usMapping: YahooMarketMapping = {
-  toYahoo: (base) => (base.startsWith('.') ? `^${base.slice(1)}` : base),
-  fromYahoo: (yahooSymbol) => (yahooSymbol.startsWith('^') ? `.${yahooSymbol.slice(1)}.US` : `${yahooSymbol}.US`),
+  toYahoo: (normalized) => {
+    const base = normalized.endsWith('.US') ? normalized.slice(0, -3) : normalized;
+    const isIndexProxy = base.startsWith('.');
+    const name = isIndexProxy ? base.slice(1) : base;
+    return (isIndexProxy ? '^' : '') + name.replaceAll('.', '-');
+  },
+  fromYahoo: (yahooSymbol) => {
+    if (yahooSymbol.startsWith('^')) {
+      const name = yahooSymbol.slice(1);
+      if (!name) throw unsupported(yahooSymbol);
+      return `.${name}.US`;
+    }
+    if (!yahooSymbol) throw unsupported(yahooSymbol);
+    return `${yahooSymbol.replaceAll('-', '.')}.US`;
+  },
 };
 
 const marketMappings: Partial<Record<Market, YahooMarketMapping>> = {
   US: usMapping,
 };
 
-function splitMarketSuffix(normalized: string): { base: string } {
-  const dot = normalized.lastIndexOf('.');
-  return { base: normalized.slice(0, dot) };
-}
-
-function unsupported(symbol: string): ClientError {
-  return new ClientError(`symbol not supported by yahoo provider: ${symbol}`, UNSUPPORTED_HINT);
-}
-
 export function toYahooSymbol(canonical: string): string {
   const normalized = normalizeSymbol(canonical);
   const mapping = marketMappings[marketOf(normalized)];
   if (!mapping) throw unsupported(normalized);
-  const { base } = splitMarketSuffix(normalized);
-  return mapping.toYahoo(base);
+  const yahooSymbol = mapping.toYahoo(normalized);
+  if (!yahooSymbol) throw unsupported(normalized);
+  return yahooSymbol;
 }
 
 export function fromYahooSymbol(yahooSymbol: string): string {

--- a/packages/core/src/marketdata/yahoo/symbolMap.ts
+++ b/packages/core/src/marketdata/yahoo/symbolMap.ts
@@ -1,0 +1,40 @@
+import { ClientError } from '../../platform/errors.js';
+import { marketOf, normalizeSymbol, type Market } from '../../symbols/symbol.utils.js';
+
+interface YahooMarketMapping {
+  toYahoo(base: string): string;
+  fromYahoo(yahooSymbol: string): string;
+}
+
+const UNSUPPORTED_HINT = 'market not supported by the yahoo provider yet';
+
+const usMapping: YahooMarketMapping = {
+  toYahoo: (base) => (base.startsWith('.') ? `^${base.slice(1)}` : base),
+  fromYahoo: (yahooSymbol) => (yahooSymbol.startsWith('^') ? `.${yahooSymbol.slice(1)}.US` : `${yahooSymbol}.US`),
+};
+
+const marketMappings: Partial<Record<Market, YahooMarketMapping>> = {
+  US: usMapping,
+};
+
+function splitMarketSuffix(normalized: string): { base: string } {
+  const dot = normalized.lastIndexOf('.');
+  return { base: normalized.slice(0, dot) };
+}
+
+function unsupported(symbol: string): ClientError {
+  return new ClientError(`symbol not supported by yahoo provider: ${symbol}`, UNSUPPORTED_HINT);
+}
+
+export function toYahooSymbol(canonical: string): string {
+  const normalized = normalizeSymbol(canonical);
+  const mapping = marketMappings[marketOf(normalized)];
+  if (!mapping) throw unsupported(normalized);
+  const { base } = splitMarketSuffix(normalized);
+  return mapping.toYahoo(base);
+}
+
+export function fromYahooSymbol(yahooSymbol: string): string {
+  if (yahooSymbol.includes('.')) throw unsupported(yahooSymbol);
+  return marketMappings.US!.fromYahoo(yahooSymbol);
+}

--- a/packages/core/src/overview/homeExtras.ts
+++ b/packages/core/src/overview/homeExtras.ts
@@ -1,6 +1,7 @@
 import type { MarketTemp } from '@kansoku/shared/types';
 import type { FlowRow } from '../analysis/simple.js';
 import { getProvider } from '../marketdata/registry.js';
+import { watchlistSymbols } from '../marketdata/watchlist.js';
 
 const FLOW_TTL_MS = 60_000;
 const OPTION_SYMBOL_RE = /\d{6}[CP]\d+/;
@@ -111,7 +112,7 @@ export async function getWatchSymbols(): Promise<string[]> {
   const provider = getProvider();
   const set = new Set<string>();
   const [watchlist, positions] = await Promise.allSettled([
-    provider.getWatchlistSymbols?.() ?? Promise.resolve([]),
+    watchlistSymbols(provider),
     provider.getPositions?.() ?? Promise.resolve([]),
   ]);
   if (watchlist.status === 'fulfilled') for (const s of watchlist.value) set.add(s);

--- a/packages/core/src/realtime/charts.ts
+++ b/packages/core/src/realtime/charts.ts
@@ -5,7 +5,7 @@ import { getEventRisk } from '../marketdata/events.js';
 import { TIMEFRAME_ORDER } from '../analysis/intraday/constants.js';
 import { activeProDetectors } from '../pro/detectors.js';
 import { featureStateSync } from '../pro/features.js';
-import { getStream } from '../marketdata/registry.js';
+import { getStream, onProviderRoutingChanged } from '../marketdata/registry.js';
 import type { CandlePeriod } from '../marketdata/quoteStream.js';
 import { classifySession, isCurrentSessionId } from '../marketdata/session.js';
 import { predictionStale } from '../platform/staleness.js';
@@ -90,6 +90,7 @@ interface LatestDoc {
 
 interface CandleState {
   viewCount: number | undefined;
+  symbol: string;
   market: Market;
   timeframes: Partial<Record<TimeframeKey, RawBar[]>>;
   frozenRanges: Partial<Record<TimeframeKey, FrozenBarRange>>;
@@ -187,7 +188,22 @@ async function runPushRebuild(key: string): Promise<void> {
   handle.pushData(await buildFromState(state, latest));
 }
 
+let routingUnsub: (() => void) | null = null;
+
+function ensureRoutingSubscription(): void {
+  if (!routingUnsub) routingUnsub = onProviderRoutingChanged(rewireCandleStreams);
+}
+
+function rewireCandleStreams(): void {
+  for (const [key, state] of candleStates) {
+    for (const unsub of state.unsubs) unsub();
+    state.unsubs = [];
+    wireCandleState(key, state.symbol, state);
+  }
+}
+
 function wireCandleState(key: string, symbol: string, state: CandleState): void {
+  ensureRoutingSubscription();
   candleStates.set(key, state);
   const stream = getStream(marketOf(symbol));
   for (const tf of TIMEFRAME_ORDER) {
@@ -228,6 +244,7 @@ function setupCandleState(
   };
   const state: CandleState = {
     viewCount,
+    symbol,
     market: marketOf(symbol),
     timeframes,
     frozenRanges: frozenRangesOf(timeframes),
@@ -259,6 +276,7 @@ function setupPreviewCandleState(
   const timeframes = { ...(input.timeframes as Partial<Record<TimeframeKey, RawBar[]>>) };
   const state: CandleState = {
     viewCount: undefined,
+    symbol,
     market: marketOf(symbol),
     timeframes,
     frozenRanges: frozenRangesOf(timeframes),
@@ -285,6 +303,10 @@ function teardownCandleState(key: string): void {
   if (state.debounceTimer) clearTimeout(state.debounceTimer);
   for (const unsub of state.unsubs) unsub();
   candleStates.delete(key);
+  if (candleStates.size === 0 && routingUnsub) {
+    routingUnsub();
+    routingUnsub = null;
+  }
 }
 
 export async function subscribeChart(

--- a/packages/core/src/realtime/position.ts
+++ b/packages/core/src/realtime/position.ts
@@ -5,7 +5,7 @@ import {
   latestIntradayDoc,
   type EntryPlan,
 } from '../cockpit/entryPlan.js';
-import { getProvider, getStream } from '../marketdata/registry.js';
+import { getProvider, getStream, onProviderRoutingChanged } from '../marketdata/registry.js';
 import type { RawPosition } from '../marketdata/types.js';
 import { computeRelativeVolume } from '../analysis/relvol.js';
 import { marketOf } from '../symbols/symbol.utils.js';
@@ -32,6 +32,21 @@ interface State {
 }
 
 const states = new Map<string, State>();
+
+let routingUnsub: (() => void) | null = null;
+
+function rewirePositionStreams(): void {
+  for (const [symbol, state] of states) {
+    state.quoteUnsub?.();
+    state.quoteUnsub = getStream(marketOf(symbol)).onUpdate((cell) => {
+      if (cell.symbol === symbol) schedulePush(state, symbol);
+    });
+    void getStream(marketOf(symbol))
+      .retain([symbol])
+      .catch((err) => console.warn('[ws-position] rewire retain failed', err));
+    void refresh(symbol, state);
+  }
+}
 
 /** Pure: cached position snapshot × a live quote → the channel payload. */
 export function buildPositionPayload(
@@ -86,6 +101,7 @@ async function refresh(symbol: string, state: State): Promise<void> {
 }
 
 export function subscribePosition(symbol: string, push: (envelope: string) => void): () => void {
+  if (!routingUnsub) routingUnsub = onProviderRoutingChanged(rewirePositionStreams);
   let state = states.get(symbol);
   const fresh = !state;
   if (!state) {
@@ -133,6 +149,10 @@ export function subscribePosition(symbol: string, push: (envelope: string) => vo
       void getStream(marketOf(symbol))
         .release([symbol])
         .catch(() => {});
+      if (states.size === 0 && routingUnsub) {
+        routingUnsub();
+        routingUnsub = null;
+      }
     }
   };
 }

--- a/packages/core/src/realtime/quotes.ts
+++ b/packages/core/src/realtime/quotes.ts
@@ -5,61 +5,10 @@ import {
   releaseSymbols,
   retainSymbols,
 } from '../marketdata/streamRouting.js';
-import type { ExtendedQuote, RawQuote } from '../marketdata/types.js';
-import { classifySession, sessionLabel } from '../marketdata/session.js';
 import { marketOf } from '../symbols/symbol.utils.js';
 
 export type { RawQuote } from '../marketdata/types.js';
-
-const EXTENDED_FRESH_MS = 15 * 60_000;
-
-export function normalizeQuote(q: RawQuote, nowMs: number): QuoteCell {
-  const regularLast = Number(q.last);
-  const regularPct = Number(q.change_percentage);
-  const market = marketOf(q.symbol);
-  const clock = classifySession(Math.floor(nowMs / 1000), market);
-  const turnoverNum = Number(q.turnover);
-  const turnover = Number.isFinite(turnoverNum) && turnoverNum > 0 ? { turnover: turnoverNum } : {};
-  if (clock === 'regular') {
-    return {
-      symbol: q.symbol,
-      session: '日盘',
-      last: regularLast,
-      pct: regularPct,
-      regularLast,
-      regularPct,
-      ...turnover,
-    };
-  }
-  const label = sessionLabel(clock, market);
-  const preferred: ExtendedQuote | undefined =
-    clock === 'pre' ? q.pre_market : clock === 'post' ? q.post_market : q.overnight;
-  if (preferred?.last && preferred.prev_close && preferred.timestamp) {
-    const ts = Date.parse(preferred.timestamp);
-    if (nowMs - ts <= EXTENDED_FRESH_MS) {
-      const last = Number(preferred.last);
-      const prev = Number(preferred.prev_close);
-      return {
-        symbol: q.symbol,
-        session: label,
-        last,
-        pct: prev ? (last / prev - 1) * 100 : null,
-        regularLast,
-        regularPct,
-        ...turnover,
-      };
-    }
-  }
-  return {
-    symbol: q.symbol,
-    session: market === 'US' ? '日盘' : label,
-    last: regularLast,
-    pct: regularPct,
-    regularLast,
-    regularPct,
-    ...turnover,
-  };
-}
+export { normalizeQuote } from '../marketdata/quoteNormalize.js';
 
 const SYMBOLS_TTL_MS = 600_000;
 const COALESCE_MS = 250;

--- a/packages/core/src/realtime/quotes.ts
+++ b/packages/core/src/realtime/quotes.ts
@@ -5,6 +5,7 @@ import {
   releaseSymbols,
   retainSymbols,
 } from '../marketdata/streamRouting.js';
+import { watchlistSymbols } from '../marketdata/watchlist.js';
 import { marketOf } from '../symbols/symbol.utils.js';
 
 export type { RawQuote } from '../marketdata/types.js';
@@ -24,7 +25,7 @@ async function refreshBaseSymbols(): Promise<void> {
     const provider = getProvider();
     const set = new Set<string>();
     const [watchlist, positions] = await Promise.allSettled([
-      provider.getWatchlistSymbols?.() ?? Promise.resolve([]),
+      watchlistSymbols(provider),
       provider.getPositions?.() ?? Promise.resolve([]),
     ]);
     if (watchlist.status === 'fulfilled') {

--- a/packages/core/src/realtime/quotes.ts
+++ b/packages/core/src/realtime/quotes.ts
@@ -1,5 +1,5 @@
 import type { QuoteCell, QuoteSnapshot } from '@kansoku/shared/types';
-import { getProvider, getStream } from '../marketdata/registry.js';
+import { getProvider, getStream, onProviderRoutingChanged } from '../marketdata/registry.js';
 import {
   distinctStreams,
   releaseSymbols,
@@ -53,6 +53,7 @@ const listeners = new Set<(env: string) => void>();
 const dedup = new Set<string>();
 let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
 let listenerHandles: Array<() => void> | null = null;
+let routingUnsub: (() => void) | null = null;
 let baseRefreshTimer: ReturnType<typeof setInterval> | null = null;
 let baseRetained = false;
 let degraded = false;
@@ -98,10 +99,32 @@ function scheduleFlush(symbol: string): void {
 }
 
 function ensureListener(): void {
+  if (!routingUnsub) routingUnsub = onProviderRoutingChanged(rewireStreamsForRoutingChange);
   if (listenerHandles) return;
   listenerHandles = distinctStreams().map((stream) =>
     stream.onUpdate((cell) => scheduleFlush(cell.symbol)),
   );
+}
+
+function rewireStreamsForRoutingChange(): void {
+  if (listenerHandles) {
+    for (const unsub of listenerHandles) unsub();
+    listenerHandles = null;
+  }
+  lastEnvelope = null;
+  if (!listeners.size) {
+    baseRetained = false;
+    return;
+  }
+  ensureListener();
+  const symbols = new Set<string>(extras.keys());
+  if (baseRetained) for (const s of baseSymbols) symbols.add(s);
+  const list = [...symbols];
+  if (list.length) {
+    void retainSymbols(list)
+      .then(() => scheduleFlush(list[0]))
+      .catch(() => {});
+  }
 }
 
 async function ensureBase(): Promise<void> {
@@ -138,6 +161,10 @@ function stopIfIdle(): void {
   if (listenerHandles) {
     for (const unsub of listenerHandles) unsub();
     listenerHandles = null;
+  }
+  if (routingUnsub) {
+    routingUnsub();
+    routingUnsub = null;
   }
   lastEnvelope = null;
   if (baseRetained && baseSymbols.length) {

--- a/packages/core/src/settings/settings.service.ts
+++ b/packages/core/src/settings/settings.service.ts
@@ -1,5 +1,9 @@
 import { resolveSubscription } from '../license/subscription.js';
 import {
+  getActiveLocalWatchlistStore,
+  validateLocalWatchlist,
+} from '../marketdata/localWatchlistStore.js';
+import {
   getActiveWatchedMarketsStore,
   validateWatchedMarkets,
 } from '../marketdata/watchedMarketsStore.js';
@@ -43,6 +47,16 @@ export const settingsService: SettingsApi = {
     const store = getActiveWatchedMarketsStore();
     store.set(validateWatchedMarkets(input.markets));
     return { markets: store.get() };
+  },
+
+  async getLocalWatchlist() {
+    return { symbols: getActiveLocalWatchlistStore().get() };
+  },
+
+  async putLocalWatchlist(input) {
+    const store = getActiveLocalWatchlistStore();
+    store.set(validateLocalWatchlist(input.symbols));
+    return { symbols: store.get() };
   },
 
   async getSubscribeUrl() {

--- a/packages/core/test/capabilities.test.ts
+++ b/packages/core/test/capabilities.test.ts
@@ -38,6 +38,11 @@ describe('capabilitiesService.get', () => {
     }
   });
 
+  it('reports the longbridge datasource for the default watched market', async () => {
+    const result = await capabilitiesService.get();
+    expect(result.datasources).toEqual([{ market: 'US', name: 'longbridge', realtime: true }]);
+  });
+
   it('marks pro-tier keys locked and reports hasEncBundle when only the enc bundle is present', async () => {
     setEncBundlePresent(true);
     const result = await capabilitiesService.get();

--- a/packages/core/test/capabilities.test.ts
+++ b/packages/core/test/capabilities.test.ts
@@ -5,6 +5,7 @@ import {
   type LicenseManager,
 } from '../src/license/licenseState.js';
 import { setEncBundlePresent, setProPresent } from '../src/pro/bundleState.js';
+import { setActiveWatchedMarketsStore } from '../src/marketdata/watchedMarketsStore.js';
 import { capabilitiesService } from '../src/capabilities/capabilities.service.js';
 
 const featureKeys = Object.keys(FEATURES) as Array<keyof typeof FEATURES>;
@@ -23,6 +24,8 @@ afterEach(() => {
   setProPresent(false);
   setEncBundlePresent(false);
   setLicenseManagerForTests(null);
+  setActiveWatchedMarketsStore(null);
+  delete process.env.MARKET_PROVIDER_HK;
 });
 
 describe('capabilitiesService.get', () => {
@@ -76,5 +79,18 @@ describe('capabilitiesService.get', () => {
     for (const key of featureKeys) {
       expect(result.features[key]).toBe('active');
     }
+  });
+
+  it('returns datasources for healthy markets when one provider fails', async () => {
+    process.env.MARKET_PROVIDER_HK = 'bogus-provider';
+    setActiveWatchedMarketsStore({
+      get: () => ['US', 'HK'],
+      set: () => {},
+      revision: () => 0,
+    });
+
+    const result = await capabilitiesService.get();
+
+    expect(result.datasources).toEqual([{ market: 'US', name: 'longbridge', realtime: true }]);
   });
 });

--- a/packages/core/test/capabilities.test.ts
+++ b/packages/core/test/capabilities.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/license/licenseState.js';
 import { setEncBundlePresent, setProPresent } from '../src/pro/bundleState.js';
 import { setActiveWatchedMarketsStore } from '../src/marketdata/watchedMarketsStore.js';
+import { setDefaultProviderName } from '../src/marketdata/registry.js';
 import { capabilitiesService } from '../src/capabilities/capabilities.service.js';
 
 const featureKeys = Object.keys(FEATURES) as Array<keyof typeof FEATURES>;
@@ -25,6 +26,7 @@ afterEach(() => {
   setEncBundlePresent(false);
   setLicenseManagerForTests(null);
   setActiveWatchedMarketsStore(null);
+  setDefaultProviderName('longbridge');
   delete process.env.MARKET_PROVIDER_HK;
 });
 
@@ -44,6 +46,12 @@ describe('capabilitiesService.get', () => {
   it('reports the longbridge datasource for the default watched market', async () => {
     const result = await capabilitiesService.get();
     expect(result.datasources).toEqual([{ market: 'US', name: 'longbridge', realtime: true }]);
+  });
+
+  it('reports a non-realtime datasource when the default provider is yahoo', async () => {
+    setDefaultProviderName('yahoo');
+    const result = await capabilitiesService.get();
+    expect(result.datasources).toEqual([{ market: 'US', name: 'yahoo', realtime: false }]);
   });
 
   it('marks pro-tier keys locked and reports hasEncBundle when only the enc bundle is present', async () => {

--- a/packages/core/test/credentialsService.test.ts
+++ b/packages/core/test/credentialsService.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const locateLongbridgeCli = vi.fn();
+const readLongbridgeToken = vi.fn();
+
+class FakeLongbridgeTokenError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+  ) {
+    super(message);
+  }
+}
+
+vi.mock('../src/marketdata/longbridgeCli.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/marketdata/longbridgeCli.js')>();
+  return {
+    ...actual,
+    locateLongbridgeCli: (...args: unknown[]) => locateLongbridgeCli(...args),
+  };
+});
+
+vi.mock('../src/marketdata/longbridgeToken.js', () => ({
+  readLongbridgeToken: (...args: unknown[]) => readLongbridgeToken(...args),
+  LongbridgeTokenError: FakeLongbridgeTokenError,
+}));
+
+const { credentialsService } = await import('../src/credentials/credentials.service.js');
+const { getDefaultProviderName, setDefaultProviderName } =
+  await import('../src/marketdata/registry.js');
+
+describe('credentialsService.status re-stamps the default provider', () => {
+  afterEach(() => {
+    locateLongbridgeCli.mockReset();
+    readLongbridgeToken.mockReset();
+    setDefaultProviderName('longbridge');
+  });
+
+  it('stamps yahoo when the CLI cannot be located', async () => {
+    locateLongbridgeCli.mockRejectedValue(new Error('not found'));
+    await credentialsService.status();
+    expect(getDefaultProviderName()).toBe('yahoo');
+  });
+
+  it('stamps yahoo when the token is unreadable', async () => {
+    locateLongbridgeCli.mockResolvedValue('/bin/longbridge');
+    readLongbridgeToken.mockRejectedValue(new FakeLongbridgeTokenError('nope', 'NOT_LOGGED_IN'));
+    await credentialsService.status();
+    expect(getDefaultProviderName()).toBe('yahoo');
+  });
+
+  it('re-stamps longbridge after an earlier yahoo stamp once credentials become configured', async () => {
+    locateLongbridgeCli.mockRejectedValue(new Error('not found'));
+    await credentialsService.status();
+    expect(getDefaultProviderName()).toBe('yahoo');
+
+    locateLongbridgeCli.mockResolvedValue('/bin/longbridge');
+    readLongbridgeToken.mockResolvedValue({});
+    await credentialsService.status();
+    expect(getDefaultProviderName()).toBe('longbridge');
+  });
+});

--- a/packages/core/test/defaultProvider.test.ts
+++ b/packages/core/test/defaultProvider.test.ts
@@ -6,9 +6,12 @@ vi.mock('../src/credentials/credentials.service.js', () => ({
   credentialsService: { status: (...args: unknown[]) => status(...args) },
 }));
 
-const { stampDefaultProvider } = await import('../src/marketdata/defaultProvider.js');
-const { getDefaultProviderName, setDefaultProviderName } =
+const { stampDefaultProvider, restampFromCredentialStatus } = await import(
+  '../src/marketdata/defaultProvider.js'
+);
+const { getDefaultProviderName, setDefaultProviderName, onProviderRoutingChanged, disposeMarketData } =
   await import('../src/marketdata/registry.js');
+const { getLongbridgeStream } = await import('../src/marketdata/longbridgeStream.js');
 
 describe('stampDefaultProvider', () => {
   afterEach(() => {
@@ -32,5 +35,35 @@ describe('stampDefaultProvider', () => {
     status.mockRejectedValue(new Error('probe crashed'));
     await expect(stampDefaultProvider()).resolves.toBe('yahoo');
     expect(getDefaultProviderName()).toBe('yahoo');
+  });
+});
+
+describe('restampFromCredentialStatus', () => {
+  afterEach(() => {
+    setDefaultProviderName('longbridge');
+    disposeMarketData();
+  });
+
+  it('fires the routing-changed callback exactly once when the stamped name flips', () => {
+    setDefaultProviderName('yahoo');
+    const cb = vi.fn();
+    const off = onProviderRoutingChanged(cb);
+    try {
+      expect(restampFromCredentialStatus(true)).toBe('longbridge');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(restampFromCredentialStatus(true)).toBe('longbridge');
+      expect(cb).toHaveBeenCalledTimes(1);
+    } finally {
+      off();
+    }
+  });
+
+  it('disposes the stream singletons on a flip but leaves them intact on a no-op', () => {
+    setDefaultProviderName('longbridge');
+    const before = getLongbridgeStream();
+    restampFromCredentialStatus(true);
+    expect(getLongbridgeStream()).toBe(before);
+    restampFromCredentialStatus(false);
+    expect(getLongbridgeStream()).not.toBe(before);
   });
 });

--- a/packages/core/test/defaultProvider.test.ts
+++ b/packages/core/test/defaultProvider.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const status = vi.fn();
+
+vi.mock('../src/credentials/credentials.service.js', () => ({
+  credentialsService: { status: (...args: unknown[]) => status(...args) },
+}));
+
+const { stampDefaultProvider } = await import('../src/marketdata/defaultProvider.js');
+const { getDefaultProviderName, setDefaultProviderName } =
+  await import('../src/marketdata/registry.js');
+
+describe('stampDefaultProvider', () => {
+  afterEach(() => {
+    status.mockReset();
+    setDefaultProviderName('longbridge');
+  });
+
+  it('stamps longbridge when credentials are configured', async () => {
+    status.mockResolvedValue({ configured: true });
+    await expect(stampDefaultProvider()).resolves.toBe('longbridge');
+    expect(getDefaultProviderName()).toBe('longbridge');
+  });
+
+  it('stamps yahoo when credentials are not configured', async () => {
+    status.mockResolvedValue({ configured: false });
+    await expect(stampDefaultProvider()).resolves.toBe('yahoo');
+    expect(getDefaultProviderName()).toBe('yahoo');
+  });
+
+  it('stamps yahoo without throwing when status() rejects', async () => {
+    status.mockRejectedValue(new Error('probe crashed'));
+    await expect(stampDefaultProvider()).resolves.toBe('yahoo');
+    expect(getDefaultProviderName()).toBe('yahoo');
+  });
+});

--- a/packages/core/test/homeExtras.test.ts
+++ b/packages/core/test/homeExtras.test.ts
@@ -1,8 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDb } from '../src/db/index.js';
+import {
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+} from '../src/marketdata/localWatchlistStore.js';
 import type { MarketDataProvider } from '../src/marketdata/types.js';
 import {
   buildHomeExtras,
   flowEligible,
+  getWatchSymbols,
   netInflow,
   resetHomeExtrasForTests,
 } from '../src/overview/homeExtras.js';
@@ -92,5 +101,27 @@ describe('buildHomeExtras', () => {
     expect(extras.flows['NVDA.US']).toBeNull();
     expect(extras.flows_at).toBeNull();
     expect(extras.market).toBeNull();
+  });
+});
+
+describe('getWatchSymbols falls back to the local watchlist', () => {
+  let dbDir: string;
+
+  afterEach(() => {
+    setActiveLocalWatchlistStore(null);
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('reads the local watchlist when the provider has no getWatchlistSymbols', async () => {
+    dbDir = mkdtempSync(join(tmpdir(), 'home-extras-local-watchlist-'));
+    const store = createLocalWatchlistStore(createDb(join(dbDir, 'app.db')));
+    store.set(['TSM', 'ASML']);
+    setActiveLocalWatchlistStore(store);
+
+    provider.getWatchlistSymbols = undefined;
+    resetHomeExtrasForTests();
+
+    const symbols = await getWatchSymbols();
+    expect(symbols).toEqual(expect.arrayContaining(['TSM.US', 'ASML.US']));
   });
 });

--- a/packages/core/test/localWatchlistSettingsService.test.ts
+++ b/packages/core/test/localWatchlistSettingsService.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDb } from '../src/db/index.js';
+import {
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+} from '../src/marketdata/localWatchlistStore.js';
+import { settingsService } from '../src/settings/settings.service.js';
+
+function tempDbPath(): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'local-watchlist-settings-service-'));
+  return { dir, path: join(dir, 'app.db') };
+}
+
+describe('settingsService local watchlist', () => {
+  afterEach(() => setActiveLocalWatchlistStore(null));
+
+  it('round-trips a valid symbol list through get/put', async () => {
+    const { dir, path } = tempDbPath();
+    try {
+      setActiveLocalWatchlistStore(createLocalWatchlistStore(createDb(path)));
+
+      expect(await settingsService.getLocalWatchlist()).toEqual({ symbols: [] });
+
+      const put = await settingsService.putLocalWatchlist({ symbols: ['mu', 'nvda'] });
+      expect(put).toEqual({ symbols: ['MU.US', 'NVDA.US'] });
+
+      expect(await settingsService.getLocalWatchlist()).toEqual({ symbols: ['MU.US', 'NVDA.US'] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid symbol with a ClientError', async () => {
+    const { dir, path } = tempDbPath();
+    try {
+      setActiveLocalWatchlistStore(createLocalWatchlistStore(createDb(path)));
+
+      await expect(
+        settingsService.putLocalWatchlist({ symbols: ['not a symbol!'] }),
+      ).rejects.toMatchObject({ name: 'ClientError' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/localWatchlistStore.test.ts
+++ b/packages/core/test/localWatchlistStore.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDb } from '../src/db/index.js';
+import {
+  createLocalWatchlistStore,
+  getActiveLocalWatchlistStore,
+  getLocalWatchlistOrDefault,
+  setActiveLocalWatchlistStore,
+  validateLocalWatchlist,
+} from '../src/marketdata/localWatchlistStore.js';
+
+function tempDbPath(): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'local-watchlist-store-'));
+  return { dir, path: join(dir, 'app.db') };
+}
+
+describe('validateLocalWatchlist', () => {
+  it('rejects a non-array', () => {
+    expect(() => validateLocalWatchlist('MU')).toThrow();
+    expect(() => validateLocalWatchlist(null)).toThrow();
+  });
+
+  it('allows an empty array', () => {
+    expect(validateLocalWatchlist([])).toEqual([]);
+  });
+
+  it('normalizes bare tickers to the .US suffix', () => {
+    expect(validateLocalWatchlist(['mu'])).toEqual(['MU.US']);
+  });
+
+  it('preserves multi-dot canonical symbols', () => {
+    expect(validateLocalWatchlist(['BRK.B'])).toEqual(['BRK.B']);
+  });
+
+  it('dedupes while preserving first-occurrence order', () => {
+    expect(validateLocalWatchlist(['MU', 'mu', 'NVDA'])).toEqual(['MU.US', 'NVDA.US']);
+  });
+
+  it('rejects an invalid symbol', () => {
+    expect(() => validateLocalWatchlist(['not a symbol!'])).toThrow();
+  });
+});
+
+describe('createLocalWatchlistStore', () => {
+  it('defaults to [] when no row exists', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      expect(store.get()).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips a set value and persists across store instances', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const db1 = createDb(path);
+      const store1 = createLocalWatchlistStore(db1);
+      store1.set(['MU', 'NVDA']);
+      expect(store1.get()).toEqual(['MU.US', 'NVDA.US']);
+
+      const store2 = createLocalWatchlistStore(createDb(path));
+      expect(store2.get()).toEqual(['MU.US', 'NVDA.US']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows clearing via an empty set()', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      store.set(['MU']);
+      expect(store.get()).toEqual(['MU.US']);
+      store.set([]);
+      expect(store.get()).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid symbol and leaves the store unchanged', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      expect(() => store.set(['not a symbol!'])).toThrow();
+      expect(store.get()).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a defensive copy from get()', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      store.set(['MU']);
+      const symbols = store.get();
+      symbols.push('NVDA.US');
+      expect(store.get()).toEqual(['MU.US']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('bumps revision on write', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      expect(store.revision()).toBe(0);
+      store.set(['MU']);
+      expect(store.revision()).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('getActiveLocalWatchlistStore / setActiveLocalWatchlistStore', () => {
+  afterEach(() => setActiveLocalWatchlistStore(null));
+
+  it('throws with a clear message when unset', () => {
+    setActiveLocalWatchlistStore(null);
+    expect(() => getActiveLocalWatchlistStore()).toThrow(/local-watchlist store/i);
+  });
+
+  it('returns the store set via setActiveLocalWatchlistStore', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      setActiveLocalWatchlistStore(store);
+      expect(getActiveLocalWatchlistStore()).toBe(store);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('getLocalWatchlistOrDefault', () => {
+  afterEach(() => setActiveLocalWatchlistStore(null));
+
+  it('falls back to [] with no active store', () => {
+    setActiveLocalWatchlistStore(null);
+    expect(getLocalWatchlistOrDefault()).toEqual([]);
+  });
+
+  it('reads through the active store', () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      store.set(['MU']);
+      setActiveLocalWatchlistStore(store);
+      expect(getLocalWatchlistOrDefault()).toEqual(['MU.US']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/marketdata.test.ts
+++ b/packages/core/test/marketdata.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getProvider, listProviders } from '../src/marketdata/registry.js';
+import { getProvider, getStream, listProviders } from '../src/marketdata/registry.js';
+import { getYahooStream, resetYahooStream } from '../src/marketdata/yahoo/stream.js';
 import type { Capability, MarketDataProvider } from '../src/marketdata/types.js';
 
 const OPTIONAL_METHODS: Record<Capability, keyof MarketDataProvider> = {
@@ -64,6 +65,18 @@ describe('marketdata registry', () => {
   it('selects the yahoo provider when named by MARKET_PROVIDER', () => {
     vi.stubEnv('MARKET_PROVIDER', 'yahoo');
     expect(getProvider().name).toBe('yahoo');
+  });
+});
+
+describe('marketdata stream registry', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetYahooStream();
+  });
+
+  it('selects the yahoo stream when named by MARKET_PROVIDER', () => {
+    vi.stubEnv('MARKET_PROVIDER', 'yahoo');
+    expect(getStream()).toBe(getYahooStream());
   });
 });
 

--- a/packages/core/test/marketdata.test.ts
+++ b/packages/core/test/marketdata.test.ts
@@ -31,8 +31,8 @@ describe('marketdata registry', () => {
   });
 
   it('rejects an unknown MARKET_PROVIDER with a hint listing the options', () => {
-    vi.stubEnv('MARKET_PROVIDER', 'yahoo');
-    expect(() => getProvider()).toThrow('unknown MARKET_PROVIDER: yahoo');
+    vi.stubEnv('MARKET_PROVIDER', 'bogus');
+    expect(() => getProvider()).toThrow('unknown MARKET_PROVIDER: bogus');
   });
 
   it('routes US/HK/CN to longbridge by default', () => {
@@ -50,15 +50,20 @@ describe('marketdata registry', () => {
 
   it('a per-market override wins for its own market only', () => {
     vi.stubEnv('MARKET_PROVIDER', 'longbridge');
-    vi.stubEnv('MARKET_PROVIDER_HK', 'yahoo');
+    vi.stubEnv('MARKET_PROVIDER_HK', 'bogus');
     expect(getProvider('US').name).toBe('longbridge');
-    expect(() => getProvider('HK')).toThrow('unknown MARKET_PROVIDER: yahoo');
+    expect(() => getProvider('HK')).toThrow('unknown MARKET_PROVIDER: bogus');
     expect(getProvider('CN').name).toBe('longbridge');
   });
 
   it('rejects an unknown per-market override with the same hint', () => {
-    vi.stubEnv('MARKET_PROVIDER_CN', 'yahoo');
-    expect(() => getProvider('CN')).toThrow('unknown MARKET_PROVIDER: yahoo');
+    vi.stubEnv('MARKET_PROVIDER_CN', 'bogus');
+    expect(() => getProvider('CN')).toThrow('unknown MARKET_PROVIDER: bogus');
+  });
+
+  it('selects the yahoo provider when named by MARKET_PROVIDER', () => {
+    vi.stubEnv('MARKET_PROVIDER', 'yahoo');
+    expect(getProvider().name).toBe('yahoo');
   });
 });
 

--- a/packages/core/test/marketdata.test.ts
+++ b/packages/core/test/marketdata.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getProvider, getStream, listProviders } from '../src/marketdata/registry.js';
+import {
+  getDefaultProviderName,
+  getProvider,
+  getStream,
+  listProviders,
+  setDefaultProviderName,
+} from '../src/marketdata/registry.js';
 import { getYahooStream, resetYahooStream } from '../src/marketdata/yahoo/stream.js';
 import type { Capability, MarketDataProvider } from '../src/marketdata/types.js';
 
@@ -65,6 +71,36 @@ describe('marketdata registry', () => {
   it('selects the yahoo provider when named by MARKET_PROVIDER', () => {
     vi.stubEnv('MARKET_PROVIDER', 'yahoo');
     expect(getProvider().name).toBe('yahoo');
+  });
+});
+
+describe('stamped default provider', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setDefaultProviderName('longbridge');
+  });
+
+  it('is visible via getDefaultProviderName after setDefaultProviderName', () => {
+    setDefaultProviderName('yahoo');
+    expect(getDefaultProviderName()).toBe('yahoo');
+  });
+
+  it('resolveProviderName falls back to the stamped default with no env', () => {
+    setDefaultProviderName('yahoo');
+    expect(getProvider().name).toBe('yahoo');
+  });
+
+  it('a global MARKET_PROVIDER env beats the stamped default', () => {
+    setDefaultProviderName('yahoo');
+    vi.stubEnv('MARKET_PROVIDER', 'longbridge');
+    expect(getProvider().name).toBe('longbridge');
+  });
+
+  it('a per-market MARKET_PROVIDER_<market> env beats the stamped default', () => {
+    setDefaultProviderName('yahoo');
+    vi.stubEnv('MARKET_PROVIDER_HK', 'longbridge');
+    expect(getProvider('HK').name).toBe('longbridge');
+    expect(getProvider('US').name).toBe('yahoo');
   });
 });
 

--- a/packages/core/test/marketdataDispose.test.ts
+++ b/packages/core/test/marketdataDispose.test.ts
@@ -3,6 +3,7 @@ import { disposeMarketData, getStream } from '../src/marketdata/registry.js';
 import { getLongbridgeStream } from '../src/marketdata/longbridgeStream.js';
 import { getSharedQuoteSocket } from '../src/marketdata/sharedSocket.js';
 import { LongbridgeQuoteSocket } from '../src/marketdata/longbridgeSocket.js';
+import { getYahooStream } from '../src/marketdata/yahoo/stream.js';
 
 afterEach(() => {
   disposeMarketData();
@@ -20,6 +21,12 @@ describe('disposeMarketData', () => {
     expect(close).toHaveBeenCalledTimes(1);
     expect(getSharedQuoteSocket()).not.toBe(socket);
     expect(getLongbridgeStream()).not.toBe(stream);
+  });
+
+  it('also resets the yahoo stream singleton', () => {
+    const stream = getYahooStream();
+    disposeMarketData();
+    expect(getYahooStream()).not.toBe(stream);
   });
 
   it('lets getStream lazily recreate a stream after disposal', () => {

--- a/packages/core/test/position.test.ts
+++ b/packages/core/test/position.test.ts
@@ -35,9 +35,17 @@ const entryPlan = vi.hoisted(() => ({
   entryPlanFromDoc: vi.fn(() => null),
 }));
 
+const routing = vi.hoisted(() => ({ cb: null as (() => void) | null }));
+
 vi.mock('../src/marketdata/registry.js', () => ({
   getProvider: () => provider,
   getStream: () => stream,
+  onProviderRoutingChanged: (cb: () => void) => {
+    routing.cb = cb;
+    return () => {
+      routing.cb = null;
+    };
+  },
 }));
 vi.mock('../src/cockpit/entryPlan.js', () => entryPlan);
 
@@ -84,8 +92,8 @@ describe('subscribePosition', () => {
     vi.useFakeTimers();
     stream.snapshots.clear();
     stream.listeners.clear();
-    stream.retain.mockClear();
-    stream.release.mockClear();
+    stream.retain.mockReset().mockResolvedValue(undefined);
+    stream.release.mockReset().mockResolvedValue(undefined);
     provider.getPositions.mockReset().mockResolvedValue([
       {
         symbol: 'MU.US',
@@ -172,5 +180,28 @@ describe('subscribePosition', () => {
     stream.push(cell('MU.US', 999));
     await vi.advanceTimersByTimeAsync(2000);
     expect(events).toHaveLength(countBefore);
+  });
+
+  it('re-retains and keeps pushing after a provider routing change', async () => {
+    const events: unknown[] = [];
+    const unsub = subscribePosition('MU.US', (env) => events.push(JSON.parse(env)));
+    await vi.advanceTimersByTimeAsync(0);
+    stream.retain.mockClear();
+    stream.onUpdate.mockClear();
+    events.length = 0;
+
+    routing.cb?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(stream.retain).toHaveBeenCalledWith(['MU.US']);
+    expect(stream.onUpdate).toHaveBeenCalledTimes(1);
+
+    events.length = 0;
+    stream.push(cell('MU.US', 175));
+    await vi.advanceTimersByTimeAsync(1000);
+    const dataEvents = events.filter((e: any) => e.type === 'data');
+    expect(dataEvents.length).toBeGreaterThan(0);
+    expect((dataEvents.at(-1) as any).data.position.last).toBe(175);
+    unsub();
   });
 });

--- a/packages/core/test/quotesProviderRewire.test.ts
+++ b/packages/core/test/quotesProviderRewire.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QuoteCell } from '@kansoku/shared/types';
+import type { QuoteStream } from '../src/marketdata/quoteStream.js';
+import type { MarketDataProvider } from '../src/marketdata/types.js';
+
+interface FakeStream extends QuoteStream {
+  emit(cell: QuoteCell): void;
+}
+
+function fakeStream(): FakeStream {
+  const listeners = new Set<(cell: QuoteCell) => void>();
+  const snapshots = new Map<string, QuoteCell>();
+  return {
+    retain: vi.fn(async () => {}),
+    release: vi.fn(async () => {}),
+    subscribeCandlesticks: vi.fn(() => () => {}),
+    onUpdate: vi.fn((l: (cell: QuoteCell) => void) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    }),
+    getSnapshot: vi.fn((s: string) => snapshots.get(s)),
+    emit(cell: QuoteCell) {
+      snapshots.set(cell.symbol, cell);
+      for (const l of listeners) l(cell);
+    },
+  };
+}
+
+const provider: Partial<MarketDataProvider> = {};
+let streams: Record<string, FakeStream>;
+const routing = { cb: null as (() => void) | null };
+
+vi.mock('../src/marketdata/registry.js', () => ({
+  getProvider: () => provider,
+  getStream: (market: string) => streams[market],
+  onProviderRoutingChanged: (cb: () => void) => {
+    routing.cb = cb;
+    return () => {
+      routing.cb = null;
+    };
+  },
+}));
+
+function cell(symbol: string, last: number): QuoteCell {
+  return { symbol, session: '日盘', last, pct: 0, regularLast: last, regularPct: 0 };
+}
+
+describe('subscribeQuotes re-wires the stream on a provider routing change', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    streams = { US: fakeStream(), HK: fakeStream(), CN: fakeStream() };
+    provider.getPositions = undefined;
+    provider.getWatchlistSymbols = vi.fn(async () => ['MU.US']);
+    provider.getQuotes = vi.fn(async () => []);
+    routing.cb = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('drops the dead stream, re-retains the same symbols on the fresh one, and keeps serving updates', async () => {
+    const { subscribeQuotes } = await import('../src/realtime/quotes.js');
+    const pushes: string[] = [];
+    const unsubscribe = subscribeQuotes((env) => pushes.push(env));
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      const yahoo = streams.US;
+      expect(yahoo.retain).toHaveBeenCalledWith(['MU.US']);
+      expect(yahoo.onUpdate).toHaveBeenCalled();
+
+      yahoo.emit(cell('MU.US', 100));
+      await vi.advanceTimersByTimeAsync(300);
+      const beforeFlip = pushes.length;
+      expect(beforeFlip).toBeGreaterThan(0);
+      expect(pushes.at(-1)).toContain('"last":100');
+
+      const longbridge = fakeStream();
+      streams.US = longbridge;
+      routing.cb?.();
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(longbridge.retain).toHaveBeenCalledWith(['MU.US']);
+      expect(longbridge.onUpdate).toHaveBeenCalled();
+
+      const afterRewire = pushes.length;
+      yahoo.emit(cell('MU.US', 999));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(pushes.length).toBe(afterRewire);
+
+      longbridge.emit(cell('MU.US', 123));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(pushes.length).toBeGreaterThan(afterRewire);
+      expect(pushes.at(-1)).toContain('"last":123');
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/packages/core/test/quotesWatchlistFallback.test.ts
+++ b/packages/core/test/quotesWatchlistFallback.test.ts
@@ -22,6 +22,7 @@ let streams: Record<string, QuoteStream>;
 vi.mock('../src/marketdata/registry.js', () => ({
   getProvider: () => provider,
   getStream: (market: string) => streams[market],
+  onProviderRoutingChanged: () => () => {},
 }));
 
 function flush(ms = 30): Promise<void> {

--- a/packages/core/test/quotesWatchlistFallback.test.ts
+++ b/packages/core/test/quotesWatchlistFallback.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QuoteStream } from '../src/marketdata/quoteStream.js';
+import type { MarketDataProvider } from '../src/marketdata/types.js';
+
+const provider: Partial<MarketDataProvider> = {};
+
+function fakeStream(): QuoteStream {
+  return {
+    retain: vi.fn(async () => {}),
+    release: vi.fn(async () => {}),
+    subscribeCandlesticks: vi.fn(() => () => {}),
+    onUpdate: vi.fn(() => () => {}),
+    getSnapshot: vi.fn(() => undefined),
+  };
+}
+
+let streams: Record<string, QuoteStream>;
+
+vi.mock('../src/marketdata/registry.js', () => ({
+  getProvider: () => provider,
+  getStream: (market: string) => streams[market],
+}));
+
+function flush(ms = 30): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('subscribeQuotes falls back to the local watchlist', () => {
+  let dbDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    streams = { US: fakeStream(), HK: fakeStream(), CN: fakeStream() };
+    provider.getPositions = undefined;
+    provider.getWatchlistSymbols = undefined;
+    provider.getQuotes = vi.fn(async () => []);
+  });
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('retains local-watchlist symbols when the active provider has no getWatchlistSymbols', async () => {
+    dbDir = mkdtempSync(join(tmpdir(), 'quotes-local-watchlist-'));
+    const { createDb } = await import('../src/db/index.js');
+    const { createLocalWatchlistStore, setActiveLocalWatchlistStore } = await import(
+      '../src/marketdata/localWatchlistStore.js'
+    );
+    const store = createLocalWatchlistStore(createDb(join(dbDir, 'app.db')));
+    store.set(['NVDA', 'MU']);
+    setActiveLocalWatchlistStore(store);
+
+    const { subscribeQuotes } = await import('../src/realtime/quotes.js');
+    const unsubscribe = subscribeQuotes(() => {});
+    try {
+      await flush();
+      expect(streams.US.retain).toHaveBeenCalledWith(['NVDA.US', 'MU.US']);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/packages/core/test/securityName.test.ts
+++ b/packages/core/test/securityName.test.ts
@@ -6,6 +6,7 @@ import { localizeChartDocName, resolveSecurityName } from '../src/symbols/securi
 function provider(getSecurityName: MarketDataProvider['getSecurityName']): MarketDataProvider {
   return {
     name: 'test',
+    realtime: true,
     capabilities: new Set(),
     getKline: async () => [],
     getQuotes: async () => [],

--- a/packages/core/test/watchlist.test.ts
+++ b/packages/core/test/watchlist.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDb } from '../src/db/index.js';
+import {
+  createLocalWatchlistStore,
+  setActiveLocalWatchlistStore,
+} from '../src/marketdata/localWatchlistStore.js';
+import type { MarketDataProvider } from '../src/marketdata/types.js';
+import { watchlistSymbols } from '../src/marketdata/watchlist.js';
+
+function tempDbPath(): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'watchlist-fallback-'));
+  return { dir, path: join(dir, 'app.db') };
+}
+
+describe('watchlistSymbols', () => {
+  afterEach(() => setActiveLocalWatchlistStore(null));
+
+  it('uses the provider method when present, ignoring a non-empty local store', async () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      store.set(['LOCAL']);
+      setActiveLocalWatchlistStore(store);
+
+      const provider: Partial<MarketDataProvider> = {
+        getWatchlistSymbols: async () => ['NVDA.US', 'MU.US'],
+      };
+      const symbols = await watchlistSymbols(provider as MarketDataProvider);
+      expect(symbols).toEqual(['NVDA.US', 'MU.US']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads the local store when the provider has no getWatchlistSymbols', async () => {
+    const { dir, path } = tempDbPath();
+    try {
+      const store = createLocalWatchlistStore(createDb(path));
+      store.set(['NVDA', 'MU']);
+      setActiveLocalWatchlistStore(store);
+
+      const provider: Partial<MarketDataProvider> = {};
+      const symbols = await watchlistSymbols(provider as MarketDataProvider);
+      expect(symbols).toEqual(['NVDA.US', 'MU.US']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to [] when the provider has no method and no local store is active', async () => {
+    setActiveLocalWatchlistStore(null);
+    const provider: Partial<MarketDataProvider> = {};
+    expect(await watchlistSymbols(provider as MarketDataProvider)).toEqual([]);
+  });
+
+  it('propagates an error thrown by the provider method rather than swallowing it', async () => {
+    const provider: Partial<MarketDataProvider> = {
+      getWatchlistSymbols: async () => {
+        throw new Error('upstream failure');
+      },
+    };
+    await expect(watchlistSymbols(provider as MarketDataProvider)).rejects.toThrow(
+      'upstream failure',
+    );
+  });
+});

--- a/packages/core/test/yahooClient.test.ts
+++ b/packages/core/test/yahooClient.test.ts
@@ -41,8 +41,8 @@ function jsonResponse(status: number, body: unknown): Response {
 
 describe('createYahooClient', () => {
   it('performs no network activity until the first getJson call', () => {
-    const { calls } = makeFetch([]);
-    createYahooClient({ fetchImpl: makeFetch([]).fetchImpl });
+    const { calls, fetchImpl } = makeFetch([]);
+    createYahooClient({ fetchImpl });
     expect(calls.length).toBe(0);
   });
 
@@ -71,6 +71,29 @@ describe('createYahooClient', () => {
     expect(calls[2].headers['User-Agent']).toContain('Mozilla');
     expect(calls[3].url).toBe('https://query1.finance.yahoo.com/v8/finance/chart/MSFT');
     expect(calls[3].headers.Cookie).toBe('A1=abc123');
+    expect(calls[0].headers['User-Agent']).toContain('Mozilla');
+    expect(calls[1].headers['User-Agent']).toContain('Mozilla');
+    expect(calls[3].headers['User-Agent']).toContain('Mozilla');
+  });
+
+  it('dedupes concurrent handshake and crumb fetches across overlapping getJson calls', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=shared' } });
+    const crumbResponse = new Response('shared-crumb', { status: 200 });
+    const ok1 = jsonResponse(200, { n: 1 });
+    const ok2 = jsonResponse(200, { n: 2 });
+    const { fetchImpl, calls } = makeFetch([cookieResponse, crumbResponse, ok1, ok2]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const results = await Promise.all([
+      client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL', { crumb: true }),
+      client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/MSFT', { crumb: true }),
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(calls).toHaveLength(4);
+    expect(calls.filter((c) => c.url === 'https://fc.yahoo.com/')).toHaveLength(1);
+    expect(calls.filter((c) => c.url === 'https://query1.finance.yahoo.com/v1/test/getcrumb')).toHaveLength(1);
   });
 
   it('refreshes cookie+crumb and retries once on 401, then succeeds', async () => {
@@ -133,6 +156,63 @@ describe('createYahooClient', () => {
       ClientError,
     );
     expect(clock.sleeps.slice(-2)).toEqual([1000, 2000]);
+  });
+
+  it('backs off a 429 on the cookie handshake before caching a cookie', async () => {
+    const rate = new Response(null, { status: 429 });
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const ok = jsonResponse(200, { ok: true });
+    const { fetchImpl, calls } = makeFetch([rate, cookieResponse, ok]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const result = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL');
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(3);
+    expect(calls[2].headers.Cookie).toBe('A1=abc');
+    expect(clock.sleeps).toContain(1000);
+  });
+
+  it('backs off a 429 on the getcrumb endpoint before caching a crumb', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const rate = new Response(null, { status: 429 });
+    const crumbResponse = new Response('a-crumb', { status: 200 });
+    const ok = jsonResponse(200, { ok: true });
+    const { fetchImpl, calls } = makeFetch([cookieResponse, rate, crumbResponse, ok]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const result = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL', { crumb: true });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(4);
+    expect(calls[3].url).toContain('crumb=a-crumb');
+    expect(clock.sleeps).toContain(1000);
+  });
+
+  it('throws ClientError when the crumb endpoint responds non-OK', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const crumbError = new Response('nope', { status: 500 });
+    const { fetchImpl } = makeFetch([cookieResponse, crumbError]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(
+      client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL', { crumb: true }),
+    ).rejects.toThrow(ClientError);
+  });
+
+  it('throws ClientError when the crumb endpoint returns an empty body', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const emptyCrumb = new Response('', { status: 200 });
+    const { fetchImpl } = makeFetch([cookieResponse, emptyCrumb]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(
+      client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL', { crumb: true }),
+    ).rejects.toThrow(ClientError);
   });
 
   it('throttles so two immediate getJson calls have request starts spaced by minIntervalMs', async () => {

--- a/packages/core/test/yahooClient.test.ts
+++ b/packages/core/test/yahooClient.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ClientError } from '../src/platform/errors.js';
+import { createYahooClient, getYahooClient, resetYahooClient } from '../src/marketdata/yahoo/client.js';
+
+interface FakeCall {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function makeClock(start = 0) {
+  let time = start;
+  const sleeps: number[] = [];
+  return {
+    now: () => time,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      time += ms;
+    },
+    sleeps,
+    advance: (ms: number) => {
+      time += ms;
+    },
+  };
+}
+
+function makeFetch(responses: Response[]) {
+  const calls: FakeCall[] = [];
+  const queue = [...responses];
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), headers: (init?.headers as Record<string, string>) ?? {} });
+    const response = queue.shift();
+    if (!response) throw new Error('no more fake responses queued');
+    return response;
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('createYahooClient', () => {
+  it('performs no network activity until the first getJson call', () => {
+    const { calls } = makeFetch([]);
+    createYahooClient({ fetchImpl: makeFetch([]).fetchImpl });
+    expect(calls.length).toBe(0);
+  });
+
+  it('handshakes once, attaches cookie to subsequent requests, and fetches crumb once only when requested', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc123' } });
+    const crumbResponse = new Response('the-crumb', { status: 200 });
+    const dataResponse1 = jsonResponse(200, { ok: 1 });
+    const dataResponse2 = jsonResponse(200, { ok: 2 });
+    const { fetchImpl, calls } = makeFetch([cookieResponse, crumbResponse, dataResponse1, dataResponse2]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const result1 = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL', { crumb: true });
+    const result2 = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/MSFT');
+
+    expect(result1).toEqual({ ok: 1 });
+    expect(result2).toEqual({ ok: 2 });
+    expect(calls).toHaveLength(4);
+    expect(calls[0].url).toBe('https://fc.yahoo.com/');
+    expect(calls[1].url).toBe('https://query1.finance.yahoo.com/v1/test/getcrumb');
+    expect(calls[1].headers.Cookie).toBe('A1=abc123');
+    expect(calls[2].url).toBe(
+      'https://query1.finance.yahoo.com/v8/finance/chart/AAPL?crumb=the-crumb',
+    );
+    expect(calls[2].headers.Cookie).toBe('A1=abc123');
+    expect(calls[2].headers['User-Agent']).toContain('Mozilla');
+    expect(calls[3].url).toBe('https://query1.finance.yahoo.com/v8/finance/chart/MSFT');
+    expect(calls[3].headers.Cookie).toBe('A1=abc123');
+  });
+
+  it('refreshes cookie+crumb and retries once on 401, then succeeds', async () => {
+    const cookieResponse1 = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=first' } });
+    const dataResponse401 = new Response(null, { status: 401 });
+    const cookieResponse2 = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=second' } });
+    const dataResponseOk = jsonResponse(200, { ok: true });
+    const { fetchImpl, calls } = makeFetch([cookieResponse1, dataResponse401, cookieResponse2, dataResponseOk]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const result = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL');
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(4);
+    expect(calls[0].url).toBe('https://fc.yahoo.com/');
+    expect(calls[2].url).toBe('https://fc.yahoo.com/');
+    expect(calls[3].headers.Cookie).toBe('A1=second');
+  });
+
+  it('throws ClientError when the retried request still fails with 401', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const dataResponse401a = new Response(null, { status: 401 });
+    const cookieResponse2 = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc2' } });
+    const dataResponse401b = new Response(null, { status: 401 });
+    const { fetchImpl } = makeFetch([cookieResponse, dataResponse401a, cookieResponse2, dataResponse401b]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')).rejects.toThrow(
+      ClientError,
+    );
+  });
+
+  it('backs off on 429 with 1s then 2s waits and returns data on a later attempt', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const rate1 = new Response(null, { status: 429 });
+    const rate2 = new Response(null, { status: 429 });
+    const ok = jsonResponse(200, { ok: 'third-try' });
+    const { fetchImpl } = makeFetch([cookieResponse, rate1, rate2, ok]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    const result = await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL');
+
+    expect(result).toEqual({ ok: 'third-try' });
+    expect(clock.sleeps.slice(-2)).toEqual([1000, 2000]);
+  });
+
+  it('throws ClientError after three consecutive 429 responses', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const rate1 = new Response(null, { status: 429 });
+    const rate2 = new Response(null, { status: 429 });
+    const rate3 = new Response(null, { status: 429 });
+    const { fetchImpl } = makeFetch([cookieResponse, rate1, rate2, rate3]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')).rejects.toThrow(
+      ClientError,
+    );
+    expect(clock.sleeps.slice(-2)).toEqual([1000, 2000]);
+  });
+
+  it('throttles so two immediate getJson calls have request starts spaced by minIntervalMs', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const ok1 = jsonResponse(200, { n: 1 });
+    const ok2 = jsonResponse(200, { n: 2 });
+    const { fetchImpl } = makeFetch([cookieResponse, ok1, ok2]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep, minIntervalMs: 250 });
+
+    await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL');
+    await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/MSFT');
+
+    expect(clock.sleeps).toContain(250);
+  });
+
+  it('does not additionally throttle when enough time has already passed between calls', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const seed = jsonResponse(200, { n: 0 });
+    const ok1 = jsonResponse(200, { n: 1 });
+    const ok2 = jsonResponse(200, { n: 2 });
+    const { fetchImpl } = makeFetch([cookieResponse, seed, ok1, ok2]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep, minIntervalMs: 250 });
+
+    await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/SEED');
+    clock.sleeps.length = 0;
+    clock.advance(1000);
+    await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL');
+    clock.advance(1000);
+    await client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/MSFT');
+
+    expect(clock.sleeps).toEqual([]);
+  });
+
+  it('throws ClientError on a non-OK, non-retryable status like 500', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const serverError = new Response('boom', { status: 500 });
+    const { fetchImpl } = makeFetch([cookieResponse, serverError]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')).rejects.toThrow(
+      ClientError,
+    );
+  });
+
+  it('throws ClientError when an OK response body is not valid JSON', async () => {
+    const cookieResponse = new Response(null, { status: 204, headers: { 'set-cookie': 'A1=abc' } });
+    const badJson = new Response('not json{', { status: 200 });
+    const { fetchImpl } = makeFetch([cookieResponse, badJson]);
+    const clock = makeClock();
+    const client = createYahooClient({ fetchImpl, now: clock.now, sleep: clock.sleep });
+
+    await expect(client.getJson('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')).rejects.toThrow(
+      ClientError,
+    );
+  });
+});
+
+describe('getYahooClient / resetYahooClient', () => {
+  afterEach(() => {
+    resetYahooClient();
+  });
+
+  it('lazily creates a shared singleton and reuses it on subsequent calls', () => {
+    const first = getYahooClient();
+    const second = getYahooClient();
+    expect(second).toBe(first);
+  });
+
+  it('creates a fresh instance after resetYahooClient', () => {
+    const first = getYahooClient();
+    resetYahooClient();
+    const second = getYahooClient();
+    expect(second).not.toBe(first);
+  });
+});

--- a/packages/core/test/yahooProvider.test.ts
+++ b/packages/core/test/yahooProvider.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'vitest';
+import { ClientError } from '../src/platform/errors.js';
+import { createYahooProvider } from '../src/marketdata/yahoo/provider.js';
+import type { YahooClient } from '../src/marketdata/yahoo/client.js';
+
+interface RecordedCall {
+  url: string;
+  crumb: boolean;
+}
+
+function fakeClient(handler: (url: string, crumb: boolean) => unknown): {
+  client: YahooClient;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const client: YahooClient = {
+    async getJson(url: string, opts?: { crumb?: boolean }) {
+      const crumb = opts?.crumb === true;
+      calls.push({ url, crumb });
+      const result = handler(url, crumb);
+      if (result instanceof Error) throw result;
+      return result;
+    },
+  };
+  return { client, calls };
+}
+
+function chartPayload(rows: Array<{ ts: number; o: number | null; h: number | null; l: number | null; c: number | null; v: number | null }>) {
+  return {
+    chart: {
+      error: null,
+      result: [
+        {
+          timestamp: rows.map((r) => r.ts),
+          indicators: {
+            quote: [
+              {
+                open: rows.map((r) => r.o),
+                high: rows.map((r) => r.h),
+                low: rows.map((r) => r.l),
+                close: rows.map((r) => r.c),
+                volume: rows.map((r) => r.v),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe('createYahooProvider: getKline', () => {
+  it('maps chart bars, skips null-OHLC rows, and keeps only the last `count` bars in ascending order', async () => {
+    const payload = chartPayload([
+      { ts: 1_000, o: 1, h: 2, l: 0.5, c: 1.5, v: 100 },
+      { ts: 2_000, o: null, h: 2, l: 0.5, c: 1.5, v: 100 },
+      { ts: 3_000, o: 2, h: 3, l: 1.5, c: 2.5, v: 200 },
+      { ts: 4_000, o: 3, h: 4, l: 2.5, c: 3.5, v: 300 },
+    ]);
+    const { client } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    const bars = await provider.getKline('MU.US', 'day', 2);
+
+    expect(bars).toEqual([
+      { time: new Date(3_000 * 1000).toISOString(), open: 2, high: 3, low: 1.5, close: 2.5, volume: 200 },
+      { time: new Date(4_000 * 1000).toISOString(), open: 3, high: 4, low: 2.5, close: 3.5, volume: 300 },
+    ]);
+  });
+
+  it('requests the mapped yahoo interval for the symbol', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', '1h', 1);
+
+    expect(calls[0].url).toContain('/v8/finance/chart/MU');
+    expect(calls[0].url).toContain('interval=60m');
+  });
+
+  it('accepts the 60m alias like longbridge and maps it to the 1h->60m interval', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', '60m', 1);
+
+    expect(calls[0].url).toContain('interval=60m');
+  });
+
+  it('sets includePrePost=true only when session is "all"', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', 'day', 1, 'all');
+    await provider.getKline('MU.US', 'day', 1, 'intraday');
+    await provider.getKline('MU.US', 'day', 1);
+
+    expect(calls[0].url).toContain('includePrePost=true');
+    expect(calls[1].url).toContain('includePrePost=false');
+    expect(calls[2].url).toContain('includePrePost=false');
+  });
+
+  it('clamps period1 for 1m history to the 7-day limit regardless of the requested count', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', '1m', 100_000);
+
+    const url = new URL(calls[0].url);
+    const period1 = Number(url.searchParams.get('period1'));
+    const period2 = Number(url.searchParams.get('period2'));
+    expect(period2 - period1).toBe(7 * 86400);
+  });
+
+  it('clamps period1 for 60m history to the 730-day limit', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', '1h', 100_000);
+
+    const url = new URL(calls[0].url);
+    const period1 = Number(url.searchParams.get('period1'));
+    const period2 = Number(url.searchParams.get('period2'));
+    expect(period2 - period1).toBe(730 * 86400);
+  });
+
+  it('does not clamp day-period history', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', 'day', 1000);
+
+    const url = new URL(calls[0].url);
+    const period1 = Number(url.searchParams.get('period1'));
+    const period2 = Number(url.searchParams.get('period2'));
+    expect(period2 - period1).toBeGreaterThan(730 * 86400);
+  });
+
+  it('rejects the year period since yahoo has no yearly interval', async () => {
+    const { client } = fakeClient(() => ({}));
+    const provider = createYahooProvider(client);
+
+    try {
+      await provider.getKline('MU.US', 'year', 10);
+      throw new Error('expected getKline to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError);
+      expect((error as ClientError).hint).toMatch(/month/);
+    }
+  });
+
+  it('rejects an unsupported period', async () => {
+    const { client } = fakeClient(() => ({}));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getKline('MU.US', '3m', 10)).rejects.toThrow(ClientError);
+  });
+
+  it('throws ClientError naming the symbol when chart.error is set', async () => {
+    const { client } = fakeClient(() => ({ chart: { error: { code: 'Not Found' }, result: null } }));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getKline('BADSYM.US', 'day', 10)).rejects.toThrow(/BADSYM\.US/);
+  });
+
+  it('throws ClientError naming the symbol when the result array is empty', async () => {
+    const { client } = fakeClient(() => ({ chart: { error: null, result: [] } }));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getKline('BADSYM.US', 'day', 10)).rejects.toThrow(ClientError);
+  });
+});
+
+describe('createYahooProvider: getQuotes', () => {
+  it('serializes numeric fields as strings and keys results by the original requested symbol', async () => {
+    const { client, calls } = fakeClient(() => ({
+      quoteResponse: {
+        result: [
+          {
+            symbol: 'MU',
+            regularMarketPrice: 110,
+            regularMarketPreviousClose: 100,
+            regularMarketChangePercent: 10,
+          },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const quotes = await provider.getQuotes(['mu']);
+
+    expect(quotes).toEqual([
+      { symbol: 'mu', last: '110', prev_close: '100', change_percentage: '10.000' },
+    ]);
+    expect(calls[0].crumb).toBe(true);
+    expect(calls[0].url).toContain('symbols=MU');
+  });
+
+  it('includes pre_market/post_market only when yahoo returns the corresponding fields, and omits overnight', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: {
+        result: [
+          {
+            symbol: 'MU',
+            regularMarketPrice: 110,
+            regularMarketPreviousClose: 100,
+            regularMarketChangePercent: 10,
+            preMarketPrice: 108,
+            preMarketTime: 2_000,
+          },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const [quote] = await provider.getQuotes(['MU.US']);
+
+    expect(quote.pre_market).toEqual({
+      last: '108',
+      prev_close: '100',
+      timestamp: new Date(2_000 * 1000).toISOString(),
+    });
+    expect(quote.post_market).toBeUndefined();
+    expect(quote.overnight).toBeUndefined();
+  });
+
+  it('omits pre_market and post_market when yahoo does not return them', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: {
+        result: [{ symbol: 'MU', regularMarketPrice: 110, regularMarketPreviousClose: 100 }],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const [quote] = await provider.getQuotes(['MU.US']);
+
+    expect(quote.pre_market).toBeUndefined();
+    expect(quote.post_market).toBeUndefined();
+  });
+
+  it('skips symbols whose mapping is not US-supported without failing the batch', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: {
+        result: [{ symbol: 'MU', regularMarketPrice: 110, regularMarketPreviousClose: 100 }],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const quotes = await provider.getQuotes(['MU.US', '700.HK']);
+
+    expect(quotes).toHaveLength(1);
+    expect(quotes[0].symbol).toBe('MU.US');
+  });
+
+  it('returns an empty array for an empty symbol list without calling the client', async () => {
+    const { client, calls } = fakeClient(() => {
+      throw new Error('should not be called');
+    });
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getQuotes([])).resolves.toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('createYahooProvider: getMarketCaps', () => {
+  it('maps marketCap keyed by the original requested symbol, omitting missing values', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: {
+        result: [
+          { symbol: 'MU', marketCap: 123_000 },
+          { symbol: 'AAPL', regularMarketPrice: 200 },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const caps = await provider.getMarketCaps!(['mu', 'aapl']);
+
+    expect(caps).toEqual({ mu: 123_000 });
+  });
+});
+
+describe('createYahooProvider: getSecurityName', () => {
+  it('prefers longName over shortName', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: { result: [{ symbol: 'MU', longName: 'Micron Technology, Inc.', shortName: 'Micron' }] },
+    }));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getSecurityName!('MU.US')).resolves.toBe('Micron Technology, Inc.');
+  });
+
+  it('falls back to shortName when longName is absent', async () => {
+    const { client } = fakeClient(() => ({
+      quoteResponse: { result: [{ symbol: 'MU', shortName: 'Micron' }] },
+    }));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getSecurityName!('MU.US')).resolves.toBe('Micron');
+  });
+
+  it('returns null on any failure', async () => {
+    const { client } = fakeClient(() => new Error('boom'));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getSecurityName!('MU.US')).resolves.toBeNull();
+  });
+
+  it('returns null for a non-US symbol', async () => {
+    const { client } = fakeClient(() => {
+      throw new Error('should not be called');
+    });
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getSecurityName!('700.HK')).resolves.toBeNull();
+  });
+});
+
+describe('createYahooProvider: getNews', () => {
+  it('maps news rows to NewsItem with ISO published_at', async () => {
+    const { client, calls } = fakeClient(() => ({
+      news: [
+        { uuid: 'abc-1', title: 'Micron beats estimates', link: 'https://example.com/a', providerPublishTime: 5_000 },
+      ],
+    }));
+    const provider = createYahooProvider(client);
+
+    const news = await provider.getNews('MU.US', 5);
+
+    expect(news).toEqual([
+      {
+        id: 'abc-1',
+        title: 'Micron beats estimates',
+        published_at: new Date(5_000 * 1000).toISOString(),
+        url: 'https://example.com/a',
+      },
+    ]);
+    expect(calls[0].url).toContain('newsCount=5');
+    expect(calls[0].url).toContain('quotesCount=0');
+  });
+
+  it('returns [] when the client throws', async () => {
+    const { client } = fakeClient(() => new Error('boom'));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getNews('MU.US')).resolves.toEqual([]);
+  });
+
+  it('returns [] when the payload is malformed (no news array)', async () => {
+    const { client } = fakeClient(() => ({}));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getNews('MU.US')).resolves.toEqual([]);
+  });
+});
+
+describe('createYahooProvider: getEarningsCalendar', () => {
+  it('picks the earliest earningsDate on/after fromDate', async () => {
+    const { client, calls } = fakeClient(() => ({
+      quoteSummary: {
+        result: [
+          {
+            calendarEvents: {
+              earnings: {
+                earningsDate: [{ raw: Date.parse('2026-08-10T00:00:00Z') / 1000 }, { raw: Date.parse('2026-08-05T00:00:00Z') / 1000 }],
+                isEarningsDateEstimate: true,
+              },
+            },
+          },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const entry = await provider.getEarningsCalendar!('MU.US', '2026-07-22');
+
+    expect(entry).toEqual({ date: '2026-08-05', title: 'earnings date (estimated)' });
+    expect(calls[0].crumb).toBe(true);
+  });
+
+  it('returns null when no earningsDate is on/after fromDate', async () => {
+    const { client } = fakeClient(() => ({
+      quoteSummary: {
+        result: [
+          {
+            calendarEvents: {
+              earnings: { earningsDate: [{ raw: Date.parse('2026-01-01T00:00:00Z') / 1000 }] },
+            },
+          },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getEarningsCalendar!('MU.US', '2026-07-22')).resolves.toBeNull();
+  });
+
+  it('returns null on any failure', async () => {
+    const { client } = fakeClient(() => new Error('boom'));
+    const provider = createYahooProvider(client);
+
+    await expect(provider.getEarningsCalendar!('MU.US', '2026-07-22')).resolves.toBeNull();
+  });
+});
+
+describe('createYahooProvider: contract', () => {
+  it('declares name, realtime, and capabilities', () => {
+    const { client } = fakeClient(() => ({}));
+    const provider = createYahooProvider(client);
+
+    expect(provider.name).toBe('yahoo');
+    expect(provider.realtime).toBe(false);
+    expect([...provider.capabilities]).toEqual(['earnings-calendar', 'market-cap']);
+  });
+});

--- a/packages/core/test/yahooProvider.test.ts
+++ b/packages/core/test/yahooProvider.test.ts
@@ -142,6 +142,19 @@ describe('createYahooProvider: getKline', () => {
     expect(period2 - period1).toBeGreaterThan(730 * 86400);
   });
 
+  it('scales the day-bar window buffer with a holiday cushion, not a flat pad', async () => {
+    const payload = chartPayload([{ ts: 1, o: 1, h: 1, l: 1, c: 1, v: 1 }]);
+    const { client, calls } = fakeClient(() => payload);
+    const provider = createYahooProvider(client);
+
+    await provider.getKline('MU.US', 'day', 500);
+
+    const url = new URL(calls[0].url);
+    const period1 = Number(url.searchParams.get('period1'));
+    const period2 = Number(url.searchParams.get('period2'));
+    expect(period2 - period1).toBeGreaterThanOrEqual(740 * 86400);
+  });
+
   it('rejects the year period since yahoo has no yearly interval', async () => {
     const { client } = fakeClient(() => ({}));
     const provider = createYahooProvider(client);
@@ -223,11 +236,32 @@ describe('createYahooProvider: getQuotes', () => {
 
     expect(quote.pre_market).toEqual({
       last: '108',
-      prev_close: '100',
+      prev_close: '110',
       timestamp: new Date(2_000 * 1000).toISOString(),
     });
     expect(quote.post_market).toBeUndefined();
     expect(quote.overnight).toBeUndefined();
+  });
+
+  it('pre_market.prev_close baselines off regularMarketPrice (yesterday\'s close during pre-market), not regularMarketPreviousClose (two sessions back)', async () => {
+    const regularMarketPrice = 100;
+    const regularMarketPreviousClose = 90;
+    const preMarketPrice = 102;
+    const { client } = fakeClient(() => ({
+      quoteResponse: {
+        result: [
+          { symbol: 'MU', regularMarketPrice, regularMarketPreviousClose, preMarketPrice, preMarketTime: 2_000 },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const [quote] = await provider.getQuotes(['MU.US']);
+
+    expect(quote.pre_market?.prev_close).toBe(String(regularMarketPrice));
+    const impliedPct = (Number(quote.pre_market!.last) / Number(quote.pre_market!.prev_close) - 1) * 100;
+    const expectedPct = (preMarketPrice / regularMarketPrice - 1) * 100;
+    expect(impliedPct).toBeCloseTo(expectedPct, 6);
   });
 
   it('omits pre_market and post_market when yahoo does not return them', async () => {
@@ -381,8 +415,30 @@ describe('createYahooProvider: getEarningsCalendar', () => {
 
     const entry = await provider.getEarningsCalendar!('MU.US', '2026-07-22');
 
-    expect(entry).toEqual({ date: '2026-08-05', title: 'earnings date (estimated)' });
+    expect(entry).toEqual({ date: '2026-08-05', title: '预计财报日期' });
     expect(calls[0].crumb).toBe(true);
+  });
+
+  it('titles a confirmed (non-estimate) earnings date differently from an estimated one', async () => {
+    const { client } = fakeClient(() => ({
+      quoteSummary: {
+        result: [
+          {
+            calendarEvents: {
+              earnings: {
+                earningsDate: [{ raw: Date.parse('2026-08-05T00:00:00Z') / 1000 }],
+                isEarningsDateEstimate: false,
+              },
+            },
+          },
+        ],
+      },
+    }));
+    const provider = createYahooProvider(client);
+
+    const entry = await provider.getEarningsCalendar!('MU.US', '2026-07-22');
+
+    expect(entry).toEqual({ date: '2026-08-05', title: '财报日期' });
   });
 
   it('returns null when no earningsDate is on/after fromDate', async () => {

--- a/packages/core/test/yahooStream.test.ts
+++ b/packages/core/test/yahooStream.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionKind } from '@kansoku/shared/types';
+import type { RawQuote } from '../src/marketdata/types.js';
+import {
+  createYahooQuoteStream,
+  getYahooStream,
+  resetYahooStream,
+} from '../src/marketdata/yahoo/stream.js';
+
+function makeQuote(symbol: string, last: number, changePct = '0'): RawQuote {
+  return { symbol, last: String(last), prev_close: '100', change_percentage: changePct };
+}
+
+function fixedClassify(kind: SessionKind) {
+  return vi.fn().mockReturnValue(kind);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('YahooQuoteStream poll cadence', () => {
+  it('polls immediately on first retain instead of waiting a full interval', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([makeQuote('AAA.US', 100)]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+    expect(getQuotes).toHaveBeenCalledWith(['AAA.US']);
+    expect(stream.getSnapshot('AAA.US')?.last).toBe(100);
+  });
+
+  it('polls every 5s while the session is regular', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([makeQuote('AAA.US', 100)]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getQuotes).toHaveBeenCalledTimes(3);
+  });
+
+  it('polls every 30s while the session is pre or post', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([makeQuote('AAA.US', 100)]);
+    const classify = fixedClassify('pre');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fetch outside pre/regular/post and rechecks every 60s so a session change wakes it up', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([]);
+    const classify = fixedClassify('overnight');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    expect(getQuotes).not.toHaveBeenCalled();
+    expect(classify).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(classify).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(classify.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(getQuotes).not.toHaveBeenCalled();
+  });
+});
+
+describe('YahooQuoteStream change detection', () => {
+  it('emits onUpdate only for cells whose last/pct/session changed since the previous snapshot', async () => {
+    const getQuotes = vi
+      .fn()
+      .mockResolvedValueOnce([makeQuote('AAA.US', 100, '0')])
+      .mockResolvedValueOnce([makeQuote('AAA.US', 100, '0')])
+      .mockResolvedValueOnce([makeQuote('AAA.US', 105, '5')]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+    const received: number[] = [];
+    stream.onUpdate((cell) => received.push(cell.last));
+
+    await stream.retain(['AAA.US']);
+    expect(received).toEqual([100]);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(received).toEqual([100]);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(received).toEqual([100, 105]);
+  });
+});
+
+describe('YahooQuoteStream refcounting', () => {
+  it('keeps polling while any ref remains and stops fetching once the last ref is released', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([makeQuote('AAA.US', 100)]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    await stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    await stream.release(['AAA.US']);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+
+    await stream.release(['AAA.US']);
+    expect(stream.getSnapshot('AAA.US')).toBeUndefined();
+    const callsBefore = getQuotes.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(getQuotes.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+describe('YahooQuoteStream failure backoff', () => {
+  it('doubles the delay on consecutive failures, resets to normal cadence on success, and keeps the loop alive', async () => {
+    const getQuotes = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([makeQuote('AAA.US', 100)])
+      .mockResolvedValueOnce([makeQuote('AAA.US', 100)]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getQuotes).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(getQuotes).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getQuotes).toHaveBeenCalledTimes(4);
+  });
+
+  it('caps the backoff delay at 300000ms and never throws an unhandled rejection', async () => {
+    const getQuotes = vi.fn().mockRejectedValue(new Error('boom'));
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    await stream.retain(['AAA.US']);
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(300_000);
+    }
+    const callsAfterManyFailures = getQuotes.mock.calls.length;
+    expect(callsAfterManyFailures).toBeGreaterThan(1);
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(getQuotes.mock.calls.length).toBe(callsAfterManyFailures + 1);
+  });
+});
+
+describe('YahooQuoteStream candlesticks', () => {
+  it('aggregates polled quotes into a candle bar and stops after unsubscribe', async () => {
+    const getQuotes = vi
+      .fn()
+      .mockResolvedValueOnce([makeQuote('AAA.US', 100)])
+      .mockResolvedValueOnce([makeQuote('AAA.US', 101)])
+      .mockResolvedValue([makeQuote('AAA.US', 999)]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    const bars: number[] = [];
+    const unsub = stream.subscribeCandlesticks('AAA.US', '5m', (bar) => bars.push(bar.close));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+    expect(bars).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getQuotes).toHaveBeenCalledTimes(2);
+    expect(bars).toEqual([101]);
+
+    unsub();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(bars).toEqual([101]);
+  });
+});
+
+describe('YahooQuoteStream snapshot', () => {
+  it('is undefined for an unknown symbol and holds the latest normalized cell after a poll', async () => {
+    const getQuotes = vi.fn().mockResolvedValue([makeQuote('AAA.US', 123, '5')]);
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    expect(stream.getSnapshot('AAA.US')).toBeUndefined();
+
+    await stream.retain(['AAA.US']);
+
+    const cell = stream.getSnapshot('AAA.US');
+    expect(cell?.symbol).toBe('AAA.US');
+    expect(cell?.last).toBe(123);
+    expect(cell?.session).toBe('日盘');
+  });
+});
+
+describe('getYahooStream/resetYahooStream singleton', () => {
+  afterEach(() => {
+    resetYahooStream();
+  });
+
+  it('returns the same instance until reset', () => {
+    const a = getYahooStream();
+    const b = getYahooStream();
+    expect(a).toBe(b);
+
+    resetYahooStream();
+    const c = getYahooStream();
+    expect(c).not.toBe(a);
+  });
+});

--- a/packages/core/test/yahooStream.test.ts
+++ b/packages/core/test/yahooStream.test.ts
@@ -221,6 +221,58 @@ describe('YahooQuoteStream snapshot', () => {
   });
 });
 
+describe('YahooQuoteStream disposal races an in-flight poll', () => {
+  it('stops the loop instead of leaking a zombie timer when disposed mid-fetch', async () => {
+    let resolvePoll: (rows: RawQuote[]) => void = () => {};
+    const getQuotes = vi.fn().mockImplementation(
+      () =>
+        new Promise<RawQuote[]>((resolve) => {
+          resolvePoll = resolve;
+        }),
+    );
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+
+    const retainPromise = stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    stream.dispose();
+    resolvePoll([makeQuote('AAA.US', 100)]);
+    await retainPromise;
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('YahooQuoteStream release races an in-flight poll', () => {
+  it('does not resurrect the snapshot or emit a stale update for a symbol released mid-fetch', async () => {
+    let resolvePoll: (rows: RawQuote[]) => void = () => {};
+    const getQuotes = vi.fn().mockImplementation(
+      () =>
+        new Promise<RawQuote[]>((resolve) => {
+          resolvePoll = resolve;
+        }),
+    );
+    const classify = fixedClassify('regular');
+    const stream = createYahooQuoteStream({ provider: { getQuotes }, classify, now: () => Date.now() });
+    const received: number[] = [];
+    stream.onUpdate((cell) => received.push(cell.last));
+
+    const retainPromise = stream.retain(['AAA.US']);
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    await stream.release(['AAA.US']);
+    expect(stream.getSnapshot('AAA.US')).toBeUndefined();
+
+    resolvePoll([makeQuote('AAA.US', 100)]);
+    await retainPromise;
+
+    expect(stream.getSnapshot('AAA.US')).toBeUndefined();
+    expect(received).toEqual([]);
+  });
+});
+
 describe('getYahooStream/resetYahooStream singleton', () => {
   afterEach(() => {
     resetYahooStream();

--- a/packages/core/test/yahooSymbolMap.test.ts
+++ b/packages/core/test/yahooSymbolMap.test.ts
@@ -16,6 +16,15 @@ describe('toYahooSymbol', () => {
     expect(toYahooSymbol('.SOX.US')).toBe('^SOX');
   });
 
+  it('maps a class-share dot to a dash', () => {
+    expect(toYahooSymbol('BRK.B')).toBe('BRK-B');
+    expect(toYahooSymbol('BRK.B.US')).toBe('BRK-B');
+  });
+
+  it('throws when the yahoo body would be empty', () => {
+    expect(() => toYahooSymbol('.US')).toThrow(ClientError);
+  });
+
   it('throws for an HK symbol', () => {
     expect(() => toYahooSymbol('700.HK')).toThrow(ClientError);
     expect(() => toYahooSymbol('700.HK')).toThrow(/700\.HK/);
@@ -46,13 +55,29 @@ describe('fromYahooSymbol', () => {
     expect(fromYahooSymbol('^SOX')).toBe('.SOX.US');
   });
 
+  it('translates a dash back to a class-share dot', () => {
+    expect(fromYahooSymbol('BRK-B')).toBe('BRK.B.US');
+  });
+
   it('throws for a yahoo symbol that looks non-US', () => {
     expect(() => fromYahooSymbol('0700.HK')).toThrow(ClientError);
   });
+
+  it('throws for a bare caret', () => {
+    expect(() => fromYahooSymbol('^')).toThrow(ClientError);
+  });
 });
 
+function fullCanonicalUS(raw: string): string {
+  const normalized = normalizeSymbol(raw);
+  return normalized.endsWith('.US') ? normalized : `${normalized}.US`;
+}
+
 describe('round trip', () => {
-  it.each(['AAPL.US', 'MU', '.SOX.US', 'mu.us'])('recovers the normalized form of %s', (raw) => {
-    expect(fromYahooSymbol(toYahooSymbol(raw))).toBe(normalizeSymbol(raw));
-  });
+  it.each(['AAPL.US', 'MU', '.SOX.US', 'mu.us', 'BRK.B', 'BRK.B.US', '.SOX'])(
+    'recovers the full canonical form of %s',
+    (raw) => {
+      expect(fromYahooSymbol(toYahooSymbol(raw))).toBe(fullCanonicalUS(raw));
+    },
+  );
 });

--- a/packages/core/test/yahooSymbolMap.test.ts
+++ b/packages/core/test/yahooSymbolMap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { ClientError } from '../src/platform/errors.js';
+import { fromYahooSymbol, toYahooSymbol } from '../src/marketdata/yahoo/symbolMap.js';
+import { normalizeSymbol } from '../src/symbols/symbol.utils.js';
+
+describe('toYahooSymbol', () => {
+  it('strips the .US suffix from a plain ticker', () => {
+    expect(toYahooSymbol('AAPL.US')).toBe('AAPL');
+  });
+
+  it('normalizes a bare ticker before mapping', () => {
+    expect(toYahooSymbol('MU')).toBe('MU');
+  });
+
+  it('maps a leading-dot index proxy to a caret-prefixed symbol', () => {
+    expect(toYahooSymbol('.SOX.US')).toBe('^SOX');
+  });
+
+  it('throws for an HK symbol', () => {
+    expect(() => toYahooSymbol('700.HK')).toThrow(ClientError);
+    expect(() => toYahooSymbol('700.HK')).toThrow(/700\.HK/);
+  });
+
+  it('throws for a CN symbol', () => {
+    expect(() => toYahooSymbol('600519.SH')).toThrow(ClientError);
+    expect(() => toYahooSymbol('000001.SZ')).toThrow(ClientError);
+  });
+
+  it('names the hint when the market is unsupported', () => {
+    try {
+      toYahooSymbol('700.HK');
+      throw new Error('expected toYahooSymbol to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError);
+      expect((error as ClientError).hint).toMatch(/market not supported by the yahoo provider yet/);
+    }
+  });
+});
+
+describe('fromYahooSymbol', () => {
+  it('appends .US to a plain ticker', () => {
+    expect(fromYahooSymbol('AAPL')).toBe('AAPL.US');
+  });
+
+  it('maps a caret-prefixed symbol back to a leading-dot index proxy', () => {
+    expect(fromYahooSymbol('^SOX')).toBe('.SOX.US');
+  });
+
+  it('throws for a yahoo symbol that looks non-US', () => {
+    expect(() => fromYahooSymbol('0700.HK')).toThrow(ClientError);
+  });
+});
+
+describe('round trip', () => {
+  it.each(['AAPL.US', 'MU', '.SOX.US', 'mu.us'])('recovers the normalized form of %s', (raw) => {
+    expect(fromYahooSymbol(toYahooSymbol(raw))).toBe(normalizeSymbol(raw));
+  });
+});


### PR DESCRIPTION
## Summary

Abstracts the market-data layer behind the existing provider registry so the app no longer hard-depends on Longbridge, and ships a free no-key Yahoo provider as the out-of-box default.

Spec: `docs/superpowers/specs/2026-07-22-marketdata-provider-abstraction-design.md` (committed on this branch).

- **Yahoo provider** (`packages/core/src/marketdata/yahoo/`): cookie+crumb HTTP client (concurrent-handshake dedupe, 429 backoff, per-host throttle), kline/quotes/news/security-name/market-caps/earnings-calendar. History limits truncate silently.
- **Symbol translation at the provider edge only**: `AAPL.US ↔ AAPL`, `.SOX.US ↔ ^SOX`, class shares `BRK.B[.US] ↔ BRK-B`; canonical Longbridge-style symbols stay untouched everywhere else.
- **Polling QuoteStream**: session-aware cadence (5s regular / 30s pre-post / paused off-session), reuses candleAggregator, exponential backoff, race-safe dispose/release (in-flight polls cannot resurrect state).
- **Local watchlist**: drizzle migration 0008 + store + `watchlistSymbols()` fallback so free mode has realtime/home content; Longbridge users unaffected. Settings API + card (「本地自选」).
- **Automatic default**: Longbridge credentials present → longbridge, else → yahoo; `MARKET_PROVIDER*` env always wins. Credential-status polling re-stamps via `restampFromCredentialStatus`, and an actual flip disposes + rewires live streams under open WS connections (no reconnect needed).
- **Honesty layer**: `realtime` provider flag → `GET /api/capabilities` `datasources` → dismissible banner + persistent 「延迟」 badge next to quote prices. Metadata-driven — future providers (IBKR etc.) inherit it.

## Onboarding

Desktop onboarding previously hard-required Longbridge (a live check), which made free mode unreachable. `bc69f1a` adds a persisted skip path: 「暂时跳过,先用免费行情」 on the Longbridge step — skip is sticky (a later dropped CLI login does not re-trap), connecting later from Settings restores full live-check behavior, and legacy onboarding state files parse unchanged.

## Review

Built via per-task review loops + a whole-branch final review. Caught and fixed along the way: handshake concurrency race; `BRK.B`-style tickers silently querying the wrong instrument; pre-market baseline field inverted (pct wrong in sign and magnitude); dispose-during-poll zombie loop; badge flipping to realtime while the stream still served delayed data (now an atomic switch).

Deferred (tracked in follow-ups): `change_percentage` shows 0 instead of — when source data is unusable; news unsorted; crumb-endpoint 401 not self-healing within a single call.

## Tests

Full suites at HEAD: core 1023 / server 207 / web 613 / desktop 310, all passing. Typecheck clean.

## Merge coordination

`kansoku-pro` needs a one-line `datasources` fixture addition in `test/capabilities.test.ts` (sitting uncommitted in the apps/pro worktree) — must land with the next pin-push, since `CapabilitiesOut.datasources` is a required field.
