### PR TITLE
Agent Kit: kansoku-cli, kansoku:// deep link, user-picked Kit location

### DIFF
--- a/.claude/skills/chart/SKILL.md
+++ b/.claude/skills/chart/SKILL.md
@@ -50,7 +50,8 @@ sparkline in the chat reply is faster.
 无 → 回退 HTTP。
 
 CLI 与 HTTP 契约一致——body 就是原本 POST /api/charts 的 body，
-返回 `{id, url, technicals?}` 也不变。
+返回 `{id, url, technicals?}` 也不变；CLI 侧额外多带一个 `deepLink`
+字段（见下方数据目录场景说明）。
 
 先加载 runtime.env（这一步只需做一次）：
 
@@ -69,9 +70,24 @@ set +a
 | `GET /api/charts?type=&symbol=` | `"$KANSOKU_CLI" chart list [--symbol X]` |
 | `GET /api/charts/<id>` | `"$KANSOKU_CLI" chart get <id>` |
 | `PATCH /api/charts/<id>` | *(暂不支持——PATCH 仍走 HTTP；数据目录场景 PATCH 目前只在 intraday-signal 里出现，届时 fallback HTTP)* |
+| 打开 `data.url`（浏览器访问 `http://localhost:5199/...`） | 打开 `data.deepLink`（`kansoku://route/...`，见下） |
 
 body/response 完全一致，写入的图表 JSON 落在 `journal/charts/data/<id>.json`
 （跟 HTTP 版本相同）。
+
+数据目录场景通常没有本机 dev server（Kit 用户不会跑 `pnpm start`），
+`data.url` 里的 `http://localhost:5199/...` 打不开。CLI 的 chart create
+响应现在多带一个 `deepLink` 字段（`url` 照旧保留，向后兼容 dev 场景），
+指向 `kansoku://route/...` 这个自定义协议。想让用户看到图表时，打开这个
+deep link 即可——它会启动 Kansoku.app（若已在运行则直接切到前台）并跳转到
+对应图表页面：
+
+```sh
+open "$(echo "$response" | jq -r .deepLink)"
+```
+
+macOS 用 `open`，Windows 用 `start`，Linux 用 `xdg-open`——三者都认协议处理器，
+换平台只需换这一条命令。
 
 ## Server lifecycle
 

--- a/.claude/skills/chart/SKILL.md
+++ b/.claude/skills/chart/SKILL.md
@@ -43,6 +43,36 @@ latest front-end code.
 Skip when the user only wants a single number or a tiny series — a Unicode
 sparkline in the chat reply is faster.
 
+## Data-root scenario (kansoku-cli)
+
+在 Kansoku 数据目录里跑（外部 Claude Code、无本地 dev server），走
+`kansoku-cli` 而不是 HTTP。判据：环境变量 `$KANSOKU_CLI` 有值 → 走 CLI；
+无 → 回退 HTTP。
+
+CLI 与 HTTP 契约一致——body 就是原本 POST /api/charts 的 body，
+返回 `{id, url, technicals?}` 也不变。
+
+先加载 runtime.env（这一步只需做一次）：
+
+```sh
+set -a
+[ -f .kansoku-agent-kit/runtime.env ] && . .kansoku-agent-kit/runtime.env
+set +a
+```
+
+之后：
+
+| HTTP 版 | CLI 等价 |
+|---|---|
+| `curl -s http://localhost:5199/api/health` | `"$KANSOKU_CLI" info kit-version` |
+| `POST /api/charts` body 为 X | `printf '%s' "$X" \| "$KANSOKU_CLI" chart create --type <T> --symbol <S> --json-input -` |
+| `GET /api/charts?type=&symbol=` | `"$KANSOKU_CLI" chart list [--symbol X]` |
+| `GET /api/charts/<id>` | `"$KANSOKU_CLI" chart get <id>` |
+| `PATCH /api/charts/<id>` | *(暂不支持——PATCH 仍走 HTTP；数据目录场景 PATCH 目前只在 intraday-signal 里出现，届时 fallback HTTP)* |
+
+body/response 完全一致，写入的图表 JSON 落在 `journal/charts/data/<id>.json`
+（跟 HTTP 版本相同）。
+
 ## Server lifecycle
 
 The app must be running before any API call:
@@ -50,6 +80,8 @@ The app must be running before any API call:
 ```bash
 curl -s http://localhost:5199/api/health # {"ok":true,...} = up
 ```
+
+CLI 等价：`"$KANSOKU_CLI" info kit-version`
 
 If it is down, start it (long-running process — use run_in_background):
 
@@ -138,6 +170,13 @@ The server fetches Longbridge data itself when `symbol` is given; pass `data`
   "prediction": null }                                // omit for preview mode
 ```
 
+CLI 等价（body 走 stdin，`--json-input -`）：
+
+- flow → `"$KANSOKU_CLI" chart create --type flow --symbol MU.US --json-input -`
+- cohort → `"$KANSOKU_CLI" chart create --type cohort --json-input -`（无单一 symbol，省略 `--symbol`）
+- sepa → `"$KANSOKU_CLI" chart create --type sepa --symbol MRVL.US --json-input -`
+- intraday → `"$KANSOKU_CLI" chart create --type intraday --symbol MU.US --json-input -`
+
 Success returns `data.id`, `data.url` (paste this into journal entries), plus
 type-specific meta: sepa → `verdict_tier / passes / fails / bars`; intraday →
 `mode / bars / technicals`.
@@ -218,6 +257,10 @@ climax top (volume ≥ 2.5×20MA + red close + local high), MA50/MA200 breakdown
 2. **PATCH `/api/charts/:id` with `{"prediction": {...}}`** → final dashboard.
    Add `"refresh": true` to any PATCH to refetch the latest bars (incl. pre/post
    market) and recompute everything before rebuilding — same id, same URL.
+
+CLI 等价：第 1 步（POST 预览）可用
+`"$KANSOKU_CLI" chart create --type intraday --symbol MU.US --json-input -`；
+第 2 步（PATCH 写入 prediction）目前无 CLI 等价，仍走 HTTP。
 
 `prediction` schema:
 

--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -3,6 +3,7 @@ dist/
 dist-main/
 dist-preload/
 dist-skills/
+dist-agent-kit/
 release/
 *.tsbuildinfo
 /pro/

--- a/apps/desktop/agent-kit-src/bin/kansoku-cli
+++ b/apps/desktop/agent-kit-src/bin/kansoku-cli
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Shim: run the packaged CLI bundle with Electron acting as Node runtime.
+# Relative-path anchored so the App can be relocated (/Applications, ~/Applications, etc.).
+here="$(cd "$(dirname "$0")" && pwd)"
+ELECTRON_RUN_AS_NODE=1 exec "$here/../../../MacOS/Kansoku" "$here/../cli.js" "$@"

--- a/apps/desktop/agent-kit-src/bin/kansoku-cli
+++ b/apps/desktop/agent-kit-src/bin/kansoku-cli
@@ -1,5 +1,15 @@
 #!/bin/sh
 # Shim: run the packaged CLI bundle with Electron acting as Node runtime.
-# Relative-path anchored so the App can be relocated (/Applications, ~/Applications, etc.).
-here="$(cd "$(dirname "$0")" && pwd)"
+# The Kit is symlinked into user-picked directories, so $0 may be a symlink
+# — resolve the chain before anchoring the relative path chain against the
+# App bundle layout (macOS lacks GNU readlink -f, so hand-walk symlinks).
+target="$0"
+while [ -L "$target" ]; do
+  link="$(readlink "$target")"
+  case "$link" in
+    /*) target="$link" ;;
+    *) target="$(cd "$(dirname "$target")" && pwd)/$link" ;;
+  esac
+done
+here="$(cd "$(dirname "$target")" && pwd)"
 ELECTRON_RUN_AS_NODE=1 exec "$here/../../../MacOS/Kansoku" "$here/../cli.js" "$@"

--- a/apps/desktop/agent-kit-src/manifest.template.json
+++ b/apps/desktop/agent-kit-src/manifest.template.json
@@ -1,0 +1,10 @@
+{
+  "kitVersion": "__KIT_VERSION__",
+  "appVersion": "__APP_VERSION__",
+  "templates": [
+    { "path": "templates/CLAUDE.md.tpl", "dest": "CLAUDE.md", "sha256": "__SHA_CLAUDE__" },
+    { "path": "templates/AGENTS.md.tpl", "dest": "AGENTS.md", "sha256": "__SHA_AGENTS__" },
+    { "path": "templates/env.tpl", "dest": ".env", "sha256": "__SHA_ENV__" },
+    { "path": "<runtime>", "dest": "journal/personal.md", "sha256": "__RENDER_VERSION__", "source": "app-config" }
+  ]
+}

--- a/apps/desktop/agent-kit-src/render-version.json
+++ b/apps/desktop/agent-kit-src/render-version.json
@@ -1,0 +1,3 @@
+{
+  "personalMd": "app-config-v1"
+}

--- a/apps/desktop/agent-kit-src/templates/AGENTS.md.tpl
+++ b/apps/desktop/agent-kit-src/templates/AGENTS.md.tpl
@@ -1,0 +1,37 @@
+# CLAUDE.md — Kansoku 数据目录
+
+这里不是 kansoku 源码仓库，是 kansoku desktop app 的数据目录。所有研究结果、
+图表、决策日志都存在这里。
+
+## 怎么操作数据
+
+数据存储：
+
+- SQLite: `charts/data/app.db`（chart_meta、comments、chat_sessions、
+  symbol_follows、watched_markets_settings 等）
+- 图表 JSON: `journal/charts/data/<id>.json`
+- Markdown: `journal/YYYY-MM-DD-*.md`、`stocks/<SYMBOL>.md`
+
+操作接口：`kansoku-cli`，位置见环境变量 `$KANSOKU_CLI`（由 App 写入
+`.kansoku-agent-kit/runtime.env`）。想在 shell 里直接用，把
+`$KANSOKU_DATA_ROOT/.kansoku-agent-kit/bin` 加到 `PATH`。
+
+调用示例：
+
+```sh
+"$KANSOKU_CLI" chart create --type sepa --symbol NVDA --json-input - < payload.json
+"$KANSOKU_CLI" info data-root
+```
+
+## Skill
+
+`.claude/skills/` 里是 kansoku 的研究 skill——市场读取、深度研究、图表生成、
+决策关卡、日内多周期预测等。任何 skill 里的接口调用都会通过 `kansoku-cli`
+落到本地 SQLite / JSON，不需要额外服务。
+
+## 规则
+
+- 交易纪律：见 `.claude/skills/trading-discipline/SKILL.md`
+- 语言：所有 markdown 用中文白话
+- 数据虚实：TD-DATA-01 不造数据；TD-DATA-02 标数据时点
+- 输出：TD-LANG-02 少用行话

--- a/apps/desktop/agent-kit-src/templates/CLAUDE.md.tpl
+++ b/apps/desktop/agent-kit-src/templates/CLAUDE.md.tpl
@@ -1,0 +1,37 @@
+# CLAUDE.md — Kansoku 数据目录
+
+这里不是 kansoku 源码仓库，是 kansoku desktop app 的数据目录。所有研究结果、
+图表、决策日志都存在这里。
+
+## 怎么操作数据
+
+数据存储：
+
+- SQLite: `charts/data/app.db`（chart_meta、comments、chat_sessions、
+  symbol_follows、watched_markets_settings 等）
+- 图表 JSON: `journal/charts/data/<id>.json`
+- Markdown: `journal/YYYY-MM-DD-*.md`、`stocks/<SYMBOL>.md`
+
+操作接口：`kansoku-cli`，位置见环境变量 `$KANSOKU_CLI`（由 App 写入
+`.kansoku-agent-kit/runtime.env`）。想在 shell 里直接用，把
+`$KANSOKU_DATA_ROOT/.kansoku-agent-kit/bin` 加到 `PATH`。
+
+调用示例：
+
+```sh
+"$KANSOKU_CLI" chart create --type sepa --symbol NVDA --json-input - < payload.json
+"$KANSOKU_CLI" info data-root
+```
+
+## Skill
+
+`.claude/skills/` 里是 kansoku 的研究 skill——市场读取、深度研究、图表生成、
+决策关卡、日内多周期预测等。任何 skill 里的接口调用都会通过 `kansoku-cli`
+落到本地 SQLite / JSON，不需要额外服务。
+
+## 规则
+
+- 交易纪律：见 `.claude/skills/trading-discipline/SKILL.md`
+- 语言：所有 markdown 用中文白话
+- 数据虚实：TD-DATA-01 不造数据；TD-DATA-02 标数据时点
+- 输出：TD-LANG-02 少用行话

--- a/apps/desktop/agent-kit-src/templates/env.tpl
+++ b/apps/desktop/agent-kit-src/templates/env.tpl
@@ -1,0 +1,6 @@
+# kansoku data root skill env
+# secret 需要用户自己填。runtime.env 里的 KANSOKU_* 由 App 自动写入，不要在这里覆盖。
+
+FRED_API_KEY=
+SEC_USER_AGENT=
+HITHINK_FINANCE_API_KEY=

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -76,6 +76,8 @@ extraResources:
   # symlinks into .agents that electron-builder would copy as dead links.
   - from: dist-skills
     to: skills
+  - from: dist-agent-kit
+    to: kansoku-agent-kit
 extraFiles:
   - from: node_modules/electron-sparkle-updater/native/vendor/Sparkle.framework
     to: Frameworks/Sparkle.framework

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -109,3 +109,7 @@ mac:
     SUPublicEDKey: SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER
     SUEnableInstallerLauncherService: false
     SUScheduledCheckInterval: 3600
+    CFBundleURLTypes:
+      - CFBundleURLName: dev.innei.kansoku
+        CFBundleURLSchemes:
+          - kansoku

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev.mjs",
     "generate-icon": "bash scripts/generate-icon.sh",
     "prepackage": "pnpm --filter @kansoku/web build && (test -f ../web/dist/index.html || (echo 'web/dist/index.html missing after build' && exit 1))",
-    "package": "pnpm build && node scripts/stageSkills.mjs && node scripts/stagePro.mjs && pnpm rebuild-native && pnpm build:native && electron-builder --mac dmg zip --arm64",
+    "package": "pnpm build && node scripts/stageSkills.mjs && node scripts/stageAgentKit.mjs && node scripts/buildCli.mjs && node scripts/stagePro.mjs && pnpm rebuild-native && pnpm build:native && electron-builder --mac dmg zip --arm64",
     "rebuild-native": "electron-rebuild -v 43.1.0 --force -w better-sqlite3",
     "prestart": "node scripts/ensureDevNative.mjs",
     "start": "electron .",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
     "electron-context-menu": "^4.1.2",
     "electron-ipc-decorator": "^1.0.1",
     "electron-window-state": "5.0.3",
+    "esbuild": "^0.24.2",
     "hono": "4.12.30",
     "partial-json": "^0.1.7",
     "reflect-metadata": "0.2.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,6 +43,7 @@
     "hono": "4.12.30",
     "partial-json": "^0.1.7",
     "reflect-metadata": "0.2.2",
+    "tsdown": "^0.22.13",
     "typescript": "^7.0.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,7 +39,7 @@
     "electron-context-menu": "^4.1.2",
     "electron-ipc-decorator": "^1.0.1",
     "electron-window-state": "5.0.3",
-    "esbuild": "^0.24.2",
+    "esbuild": "^0.28.0",
     "hono": "4.12.30",
     "partial-json": "^0.1.7",
     "reflect-metadata": "0.2.2",

--- a/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
+++ b/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
@@ -1,0 +1,161 @@
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { stageAgentKit } from '../stageAgentKit.mjs';
+
+const temps = [];
+
+function tempDir(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function buildFixtureSrc() {
+  const srcRoot = tempDir('agent-kit-src-');
+  mkdirSync(join(srcRoot, 'templates'), { recursive: true });
+  mkdirSync(join(srcRoot, 'bin'), { recursive: true });
+
+  writeFileSync(join(srcRoot, 'templates', 'CLAUDE.md.tpl'), '# CLAUDE\nhello\n');
+  writeFileSync(join(srcRoot, 'templates', 'AGENTS.md.tpl'), '# CLAUDE\nhello\n');
+  writeFileSync(join(srcRoot, 'templates', 'env.tpl'), 'FRED_API_KEY=\n');
+
+  const shimPath = join(srcRoot, 'bin', 'kansoku-cli');
+  writeFileSync(shimPath, '#!/bin/sh\necho hi\n');
+  chmodSync(shimPath, 0o755);
+
+  writeFileSync(
+    join(srcRoot, 'manifest.template.json'),
+    `${JSON.stringify(
+      {
+        kitVersion: '__KIT_VERSION__',
+        appVersion: '__APP_VERSION__',
+        templates: [
+          { path: 'templates/CLAUDE.md.tpl', dest: 'CLAUDE.md', sha256: '__SHA_CLAUDE__' },
+          { path: 'templates/AGENTS.md.tpl', dest: 'AGENTS.md', sha256: '__SHA_AGENTS__' },
+          { path: 'templates/env.tpl', dest: '.env', sha256: '__SHA_ENV__' },
+          {
+            path: '<runtime>',
+            dest: 'journal/personal.md',
+            sha256: '__RENDER_VERSION__',
+            source: 'app-config',
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  return srcRoot;
+}
+
+function hashTree(root) {
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else {
+        files.push(full);
+      }
+    }
+  };
+  walk(root);
+
+  const hash = createHash('sha256');
+  for (const file of files) {
+    hash.update(relative(root, file));
+    hash.update('\0');
+    hash.update(readFileSync(file));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+describe('stageAgentKit', () => {
+  it('stages templates, preserves the shim executable bit, and fills sha256 placeholders', () => {
+    const srcRoot = buildFixtureSrc();
+    const destRoot = tempDir('agent-kit-dist-');
+    const pkg = { version: '1.2.3' };
+
+    stageAgentKit({ srcRoot, destRoot, pkg });
+
+    const manifest = JSON.parse(readFileSync(join(destRoot, 'manifest.json'), 'utf8'));
+
+    const shimMode = statSync(join(destRoot, 'bin', 'kansoku-cli')).mode & 0o777;
+    expect(shimMode & 0o111).toBe(0o111);
+
+    const claudeHash = createHash('sha256')
+      .update(readFileSync(join(srcRoot, 'templates', 'CLAUDE.md.tpl')))
+      .digest('hex');
+    const agentsHash = createHash('sha256')
+      .update(readFileSync(join(srcRoot, 'templates', 'AGENTS.md.tpl')))
+      .digest('hex');
+    const envHash = createHash('sha256')
+      .update(readFileSync(join(srcRoot, 'templates', 'env.tpl')))
+      .digest('hex');
+
+    expect(manifest.templates.find((t) => t.dest === 'CLAUDE.md').sha256).toBe(claudeHash);
+    expect(manifest.templates.find((t) => t.dest === 'AGENTS.md').sha256).toBe(agentsHash);
+    expect(manifest.templates.find((t) => t.dest === '.env').sha256).toBe(envHash);
+  });
+
+  it('produces byte-identical output across two consecutive stages', () => {
+    const srcRoot = buildFixtureSrc();
+    const destRoot = tempDir('agent-kit-dist-');
+    const pkg = { version: '1.2.3' };
+
+    stageAgentKit({ srcRoot, destRoot, pkg });
+    const firstHash = hashTree(destRoot);
+
+    stageAgentKit({ srcRoot, destRoot, pkg });
+    const secondHash = hashTree(destRoot);
+
+    expect(secondHash).toBe(firstHash);
+  });
+
+  it('leaves the personal.md manifest entry as the app-config sentinel', () => {
+    const srcRoot = buildFixtureSrc();
+    const destRoot = tempDir('agent-kit-dist-');
+    const pkg = { version: '1.2.3' };
+
+    stageAgentKit({ srcRoot, destRoot, pkg });
+
+    const manifest = JSON.parse(readFileSync(join(destRoot, 'manifest.json'), 'utf8'));
+    const personal = manifest.templates.find((t) => t.dest === 'journal/personal.md');
+
+    expect(personal.source).toBe('app-config');
+    expect(personal.sha256).toBe('app-config-v1');
+  });
+
+  it('formats kitVersion as semver plus a UTC YYYYMMDD suffix', () => {
+    const srcRoot = buildFixtureSrc();
+    const destRoot = tempDir('agent-kit-dist-');
+    const pkg = { version: '1.2.3-beta.1' };
+
+    stageAgentKit({ srcRoot, destRoot, pkg });
+
+    const manifest = JSON.parse(readFileSync(join(destRoot, 'manifest.json'), 'utf8'));
+    expect(manifest.kitVersion).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?\+\d{8}$/);
+    expect(manifest.appVersion).toBe(pkg.version);
+  });
+});

--- a/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
+++ b/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
@@ -67,6 +67,19 @@ function buildFixtureSrc() {
   return srcRoot;
 }
 
+function buildFixtureSrcWithMissingTemplate() {
+  const srcRoot = buildFixtureSrc();
+  const manifestPath = join(srcRoot, 'manifest.template.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.templates.push({
+    path: 'templates/nonexistent.md.tpl',
+    dest: 'NONEXISTENT.md',
+    sha256: '__SHA_MISSING__',
+  });
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return srcRoot;
+}
+
 function hashTree(root) {
   const files = [];
   const walk = (dir) => {
@@ -157,5 +170,15 @@ describe('stageAgentKit', () => {
     const manifest = JSON.parse(readFileSync(join(destRoot, 'manifest.json'), 'utf8'));
     expect(manifest.kitVersion).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?\+\d{8}$/);
     expect(manifest.appVersion).toBe(pkg.version);
+  });
+
+  it('throws when a non-app-config manifest entry has no real file', () => {
+    const srcRoot = buildFixtureSrcWithMissingTemplate();
+    const destRoot = tempDir('agent-kit-dist-');
+    const pkg = { version: '1.2.3' };
+
+    expect(() => stageAgentKit({ srcRoot, destRoot, pkg })).toThrow(
+      join(srcRoot, 'templates', 'nonexistent.md.tpl'),
+    );
   });
 });

--- a/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
+++ b/apps/desktop/scripts/__tests__/stageAgentKit.spec.mjs
@@ -36,6 +36,10 @@ function buildFixtureSrc() {
   writeFileSync(join(srcRoot, 'templates', 'CLAUDE.md.tpl'), '# CLAUDE\nhello\n');
   writeFileSync(join(srcRoot, 'templates', 'AGENTS.md.tpl'), '# CLAUDE\nhello\n');
   writeFileSync(join(srcRoot, 'templates', 'env.tpl'), 'FRED_API_KEY=\n');
+  writeFileSync(
+    join(srcRoot, 'render-version.json'),
+    `${JSON.stringify({ personalMd: 'app-config-v1' }, null, 2)}\n`,
+  );
 
   const shimPath = join(srcRoot, 'bin', 'kansoku-cli');
   writeFileSync(shimPath, '#!/bin/sh\necho hi\n');

--- a/apps/desktop/scripts/buildCli.mjs
+++ b/apps/desktop/scripts/buildCli.mjs
@@ -1,4 +1,4 @@
-import { build } from 'esbuild';
+import { build } from 'tsdown';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -6,16 +6,24 @@ const here = dirname(fileURLToPath(import.meta.url));
 const desktopDir = dirname(here);
 
 await build({
-  entryPoints: [join(desktopDir, 'src/cli/main.ts')],
-  outfile: join(desktopDir, 'dist-agent-kit/cli.js'),
+  entry: [join(desktopDir, 'src/cli/main.ts')],
+  outDir: join(desktopDir, 'dist-agent-kit'),
   platform: 'node',
   target: 'node20',
   format: 'esm',
-  bundle: true,
-  external: ['better-sqlite3', 'electron'],
-  banner: {
-    js: `import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);`,
+  external: (id) => {
+    if (id === 'better-sqlite3' || id === 'electron') return true;
+    if (/\/research\//.test(id)) return true;
+    if (/\/ai\//.test(id) && !/\/ai\/personas\/follows/.test(id)) return true;
+    if (/\/settings\/(aiSettings|settings\.(deps|test)|settingsStore|settingsValidation)/.test(id)) return true;
+    return false;
   },
-  logLevel: 'info',
+  treeshake: true,
+  clean: false,
+  dts: false,
+  outputOptions: {
+    entryFileNames: 'cli.js',
+    inlineDynamicImports: true,
+    banner: `import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);`,
+  },
 });

--- a/apps/desktop/scripts/buildCli.mjs
+++ b/apps/desktop/scripts/buildCli.mjs
@@ -1,0 +1,21 @@
+import { build } from 'esbuild';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopDir = dirname(here);
+
+await build({
+  entryPoints: [join(desktopDir, 'src/cli/main.ts')],
+  outfile: join(desktopDir, 'dist-agent-kit/cli.js'),
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  bundle: true,
+  external: ['better-sqlite3', 'electron'],
+  banner: {
+    js: `import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);`,
+  },
+  logLevel: 'info',
+});

--- a/apps/desktop/scripts/stageAgentKit.mjs
+++ b/apps/desktop/scripts/stageAgentKit.mjs
@@ -1,0 +1,58 @@
+import { createHash } from 'node:crypto';
+import { chmodSync, cpSync, existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function sha256File(filePath) {
+  return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+function kitVersion(pkgVersion, now = new Date()) {
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(now.getUTCDate()).padStart(2, '0');
+  return `${pkgVersion}+${yyyy}${mm}${dd}`;
+}
+
+export function stageAgentKit({ srcRoot, destRoot, pkg }) {
+  rmSync(destRoot, { recursive: true, force: true });
+  cpSync(join(srcRoot, 'templates'), join(destRoot, 'templates'), { recursive: true });
+  cpSync(join(srcRoot, 'bin'), join(destRoot, 'bin'), { recursive: true });
+
+  const shimPath = join(destRoot, 'bin', 'kansoku-cli');
+  if ((statSync(shimPath).mode & 0o111) !== 0o111) {
+    chmodSync(shimPath, 0o755);
+  }
+
+  const manifest = JSON.parse(readFileSync(join(srcRoot, 'manifest.template.json'), 'utf8'));
+  const version = kitVersion(pkg.version);
+  manifest.kitVersion = version;
+  manifest.appVersion = pkg.version;
+
+  let templateCount = 0;
+  for (const entry of manifest.templates) {
+    if (entry.source === 'app-config') {
+      entry.sha256 = 'app-config-v1';
+      continue;
+    }
+    const filePath = join(srcRoot, entry.path);
+    if (!existsSync(filePath)) continue;
+    entry.sha256 = sha256File(filePath);
+    templateCount += 1;
+  }
+
+  writeFileSync(join(destRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(`agent-kit staged (${templateCount} templates, kitVersion=${version})`);
+
+  return manifest;
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const desktopDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const srcRoot = join(desktopDir, 'agent-kit-src');
+  const destRoot = join(desktopDir, 'dist-agent-kit');
+  const pkg = JSON.parse(readFileSync(join(desktopDir, 'package.json'), 'utf8'));
+  stageAgentKit({ srcRoot, destRoot, pkg });
+}

--- a/apps/desktop/scripts/stageAgentKit.mjs
+++ b/apps/desktop/scripts/stageAgentKit.mjs
@@ -25,6 +25,7 @@ export function stageAgentKit({ srcRoot, destRoot, pkg }) {
   }
 
   const manifest = JSON.parse(readFileSync(join(srcRoot, 'manifest.template.json'), 'utf8'));
+  const renderVersion = JSON.parse(readFileSync(join(srcRoot, 'render-version.json'), 'utf8'));
   const version = kitVersion(pkg.version);
   manifest.kitVersion = version;
   manifest.appVersion = pkg.version;
@@ -32,7 +33,7 @@ export function stageAgentKit({ srcRoot, destRoot, pkg }) {
   let templateCount = 0;
   for (const entry of manifest.templates) {
     if (entry.source === 'app-config') {
-      entry.sha256 = 'app-config-v1';
+      entry.sha256 = renderVersion.personalMd;
       continue;
     }
     const filePath = join(srcRoot, entry.path);

--- a/apps/desktop/scripts/stageAgentKit.mjs
+++ b/apps/desktop/scripts/stageAgentKit.mjs
@@ -36,7 +36,11 @@ export function stageAgentKit({ srcRoot, destRoot, pkg }) {
       continue;
     }
     const filePath = join(srcRoot, entry.path);
-    if (!existsSync(filePath)) continue;
+    if (!existsSync(filePath)) {
+      throw new Error(
+        `stageAgentKit: manifest entry "${entry.path}" has no real file at ${filePath} — did the manifest drift from agent-kit-src/templates/?`,
+      );
+    }
     entry.sha256 = sha256File(filePath);
     templateCount += 1;
   }

--- a/apps/desktop/src/agent-kit/ensureAgentKit.ts
+++ b/apps/desktop/src/agent-kit/ensureAgentKit.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Db } from '@kansoku/core/db/index';
+import { readManifest } from './manifest.js';
+import {
+  readState,
+  sha256,
+  writeState,
+  type PendingConflict,
+  type PendingUpdate,
+  type TemplateState,
+} from './state.js';
+import { makeRender, syncTemplate } from './templates.js';
+
+export async function ensureAgentKit(input: {
+  dataRoot: string;
+  resourcesPath: string;
+  db: Db;
+  now?: () => Date;
+}): Promise<{ conflicts: PendingConflict[]; updates: PendingUpdate[] }> {
+  const manifest = readManifest(input.resourcesPath);
+  const state = readState(input.dataRoot);
+  const now = (input.now ?? (() => new Date()))();
+
+  const kitDir = join(input.dataRoot, '.kansoku-agent-kit');
+  mkdirSync(join(kitDir, 'bin'), { recursive: true });
+
+  const cliShim = join(kitDir, 'bin', 'kansoku-cli');
+  writeFileSync(
+    join(kitDir, 'runtime.env'),
+    [
+      `KANSOKU_CLI=${cliShim}`,
+      `KANSOKU_DATA_ROOT=${input.dataRoot}`,
+      `KANSOKU_APP_VERSION=${manifest.appVersion}`,
+      `KANSOKU_KIT_VERSION=${manifest.kitVersion}`,
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const targetShim = join(input.resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli');
+  rmSync(cliShim, { force: true });
+  symlinkSync(targetShim, cliShim, 'file');
+
+  const render = makeRender(input.resourcesPath, input.db);
+  const conflicts: PendingConflict[] = [];
+  const updates: PendingUpdate[] = [];
+  const templatesNext: Record<string, TemplateState> = { ...state?.templates };
+
+  for (const t of manifest.templates) {
+    const outcome = syncTemplate({
+      template: t,
+      resourcesPath: input.resourcesPath,
+      dataRoot: input.dataRoot,
+      db: input.db,
+      state,
+      render,
+    });
+    switch (outcome.kind) {
+      case 'written': {
+        templatesNext[t.dest] = {
+          initialContentHash: sha256(readFileSync(join(input.dataRoot, t.dest))),
+          sourceTemplateHash: t.sha256,
+          writtenAt: now.toISOString(),
+        };
+        break;
+      }
+      case 'conflict': {
+        conflicts.push(outcome.conflict);
+        break;
+      }
+      case 'skip-user-modified':
+      case 'skip-uptodate': {
+        break;
+      }
+      case 'pending-update': {
+        updates.push(outcome.update);
+        break;
+      }
+    }
+  }
+
+  writeState(input.dataRoot, {
+    kitVersion: manifest.kitVersion,
+    appVersion: manifest.appVersion,
+    syncedAt: now.toISOString(),
+    templates: templatesNext,
+    ...(conflicts.length ? { pendingConflicts: conflicts } : {}),
+    ...(updates.length ? { pendingUpdates: updates } : {}),
+  });
+
+  return { conflicts, updates };
+}

--- a/apps/desktop/src/agent-kit/ensureAgentKit.ts
+++ b/apps/desktop/src/agent-kit/ensureAgentKit.ts
@@ -13,16 +13,17 @@ import {
 import { makeRender, syncTemplate } from './templates.js';
 
 export async function ensureAgentKit(input: {
+  agentKitDir: string;
   dataRoot: string;
   resourcesPath: string;
   db: Db;
   now?: () => Date;
 }): Promise<{ conflicts: PendingConflict[]; updates: PendingUpdate[] }> {
   const manifest = readManifest(input.resourcesPath);
-  const state = readState(input.dataRoot);
+  const state = readState(input.agentKitDir);
   const now = (input.now ?? (() => new Date()))();
 
-  const kitDir = join(input.dataRoot, '.kansoku-agent-kit');
+  const kitDir = join(input.agentKitDir, '.kansoku-agent-kit');
   mkdirSync(join(kitDir, 'bin'), { recursive: true });
 
   const cliShim = join(kitDir, 'bin', 'kansoku-cli');
@@ -31,6 +32,7 @@ export async function ensureAgentKit(input: {
     [
       `KANSOKU_CLI=${cliShim}`,
       `KANSOKU_DATA_ROOT=${input.dataRoot}`,
+      `KANSOKU_AGENT_KIT_DIR=${input.agentKitDir}`,
       `KANSOKU_APP_VERSION=${manifest.appVersion}`,
       `KANSOKU_KIT_VERSION=${manifest.kitVersion}`,
       `TRADE_MIGRATIONS_DIR=${join(input.resourcesPath, 'drizzle')}`,
@@ -52,7 +54,7 @@ export async function ensureAgentKit(input: {
     const outcome = syncTemplate({
       template: t,
       resourcesPath: input.resourcesPath,
-      dataRoot: input.dataRoot,
+      dataRoot: input.agentKitDir,
       db: input.db,
       state,
       render,
@@ -60,7 +62,7 @@ export async function ensureAgentKit(input: {
     switch (outcome.kind) {
       case 'written': {
         templatesNext[t.dest] = {
-          initialContentHash: sha256(readFileSync(join(input.dataRoot, t.dest))),
+          initialContentHash: sha256(readFileSync(join(input.agentKitDir, t.dest))),
           sourceTemplateHash: t.sha256,
           writtenAt: now.toISOString(),
         };
@@ -81,7 +83,7 @@ export async function ensureAgentKit(input: {
     }
   }
 
-  writeState(input.dataRoot, {
+  writeState(input.agentKitDir, {
     kitVersion: manifest.kitVersion,
     appVersion: manifest.appVersion,
     syncedAt: now.toISOString(),

--- a/apps/desktop/src/agent-kit/ensureAgentKit.ts
+++ b/apps/desktop/src/agent-kit/ensureAgentKit.ts
@@ -33,6 +33,7 @@ export async function ensureAgentKit(input: {
       `KANSOKU_DATA_ROOT=${input.dataRoot}`,
       `KANSOKU_APP_VERSION=${manifest.appVersion}`,
       `KANSOKU_KIT_VERSION=${manifest.kitVersion}`,
+      `TRADE_MIGRATIONS_DIR=${join(input.resourcesPath, 'drizzle')}`,
       '',
     ].join('\n'),
     'utf8',

--- a/apps/desktop/src/agent-kit/ipc.ts
+++ b/apps/desktop/src/agent-kit/ipc.ts
@@ -1,12 +1,14 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { app } from 'electron';
+import { app, BrowserWindow, dialog } from 'electron';
 import { IpcMethod, IpcService } from 'electron-ipc-decorator';
 import { getDb } from '@kansoku/core/db/index';
-import { dataRoot } from '../boot/env.js';
+import type { AgentKitLocation, AgentKitStatus } from '@kansoku/core/contract/agentKit';
+import { dataRoot, dataRootStatus } from '../boot/env.js';
 import { toEnvelope } from '../kernel/ipc/envelope.js';
 import { ensureAgentKit } from './ensureAgentKit.js';
 import { readManifest, type ManifestTemplate } from './manifest.js';
+import { isFollowBlocked, resolveAgentKitDir } from './resolveLocation.js';
 import {
   readState,
   removeConflict,
@@ -16,7 +18,7 @@ import {
   writeState,
   type AgentKitDataState,
 } from './state.js';
-import { defaultAgentKitStore } from './store.js';
+import { defaultAgentKitStore, type AgentKitStore } from './store.js';
 import { acceptConflictWithTemplate, keepConflictOriginal, makeRender } from './templates.js';
 
 function resourcesPath(): string {
@@ -29,10 +31,62 @@ function templateFor(dest: string): ManifestTemplate {
   return template;
 }
 
-function requireState(): AgentKitDataState {
-  const state = readState(dataRoot);
+function resolveDir(store: AgentKitStore): string | null {
+  return resolveAgentKitDir(store.read().location, dataRoot, dataRootStatus.mode);
+}
+
+function requireDir(store: AgentKitStore): string {
+  const dir = resolveDir(store);
+  if (dir === null) {
+    throw new Error(
+      'agentKit: no writable location — data root is the app default, please pick a custom folder',
+    );
+  }
+  return dir;
+}
+
+function requireState(agentKitDir: string): AgentKitDataState {
+  const state = readState(agentKitDir);
   if (!state) throw new Error('agentKit: no state to act against');
   return state;
+}
+
+function buildStatus(store: AgentKitStore): AgentKitStatus {
+  const s = store.read();
+  const dir = resolveAgentKitDir(s.location, dataRoot, dataRootStatus.mode);
+  const state = dir ? readState(dir) : null;
+  return {
+    enabled: s.enabled,
+    location: s.location,
+    resolvedPath: dir,
+    followBlocked: isFollowBlocked(s.location, dataRootStatus.mode),
+    dataRoot,
+    lastSyncAt: s.lastSyncAt,
+    kitVersion: state?.kitVersion,
+    pendingConflicts: state?.pendingConflicts,
+    pendingUpdates: state?.pendingUpdates,
+  };
+}
+
+async function runSync(store: AgentKitStore, agentKitDir: string) {
+  const result = await ensureAgentKit({
+    agentKitDir,
+    dataRoot,
+    resourcesPath: resourcesPath(),
+    db: getDb(),
+  });
+  store.write({ ...store.read(), lastSyncAt: new Date().toISOString() });
+  return result;
+}
+
+async function applyLocation(store: AgentKitStore, location: AgentKitLocation): Promise<AgentKitStatus> {
+  store.write({ ...store.read(), location });
+  const s = store.read();
+  if (s.enabled) {
+    const dir = resolveAgentKitDir(s.location, dataRoot, dataRootStatus.mode);
+    if (dir) await runSync(store, dir);
+  }
+  return buildStatus(store);
 }
 
 export class AgentKitIpc extends IpcService {
@@ -40,17 +94,7 @@ export class AgentKitIpc extends IpcService {
 
   @IpcMethod()
   getStatus() {
-    return toEnvelope('agentKit.getStatus', () => {
-      const s = defaultAgentKitStore(app).read();
-      const state = readState(dataRoot);
-      return {
-        enabled: s.enabled,
-        lastSyncAt: s.lastSyncAt,
-        kitVersion: state?.kitVersion,
-        pendingConflicts: state?.pendingConflicts,
-        pendingUpdates: state?.pendingUpdates,
-      };
-    });
+    return toEnvelope('agentKit.getStatus', () => buildStatus(defaultAgentKitStore(app)));
   }
 
   @IpcMethod()
@@ -61,8 +105,13 @@ export class AgentKitIpc extends IpcService {
         store.write({ ...store.read(), enabled: false });
         return { enabled: false };
       }
-      const result = await ensureAgentKit({ dataRoot, resourcesPath: resourcesPath(), db: getDb() });
-      store.write({ ...store.read(), enabled: true, lastSyncAt: new Date().toISOString() });
+      const dir = resolveDir(store);
+      if (dir === null) {
+        store.write({ ...store.read(), enabled: true });
+        return { enabled: true, conflicts: [], updates: [] };
+      }
+      const result = await runSync(store, dir);
+      store.write({ ...store.read(), enabled: true });
       return { enabled: true, ...result };
     });
   }
@@ -70,30 +119,31 @@ export class AgentKitIpc extends IpcService {
   @IpcMethod()
   forceSync() {
     return toEnvelope('agentKit.forceSync', async () => {
-      const result = await ensureAgentKit({ dataRoot, resourcesPath: resourcesPath(), db: getDb() });
       const store = defaultAgentKitStore(app);
-      store.write({ ...store.read(), lastSyncAt: new Date().toISOString() });
-      return result;
+      const dir = requireDir(store);
+      return runSync(store, dir);
     });
   }
 
   @IpcMethod()
   resolveConflict(input: { dest: string; choice: 'use-template' | 'keep-original' }) {
     return toEnvelope('agentKit.resolveConflict', () => {
+      const store = defaultAgentKitStore(app);
+      const dir = requireDir(store);
       const template = templateFor(input.dest);
-      const state = requireState();
+      const state = requireState(dir);
       const db = getDb();
       const templateState =
         input.choice === 'use-template'
           ? acceptConflictWithTemplate({
               template,
               resourcesPath: resourcesPath(),
-              dataRoot,
+              dataRoot: dir,
               db,
               render: makeRender(resourcesPath(), db),
             })
-          : keepConflictOriginal({ template, dataRoot });
-      writeState(dataRoot, removeConflict(upsertTemplate(state, input.dest, templateState), input.dest));
+          : keepConflictOriginal({ template, dataRoot: dir });
+      writeState(dir, removeConflict(upsertTemplate(state, input.dest, templateState), input.dest));
       return { dest: input.dest };
     });
   }
@@ -101,19 +151,21 @@ export class AgentKitIpc extends IpcService {
   @IpcMethod()
   applyUpdate(input: { dest: string }) {
     return toEnvelope('agentKit.applyUpdate', () => {
+      const store = defaultAgentKitStore(app);
+      const dir = requireDir(store);
       const template = templateFor(input.dest);
-      const state = requireState();
+      const state = requireState(dir);
       const db = getDb();
       const oldTemplateHash = state.templates[input.dest]?.sourceTemplateHash;
       const templateState = acceptConflictWithTemplate({
         template,
         resourcesPath: resourcesPath(),
-        dataRoot,
+        dataRoot: dir,
         db,
         render: makeRender(resourcesPath(), db),
         backupSuffix: (oldTemplateHash ?? 'unknown').slice(0, 8),
       });
-      writeState(dataRoot, removeUpdate(upsertTemplate(state, input.dest, templateState), input.dest));
+      writeState(dir, removeUpdate(upsertTemplate(state, input.dest, templateState), input.dest));
       return { dest: input.dest };
     });
   }
@@ -121,21 +173,50 @@ export class AgentKitIpc extends IpcService {
   @IpcMethod()
   clean() {
     return toEnvelope('agentKit.clean', () => {
-      const state = readState(dataRoot);
-      if (state) {
-        for (const [dest, templateState] of Object.entries(state.templates)) {
-          if (templateState.kept) continue;
-          const targetPath = join(dataRoot, dest);
-          if (!existsSync(targetPath)) continue;
-          if (sha256(readFileSync(targetPath)) === templateState.initialContentHash) {
-            rmSync(targetPath, { force: true });
+      const store = defaultAgentKitStore(app);
+      const dir = resolveDir(store);
+      if (dir) {
+        const state = readState(dir);
+        if (state) {
+          for (const [dest, templateState] of Object.entries(state.templates)) {
+            if (templateState.kept) continue;
+            const targetPath = join(dir, dest);
+            if (!existsSync(targetPath)) continue;
+            if (sha256(readFileSync(targetPath)) === templateState.initialContentHash) {
+              rmSync(targetPath, { force: true });
+            }
           }
         }
+        rmSync(join(dir, '.kansoku-agent-kit'), { recursive: true, force: true });
       }
-      rmSync(join(dataRoot, '.kansoku-agent-kit'), { recursive: true, force: true });
-      const store = defaultAgentKitStore(app);
       store.write({ ...store.read(), enabled: false });
       return { cleaned: true };
+    });
+  }
+
+  @IpcMethod()
+  followDataRoot() {
+    return toEnvelope('agentKit.followDataRoot', () =>
+      applyLocation(defaultAgentKitStore(app), { kind: 'follow-data-root' }),
+    );
+  }
+
+  @IpcMethod()
+  pickCustomLocation() {
+    return toEnvelope('agentKit.pickCustomLocation', async () => {
+      const store = defaultAgentKitStore(app);
+      const win = BrowserWindow.getFocusedWindow();
+      const picked = await (win
+        ? dialog.showOpenDialog(win, {
+            title: '选择 Agent Kit 目录',
+            properties: ['openDirectory', 'createDirectory'],
+          })
+        : dialog.showOpenDialog({
+            title: '选择 Agent Kit 目录',
+            properties: ['openDirectory', 'createDirectory'],
+          }));
+      if (picked.canceled || picked.filePaths.length === 0) return buildStatus(store);
+      return applyLocation(store, { kind: 'custom', path: picked.filePaths[0] });
     });
   }
 }

--- a/apps/desktop/src/agent-kit/ipc.ts
+++ b/apps/desktop/src/agent-kit/ipc.ts
@@ -1,0 +1,128 @@
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { app } from 'electron';
+import { IpcMethod, IpcService } from 'electron-ipc-decorator';
+import { getDb } from '@kansoku/core/db/index';
+import { dataRoot } from '../boot/env.js';
+import { toEnvelope } from '../kernel/ipc/envelope.js';
+import { ensureAgentKit } from './ensureAgentKit.js';
+import { readManifest, type ManifestTemplate } from './manifest.js';
+import { readState, writeState, type AgentKitDataState } from './state.js';
+import { defaultAgentKitStore } from './store.js';
+import { acceptConflictWithTemplate, keepConflictOriginal, makeRender } from './templates.js';
+
+function resourcesPath(): string {
+  return process.resourcesPath;
+}
+
+function templateFor(dest: string): ManifestTemplate {
+  const template = readManifest(resourcesPath()).templates.find((t) => t.dest === dest);
+  if (!template) throw new Error(`agentKit: unknown template dest ${dest}`);
+  return template;
+}
+
+function requireState(): AgentKitDataState {
+  const state = readState(dataRoot);
+  if (!state) throw new Error('agentKit: no state to act against');
+  return state;
+}
+
+export class AgentKitIpc extends IpcService {
+  static readonly groupName = 'agentKit';
+
+  @IpcMethod()
+  getStatus() {
+    return toEnvelope('agentKit.getStatus', () => {
+      const s = defaultAgentKitStore(app).read();
+      const state = readState(dataRoot);
+      return {
+        enabled: s.enabled,
+        lastSyncAt: s.lastSyncAt,
+        kitVersion: state?.kitVersion,
+        pendingConflicts: state?.pendingConflicts,
+        pendingUpdates: state?.pendingUpdates,
+      };
+    });
+  }
+
+  @IpcMethod()
+  setEnabled(input: { enabled: boolean }) {
+    return toEnvelope('agentKit.setEnabled', async () => {
+      const store = defaultAgentKitStore(app);
+      if (!input.enabled) {
+        store.write({ ...store.read(), enabled: false });
+        return { enabled: false };
+      }
+      const result = await ensureAgentKit({ dataRoot, resourcesPath: resourcesPath(), db: getDb() });
+      store.write({ ...store.read(), enabled: true, lastSyncAt: new Date().toISOString() });
+      return { enabled: true, ...result };
+    });
+  }
+
+  @IpcMethod()
+  forceSync() {
+    return toEnvelope('agentKit.forceSync', async () => {
+      const result = await ensureAgentKit({ dataRoot, resourcesPath: resourcesPath(), db: getDb() });
+      const store = defaultAgentKitStore(app);
+      store.write({ ...store.read(), lastSyncAt: new Date().toISOString() });
+      return result;
+    });
+  }
+
+  @IpcMethod()
+  resolveConflict(input: { dest: string; choice: 'use-template' | 'keep-original' }) {
+    return toEnvelope('agentKit.resolveConflict', () => {
+      const template = templateFor(input.dest);
+      const state = requireState();
+      const db = getDb();
+      const templateState =
+        input.choice === 'use-template'
+          ? acceptConflictWithTemplate({
+              template,
+              resourcesPath: resourcesPath(),
+              dataRoot,
+              db,
+              render: makeRender(resourcesPath(), db),
+            })
+          : keepConflictOriginal({ template, dataRoot });
+      const pendingConflicts = state.pendingConflicts?.filter((c) => c.dest !== input.dest) ?? [];
+      writeState(dataRoot, {
+        ...state,
+        templates: { ...state.templates, [input.dest]: templateState },
+        pendingConflicts: pendingConflicts.length ? pendingConflicts : undefined,
+      });
+      return { dest: input.dest };
+    });
+  }
+
+  @IpcMethod()
+  applyUpdate(input: { dest: string }) {
+    return toEnvelope('agentKit.applyUpdate', () => {
+      const template = templateFor(input.dest);
+      const state = requireState();
+      const db = getDb();
+      const templateState = acceptConflictWithTemplate({
+        template,
+        resourcesPath: resourcesPath(),
+        dataRoot,
+        db,
+        render: makeRender(resourcesPath(), db),
+      });
+      const pendingUpdates = state.pendingUpdates?.filter((u) => u.dest !== input.dest) ?? [];
+      writeState(dataRoot, {
+        ...state,
+        templates: { ...state.templates, [input.dest]: templateState },
+        pendingUpdates: pendingUpdates.length ? pendingUpdates : undefined,
+      });
+      return { dest: input.dest };
+    });
+  }
+
+  @IpcMethod()
+  clean() {
+    return toEnvelope('agentKit.clean', () => {
+      rmSync(join(dataRoot, '.kansoku-agent-kit'), { recursive: true, force: true });
+      return { cleaned: true };
+    });
+  }
+}

--- a/apps/desktop/src/agent-kit/ipc.ts
+++ b/apps/desktop/src/agent-kit/ipc.ts
@@ -7,7 +7,14 @@ import { dataRoot } from '../boot/env.js';
 import { toEnvelope } from '../kernel/ipc/envelope.js';
 import { ensureAgentKit } from './ensureAgentKit.js';
 import { readManifest, type ManifestTemplate } from './manifest.js';
-import { readState, writeState, type AgentKitDataState } from './state.js';
+import {
+  readState,
+  removeConflict,
+  removeUpdate,
+  upsertTemplate,
+  writeState,
+  type AgentKitDataState,
+} from './state.js';
 import { defaultAgentKitStore } from './store.js';
 import { acceptConflictWithTemplate, keepConflictOriginal, makeRender } from './templates.js';
 
@@ -85,12 +92,7 @@ export class AgentKitIpc extends IpcService {
               render: makeRender(resourcesPath(), db),
             })
           : keepConflictOriginal({ template, dataRoot });
-      const pendingConflicts = state.pendingConflicts?.filter((c) => c.dest !== input.dest) ?? [];
-      writeState(dataRoot, {
-        ...state,
-        templates: { ...state.templates, [input.dest]: templateState },
-        pendingConflicts: pendingConflicts.length ? pendingConflicts : undefined,
-      });
+      writeState(dataRoot, removeConflict(upsertTemplate(state, input.dest, templateState), input.dest));
       return { dest: input.dest };
     });
   }
@@ -108,12 +110,7 @@ export class AgentKitIpc extends IpcService {
         db,
         render: makeRender(resourcesPath(), db),
       });
-      const pendingUpdates = state.pendingUpdates?.filter((u) => u.dest !== input.dest) ?? [];
-      writeState(dataRoot, {
-        ...state,
-        templates: { ...state.templates, [input.dest]: templateState },
-        pendingUpdates: pendingUpdates.length ? pendingUpdates : undefined,
-      });
+      writeState(dataRoot, removeUpdate(upsertTemplate(state, input.dest, templateState), input.dest));
       return { dest: input.dest };
     });
   }

--- a/apps/desktop/src/agent-kit/ipc.ts
+++ b/apps/desktop/src/agent-kit/ipc.ts
@@ -1,4 +1,4 @@
-import { rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { app } from 'electron';
 import { IpcMethod, IpcService } from 'electron-ipc-decorator';
@@ -11,6 +11,7 @@ import {
   readState,
   removeConflict,
   removeUpdate,
+  sha256,
   upsertTemplate,
   writeState,
   type AgentKitDataState,
@@ -103,12 +104,14 @@ export class AgentKitIpc extends IpcService {
       const template = templateFor(input.dest);
       const state = requireState();
       const db = getDb();
+      const oldTemplateHash = state.templates[input.dest]?.sourceTemplateHash;
       const templateState = acceptConflictWithTemplate({
         template,
         resourcesPath: resourcesPath(),
         dataRoot,
         db,
         render: makeRender(resourcesPath(), db),
+        backupSuffix: (oldTemplateHash ?? 'unknown').slice(0, 8),
       });
       writeState(dataRoot, removeUpdate(upsertTemplate(state, input.dest, templateState), input.dest));
       return { dest: input.dest };
@@ -118,7 +121,20 @@ export class AgentKitIpc extends IpcService {
   @IpcMethod()
   clean() {
     return toEnvelope('agentKit.clean', () => {
+      const state = readState(dataRoot);
+      if (state) {
+        for (const [dest, templateState] of Object.entries(state.templates)) {
+          if (templateState.kept) continue;
+          const targetPath = join(dataRoot, dest);
+          if (!existsSync(targetPath)) continue;
+          if (sha256(readFileSync(targetPath)) === templateState.initialContentHash) {
+            rmSync(targetPath, { force: true });
+          }
+        }
+      }
       rmSync(join(dataRoot, '.kansoku-agent-kit'), { recursive: true, force: true });
+      const store = defaultAgentKitStore(app);
+      store.write({ ...store.read(), enabled: false });
       return { cleaned: true };
     });
   }

--- a/apps/desktop/src/agent-kit/manifest.ts
+++ b/apps/desktop/src/agent-kit/manifest.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type ManifestTemplate = {
+  path: string;
+  dest: string;
+  sha256: string;
+  source?: 'app-config';
+};
+
+export type Manifest = {
+  kitVersion: string;
+  appVersion: string;
+  templates: ManifestTemplate[];
+};
+
+export function readManifest(resourcesPath: string): Manifest {
+  const p = join(resourcesPath, 'kansoku-agent-kit', 'manifest.json');
+  return JSON.parse(readFileSync(p, 'utf8')) as Manifest;
+}

--- a/apps/desktop/src/agent-kit/renderPersonalMd.ts
+++ b/apps/desktop/src/agent-kit/renderPersonalMd.ts
@@ -1,0 +1,20 @@
+import type { Db } from '@kansoku/core/db/index';
+import { createWatchedMarketsStore } from '@kansoku/core/marketdata/watchedMarketsStore';
+
+export const PERSONAL_MD_RENDER_VERSION = 'app-config-v1';
+
+function readWatchedMarkets(db: Db): string[] {
+  return createWatchedMarketsStore(db).get();
+}
+
+export function renderPersonalMd(db: Db): string {
+  const markets = readWatchedMarkets(db);
+  return [
+    '# 个人研究配置',
+    '',
+    '来自 App 设置（watched_markets_settings 表快照，首次生成，之后归用户）。',
+    '',
+    `- 关注市场：${markets.length ? markets.join(', ') : '（未配置）'}`,
+    '',
+  ].join('\n');
+}

--- a/apps/desktop/src/agent-kit/resolveLocation.ts
+++ b/apps/desktop/src/agent-kit/resolveLocation.ts
@@ -1,0 +1,16 @@
+import type { AgentKitLocation } from '@kansoku/core/contract/agentKit';
+import type { DataRootMode } from '../data/dataRoot/status.js';
+
+export function resolveAgentKitDir(
+  location: AgentKitLocation,
+  dataRoot: string,
+  dataRootMode: DataRootMode,
+): string | null {
+  if (location.kind === 'custom') return location.path;
+  if (dataRootMode === 'default') return null;
+  return dataRoot;
+}
+
+export function isFollowBlocked(location: AgentKitLocation, dataRootMode: DataRootMode): boolean {
+  return location.kind === 'follow-data-root' && dataRootMode === 'default';
+}

--- a/apps/desktop/src/agent-kit/state.ts
+++ b/apps/desktop/src/agent-kit/state.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type TemplateState = {
+  initialContentHash: string;
+  sourceTemplateHash: string;
+  writtenAt: string;
+  kept?: boolean;
+};
+
+export type PendingConflict = {
+  dest: string;
+  templatePath: string;
+  reason: 'target-exists-no-state';
+};
+
+export type PendingUpdate = {
+  dest: string;
+  templatePath: string;
+  oldTemplateHash: string;
+  newTemplateHash: string;
+};
+
+export type AgentKitDataState = {
+  kitVersion: string;
+  appVersion: string;
+  syncedAt: string;
+  templates: Record<string, TemplateState>;
+  pendingConflicts?: PendingConflict[];
+  pendingUpdates?: PendingUpdate[];
+};
+
+export function sha256(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function kitDir(dataRoot: string): string {
+  return join(dataRoot, '.kansoku-agent-kit');
+}
+
+export function readState(dataRoot: string): AgentKitDataState | null {
+  const p = join(kitDir(dataRoot), 'state.json');
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as AgentKitDataState;
+  } catch {
+    return null;
+  }
+}
+
+export function writeState(dataRoot: string, state: AgentKitDataState): void {
+  const dir = kitDir(dataRoot);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'state.json'), `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}

--- a/apps/desktop/src/agent-kit/state.ts
+++ b/apps/desktop/src/agent-kit/state.ts
@@ -54,3 +54,21 @@ export function writeState(dataRoot: string, state: AgentKitDataState): void {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, 'state.json'), `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
+
+export function upsertTemplate(
+  state: AgentKitDataState,
+  dest: string,
+  templateState: TemplateState,
+): AgentKitDataState {
+  return { ...state, templates: { ...state.templates, [dest]: templateState } };
+}
+
+export function removeConflict(state: AgentKitDataState, dest: string): AgentKitDataState {
+  const pendingConflicts = state.pendingConflicts?.filter((c) => c.dest !== dest) ?? [];
+  return { ...state, pendingConflicts: pendingConflicts.length ? pendingConflicts : undefined };
+}
+
+export function removeUpdate(state: AgentKitDataState, dest: string): AgentKitDataState {
+  const pendingUpdates = state.pendingUpdates?.filter((u) => u.dest !== dest) ?? [];
+  return { ...state, pendingUpdates: pendingUpdates.length ? pendingUpdates : undefined };
+}

--- a/apps/desktop/src/agent-kit/store.ts
+++ b/apps/desktop/src/agent-kit/store.ts
@@ -1,0 +1,34 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export type AgentKitStoreState = { enabled: boolean; lastSyncAt?: string };
+
+export interface AgentKitStore {
+  read(): AgentKitStoreState;
+  write(next: AgentKitStoreState): void;
+}
+
+export function createAgentKitStore(filePath: string): AgentKitStore {
+  return {
+    read() {
+      if (!existsSync(filePath)) return { enabled: true };
+      try {
+        const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+        return {
+          enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : true,
+          lastSyncAt: typeof parsed.lastSyncAt === 'string' ? parsed.lastSyncAt : undefined,
+        };
+      } catch {
+        return { enabled: true };
+      }
+    },
+    write(next) {
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    },
+  };
+}
+
+export function defaultAgentKitStore(app: Pick<Electron.App, 'getPath'>): AgentKitStore {
+  return createAgentKitStore(join(app.getPath('userData'), 'agent-kit.json'));
+}

--- a/apps/desktop/src/agent-kit/store.ts
+++ b/apps/desktop/src/agent-kit/store.ts
@@ -1,25 +1,48 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { AgentKitLocation } from '@kansoku/core/contract/agentKit';
 
-export type AgentKitStoreState = { enabled: boolean; lastSyncAt?: string };
+export type AgentKitStoreState = {
+  enabled: boolean;
+  location: AgentKitLocation;
+  lastSyncAt?: string;
+};
 
 export interface AgentKitStore {
   read(): AgentKitStoreState;
   write(next: AgentKitStoreState): void;
+  exists(): boolean;
+}
+
+const FALLBACK: AgentKitStoreState = { enabled: false, location: { kind: 'follow-data-root' } };
+
+function parseLocation(raw: unknown): AgentKitLocation {
+  if (raw && typeof raw === 'object') {
+    const kind = (raw as { kind?: unknown }).kind;
+    if (kind === 'custom' && typeof (raw as { path?: unknown }).path === 'string') {
+      return { kind: 'custom', path: (raw as { path: string }).path };
+    }
+    if (kind === 'follow-data-root') return { kind: 'follow-data-root' };
+  }
+  return { kind: 'follow-data-root' };
 }
 
 export function createAgentKitStore(filePath: string): AgentKitStore {
   return {
+    exists() {
+      return existsSync(filePath);
+    },
     read() {
-      if (!existsSync(filePath)) return { enabled: true };
+      if (!existsSync(filePath)) return { ...FALLBACK };
       try {
         const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
         return {
-          enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : true,
+          enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : false,
+          location: parseLocation(parsed.location),
           lastSyncAt: typeof parsed.lastSyncAt === 'string' ? parsed.lastSyncAt : undefined,
         };
       } catch {
-        return { enabled: true };
+        return { ...FALLBACK };
       }
     },
     write(next) {

--- a/apps/desktop/src/agent-kit/templates.ts
+++ b/apps/desktop/src/agent-kit/templates.ts
@@ -1,0 +1,108 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Db } from '@kansoku/core/db/index';
+import type { ManifestTemplate } from './manifest.js';
+import { renderPersonalMd } from './renderPersonalMd.js';
+import {
+  sha256,
+  type AgentKitDataState,
+  type PendingConflict,
+  type PendingUpdate,
+  type TemplateState,
+} from './state.js';
+
+export type TemplateSyncOutcome =
+  | { kind: 'written'; dest: string }
+  | { kind: 'conflict'; conflict: PendingConflict }
+  | { kind: 'skip-user-modified'; dest: string }
+  | { kind: 'skip-uptodate'; dest: string }
+  | { kind: 'pending-update'; update: PendingUpdate };
+
+export function syncTemplate(input: {
+  template: ManifestTemplate;
+  resourcesPath: string;
+  dataRoot: string;
+  db: Db;
+  state: AgentKitDataState | null;
+  render: (template: ManifestTemplate) => string;
+}): TemplateSyncOutcome {
+  const targetPath = join(input.dataRoot, input.template.dest);
+  const prev = input.state?.templates[input.template.dest];
+  const targetExists = existsSync(targetPath);
+
+  if (!targetExists) {
+    const content = input.render(input.template);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, content, 'utf8');
+    return { kind: 'written', dest: input.template.dest };
+  }
+
+  if (!prev) {
+    return {
+      kind: 'conflict',
+      conflict: {
+        dest: input.template.dest,
+        templatePath: input.template.path,
+        reason: 'target-exists-no-state',
+      },
+    };
+  }
+
+  const currentHash = sha256(readFileSync(targetPath));
+  if (currentHash !== prev.initialContentHash) {
+    return { kind: 'skip-user-modified', dest: input.template.dest };
+  }
+  if (input.template.sha256 === prev.sourceTemplateHash) {
+    return { kind: 'skip-uptodate', dest: input.template.dest };
+  }
+  return {
+    kind: 'pending-update',
+    update: {
+      dest: input.template.dest,
+      templatePath: input.template.path,
+      oldTemplateHash: prev.sourceTemplateHash,
+      newTemplateHash: input.template.sha256,
+    },
+  };
+}
+
+export function makeRender(resourcesPath: string, db: Db): (t: ManifestTemplate) => string {
+  return (t) => {
+    if (t.source === 'app-config') return renderPersonalMd(db);
+    return readFileSync(join(resourcesPath, 'kansoku-agent-kit', t.path), 'utf8');
+  };
+}
+
+export function acceptConflictWithTemplate(input: {
+  template: ManifestTemplate;
+  resourcesPath: string;
+  dataRoot: string;
+  db: Db;
+  render: (t: ManifestTemplate) => string;
+}): TemplateState {
+  const targetPath = join(input.dataRoot, input.template.dest);
+  const bakPath = `${targetPath}.bak`;
+  if (existsSync(targetPath)) copyFileSync(targetPath, bakPath);
+  const content = input.render(input.template);
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, content, 'utf8');
+  return {
+    initialContentHash: sha256(content),
+    sourceTemplateHash: input.template.sha256,
+    writtenAt: new Date().toISOString(),
+  };
+}
+
+export function keepConflictOriginal(input: {
+  template: ManifestTemplate;
+  dataRoot: string;
+}): TemplateState {
+  const targetPath = join(input.dataRoot, input.template.dest);
+  const currentHash = sha256(readFileSync(targetPath));
+  return {
+    initialContentHash: currentHash,
+    sourceTemplateHash: input.template.sha256,
+    writtenAt: new Date().toISOString(),
+    kept: true,
+  };
+}

--- a/apps/desktop/src/agent-kit/templates.ts
+++ b/apps/desktop/src/agent-kit/templates.ts
@@ -79,9 +79,10 @@ export function acceptConflictWithTemplate(input: {
   dataRoot: string;
   db: Db;
   render: (t: ManifestTemplate) => string;
+  backupSuffix?: string;
 }): TemplateState {
   const targetPath = join(input.dataRoot, input.template.dest);
-  const bakPath = `${targetPath}.bak`;
+  const bakPath = `${targetPath}.bak${input.backupSuffix ? `.${input.backupSuffix}` : ''}`;
   if (existsSync(targetPath)) copyFileSync(targetPath, bakPath);
   const content = input.render(input.template);
   mkdirSync(dirname(targetPath), { recursive: true });

--- a/apps/desktop/src/boot/env.ts
+++ b/apps/desktop/src/boot/env.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { app } from 'electron';
 import { ensureAgentKit } from '../agent-kit/ensureAgentKit.js';
+import { resolveAgentKitDir } from '../agent-kit/resolveLocation.js';
 import { defaultAgentKitStore } from '../agent-kit/store.js';
 import { buildDataRootStatus } from '../data/dataRoot/status.js';
 import { isDataRootUsable } from '../data/dataRoot/usability.js';
@@ -49,15 +50,33 @@ process.env.TRADE_PROJECT_ROOT = dataRoot;
 
 export const IS_DEV = __DESKTOP_DEV__;
 
-if (isPackaged && process.platform === 'darwin' && defaultAgentKitStore(app).read().enabled) {
-  void (async () => {
-    try {
-      const { getDb } = await import('@kansoku/core/db/index');
-      await ensureAgentKit({ dataRoot, resourcesPath: process.resourcesPath, db: getDb() });
-    } catch (err) {
-      console.error('[agent-kit] boot sync failed', err);
+if (isPackaged && process.platform === 'darwin') {
+  const store = defaultAgentKitStore(app);
+  if (!store.exists()) {
+    store.write({
+      enabled: dataRootStatus.mode !== 'default',
+      location: { kind: 'follow-data-root' },
+    });
+  }
+  const state = store.read();
+  if (state.enabled) {
+    const agentKitDir = resolveAgentKitDir(state.location, dataRoot, dataRootStatus.mode);
+    if (agentKitDir) {
+      void (async () => {
+        try {
+          const { getDb } = await import('@kansoku/core/db/index');
+          await ensureAgentKit({
+            agentKitDir,
+            dataRoot,
+            resourcesPath: process.resourcesPath,
+            db: getDb(),
+          });
+        } catch (err) {
+          console.error('[agent-kit] boot sync failed', err);
+        }
+      })();
     }
-  })();
+  }
 }
 
 function readConfiguredPath(userDataPath: string): string | null {

--- a/apps/desktop/src/boot/env.ts
+++ b/apps/desktop/src/boot/env.ts
@@ -49,7 +49,7 @@ process.env.TRADE_PROJECT_ROOT = dataRoot;
 
 export const IS_DEV = __DESKTOP_DEV__;
 
-if (defaultAgentKitStore(app).read().enabled) {
+if (isPackaged && process.platform === 'darwin' && defaultAgentKitStore(app).read().enabled) {
   void (async () => {
     try {
       const { getDb } = await import('@kansoku/core/db/index');

--- a/apps/desktop/src/boot/env.ts
+++ b/apps/desktop/src/boot/env.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { app } from 'electron';
+import { ensureAgentKit } from '../agent-kit/ensureAgentKit.js';
+import { defaultAgentKitStore } from '../agent-kit/store.js';
 import { buildDataRootStatus } from '../data/dataRoot/status.js';
 import { isDataRootUsable } from '../data/dataRoot/usability.js';
 import { resolveDataRoot, scaffoldDataRoot } from './paths.js';
@@ -46,6 +48,17 @@ if (isPackaged) {
 process.env.TRADE_PROJECT_ROOT = dataRoot;
 
 export const IS_DEV = __DESKTOP_DEV__;
+
+if (defaultAgentKitStore(app).read().enabled) {
+  void (async () => {
+    try {
+      const { getDb } = await import('@kansoku/core/db/index');
+      await ensureAgentKit({ dataRoot, resourcesPath: process.resourcesPath, db: getDb() });
+    } catch (err) {
+      console.error('[agent-kit] boot sync failed', err);
+    }
+  })();
+}
 
 function readConfiguredPath(userDataPath: string): string | null {
   try {

--- a/apps/desktop/src/cli/commands/chart.ts
+++ b/apps/desktop/src/cli/commands/chart.ts
@@ -1,0 +1,27 @@
+import { runChartCreate } from './chart/create.js';
+import { runChartGet } from './chart/get.js';
+import { runChartList } from './chart/list.js';
+
+export { runChartCreate } from './chart/create.js';
+export { runChartGet } from './chart/get.js';
+export { runChartList } from './chart/list.js';
+
+export async function runChart(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  switch (sub) {
+    case 'create': {
+      return runChartCreate(rest);
+    }
+    case 'list': {
+      return runChartList(rest);
+    }
+    case 'get': {
+      return runChartGet(rest);
+    }
+    default: {
+      process.stderr.write(`chart: unknown sub-command "${sub}"\n`);
+      process.exit(64);
+    }
+  }
+}

--- a/apps/desktop/src/cli/commands/chart/create.ts
+++ b/apps/desktop/src/cli/commands/chart/create.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import type { ChartUrlDoc } from '@kansoku/shared/chartUrl';
 import { emit } from '../../report.js';
 
 interface CreateArgs {
@@ -70,7 +71,8 @@ export async function runChartCreate(argv: string[], create?: CreateChartFn): Pr
     const createChart =
       create ?? (await import('@kansoku/core/charts/charts.service')).chartsService.create;
     const result = await createChart(payload);
-    emit(result.data);
+    const { chartDeepLink } = await import('@kansoku/core/platform/chartUrl');
+    emit({ ...result.data, deepLink: chartDeepLink(result.data as unknown as ChartUrlDoc) });
   } catch (err) {
     return fail(err instanceof Error ? err.message : String(err));
   }

--- a/apps/desktop/src/cli/commands/chart/create.ts
+++ b/apps/desktop/src/cli/commands/chart/create.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { emit } from '../../report.js';
+
+interface CreateArgs {
+  type?: string;
+  symbol?: string;
+  jsonInput?: string;
+}
+
+type CreateChartFn = (
+  payload: Record<string, unknown>,
+) => Promise<{ data: Record<string, unknown> }>;
+
+function parseCreateArgs(argv: string[]): CreateArgs {
+  const args: CreateArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--type') args.type = argv[++i];
+    else if (argv[i] === '--symbol') args.symbol = argv[++i];
+    else if (argv[i] === '--json-input') args.jsonInput = argv[++i];
+  }
+  return args;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function fail(message: string): void {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}
+
+export async function runChartCreate(argv: string[], create?: CreateChartFn): Promise<void> {
+  const args = parseCreateArgs(argv);
+  if (!args.type) return fail('chart create: --type is required');
+  if (!args.jsonInput) return fail('chart create: --json-input is required');
+
+  let raw: string;
+  try {
+    raw = args.jsonInput === '-' ? await readStdin() : readFileSync(args.jsonInput, 'utf8');
+  } catch (err) {
+    return fail(
+      `chart create: failed to read --json-input (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  let extra: Record<string, unknown>;
+  try {
+    const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('--json-input must contain a JSON object');
+    }
+    extra = parsed as Record<string, unknown>;
+  } catch (err) {
+    return fail(
+      `chart create: invalid --json-input (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  const payload: Record<string, unknown> = { ...extra, type: args.type };
+  if (args.symbol) payload.symbol = args.symbol;
+
+  try {
+    // Kernel modules resolve `journal/charts/data` etc. off `TRADE_PROJECT_ROOT` at
+    // import time, so this import must stay dynamic and run after resolveDataRoot()
+    // has already set the env var (see apps/desktop/src/boot/kernel.ts for the same
+    // constraint on the Electron boot path).
+    const createChart =
+      create ?? (await import('@kansoku/core/charts/charts.service')).chartsService.create;
+    const result = await createChart(payload);
+    emit(result.data);
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}

--- a/apps/desktop/src/cli/commands/chart/get.ts
+++ b/apps/desktop/src/cli/commands/chart/get.ts
@@ -1,0 +1,28 @@
+import { emit } from '../../report.js';
+
+export async function runChartGet(argv: string[]): Promise<void> {
+  const id = argv[0];
+  if (!id) {
+    process.stderr.write('chart get: missing chart id\n');
+    process.exit(64);
+    return;
+  }
+
+  const { listCharts, loadChart } = await import('@kansoku/core/charts/store');
+  const metas = await listCharts();
+  const meta = metas.find((m) => m.id === id);
+  if (!meta) {
+    process.stderr.write(`chart get: not found: ${id}\n`);
+    process.exit(1);
+    return;
+  }
+
+  const data = await loadChart(id);
+  if (!data) {
+    process.stderr.write(`chart get: missing chart data for: ${id}\n`);
+    process.exit(1);
+    return;
+  }
+
+  emit({ meta, data });
+}

--- a/apps/desktop/src/cli/commands/chart/list.ts
+++ b/apps/desktop/src/cli/commands/chart/list.ts
@@ -1,0 +1,26 @@
+import { marketDate } from '@kansoku/shared/time';
+import { emit } from '../../report.js';
+
+interface ListArgs {
+  symbol?: string;
+  date?: string;
+}
+
+function parseListArgs(argv: string[]): ListArgs {
+  const args: ListArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--symbol') args.symbol = argv[++i];
+    else if (argv[i] === '--date') args.date = argv[++i];
+  }
+  return args;
+}
+
+export async function runChartList(argv: string[]): Promise<void> {
+  const args = parseListArgs(argv);
+  const { listCharts } = await import('@kansoku/core/charts/store');
+  const metas = await listCharts({ symbol: args.symbol });
+  const filtered = args.date
+    ? metas.filter((m) => marketDate(m.created_at) === args.date)
+    : metas;
+  emit(filtered);
+}

--- a/apps/desktop/src/cli/commands/info.ts
+++ b/apps/desktop/src/cli/commands/info.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { emit } from '../report.js';
+
+interface Manifest {
+  kitVersion: string;
+  appVersion: string;
+}
+
+function defaultReadManifest(): Manifest {
+  const manifestPath = join(import.meta.dirname ?? __dirname, 'manifest.json');
+  return JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest;
+}
+
+export function runInfo(argv: string[], readManifest: () => Manifest = defaultReadManifest): void {
+  const sub = argv[0];
+  switch (sub) {
+    case 'kit-version': {
+      return emit({ kitVersion: readManifest().kitVersion });
+    }
+    case 'data-root': {
+      return emit({ dataRoot: process.env.TRADE_PROJECT_ROOT ?? null });
+    }
+    case 'version': {
+      return emit({ version: readManifest().appVersion });
+    }
+    default: {
+      process.stderr.write(`info: unknown sub-command "${sub}"\n`);
+      process.exit(64);
+    }
+  }
+}

--- a/apps/desktop/src/cli/dataRoot.ts
+++ b/apps/desktop/src/cli/dataRoot.ts
@@ -1,0 +1,16 @@
+export function resolveDataRoot(argv: string[]): string | undefined {
+  const flagIdx = argv.indexOf('--data-root');
+  if (flagIdx >= 0 && argv[flagIdx + 1]) {
+    const root = argv[flagIdx + 1];
+    process.env.TRADE_PROJECT_ROOT = root;
+    return root;
+  }
+
+  const fromKansokuEnv = process.env.KANSOKU_DATA_ROOT;
+  if (fromKansokuEnv) {
+    process.env.TRADE_PROJECT_ROOT = fromKansokuEnv;
+    return fromKansokuEnv;
+  }
+
+  return process.env.TRADE_PROJECT_ROOT;
+}

--- a/apps/desktop/src/cli/main.ts
+++ b/apps/desktop/src/cli/main.ts
@@ -1,3 +1,4 @@
+import { runChart } from './commands/chart.js';
 import { runInfo } from './commands/info.js';
 import { resolveDataRoot } from './dataRoot.js';
 
@@ -10,6 +11,9 @@ Commands:
   info kit-version           print the packaged Agent Kit version
   info data-root             print the resolved data root path
   info version               print the CLI's own version (matches App)
+  chart create               create a chart (--type, --symbol, --json-input)
+  chart list                 list chart metas (--symbol, --date)
+  chart get <id>             print a chart's meta + data
 
 Data root resolution (priority):
   --data-root <path>         command-line flag
@@ -41,7 +45,7 @@ async function main() {
       return runInfo(rest);
     }
     case 'chart': {
-      throw new Error('chart subcommand not yet available (implemented in Task 3)');
+      return runChart(rest);
     }
     default: {
       process.stderr.write(`Unknown command: ${command}\n`);

--- a/apps/desktop/src/cli/main.ts
+++ b/apps/desktop/src/cli/main.ts
@@ -1,0 +1,56 @@
+import { runInfo } from './commands/info.js';
+import { resolveDataRoot } from './dataRoot.js';
+
+const HELP_TEXT = `kansoku-cli — data-root operations for Kansoku
+
+Usage:
+  kansoku-cli <command> [options]
+
+Commands:
+  info kit-version           print the packaged Agent Kit version
+  info data-root             print the resolved data root path
+  info version               print the CLI's own version (matches App)
+
+Data root resolution (priority):
+  --data-root <path>         command-line flag
+  $KANSOKU_DATA_ROOT         environment
+  $TRADE_PROJECT_ROOT        environment
+
+Environment set by App:
+  $KANSOKU_CLI, $KANSOKU_DATA_ROOT, $KANSOKU_APP_VERSION, $KANSOKU_KIT_VERSION
+  loaded from <dataRoot>/.kansoku-agent-kit/runtime.env
+`;
+
+function printHelp(): void {
+  process.stdout.write(HELP_TEXT);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    return printHelp();
+  }
+
+  const command = argv[0];
+  const rest = argv.slice(1);
+
+  resolveDataRoot(rest);
+
+  switch (command) {
+    case 'info': {
+      return runInfo(rest);
+    }
+    case 'chart': {
+      throw new Error('chart subcommand not yet available (implemented in Task 3)');
+    }
+    default: {
+      process.stderr.write(`Unknown command: ${command}\n`);
+      process.exit(64);
+    }
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write((err instanceof Error ? err.message : String(err)) + '\n');
+  process.exit(1);
+});

--- a/apps/desktop/src/cli/report.ts
+++ b/apps/desktop/src/cli/report.ts
@@ -1,0 +1,3 @@
+export function emit(payload: unknown): void {
+  process.stdout.write(JSON.stringify(payload) + '\n');
+}

--- a/apps/desktop/src/kernel/ipc/groups.ts
+++ b/apps/desktop/src/kernel/ipc/groups.ts
@@ -4,6 +4,7 @@ export const KERNEL_IPC_GROUPS = [
   'charts',
   'chat',
   'symbols',
+  'agentKit',
   'annotations',
   'positions',
   'research',

--- a/apps/desktop/src/kernel/ipc/index.ts
+++ b/apps/desktop/src/kernel/ipc/index.ts
@@ -1,3 +1,4 @@
+import { AgentKitIpc } from '../../agent-kit/ipc.js';
 import { AnnotationsIpc } from './annotationsIpc.js';
 import { AssistantIpc } from './assistantIpc.js';
 import { CapabilitiesIpc } from './capabilitiesIpc.js';
@@ -14,6 +15,7 @@ import { SettingsIpc } from './settingsIpc.js';
 import { SymbolsIpc } from './symbolsIpc.js';
 
 export const ipcServiceClasses = [
+  AgentKitIpc,
   ChartsIpc,
   SymbolsIpc,
   AnnotationsIpc,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,7 +13,8 @@ import { createServices } from 'electron-ipc-decorator';
 import { AppControlIpc } from './shell/appControl/ipc.js';
 import { createAppMenuManager } from './shell/menu/appMenuManager.js';
 import { bootKernel } from './boot/kernel.js';
-import { createWindowManager } from './shell/window/windowManager.js';
+import { createWindowManager, type WindowManager } from './shell/window/windowManager.js';
+import { dispatchDeepLink, findDeepLinkArg } from './platform/deepLink/deepLink.js';
 import { showFatalErrorWindow } from './shell/window/fatalErrorWindow.js';
 import { applyDevDockIcon } from './shell/window/dockIcon.js';
 import {
@@ -64,6 +65,53 @@ console.log(`[desktop] logging to ${fileLogger.path}`);
 // that ordering impossible to get wrong regardless of what else this file
 // grows into.
 registerAppScheme();
+
+if (!app.isDefaultProtocolClient('kansoku')) {
+  app.setAsDefaultProtocolClient('kansoku');
+}
+
+// Electron quits before firing 'ready' when the lock is lost, so nothing
+// below this block runs in the losing process — no wrapping else needed.
+const gotDeepLinkLock = app.requestSingleInstanceLock();
+if (!gotDeepLinkLock) {
+  app.quit();
+}
+
+let windowManagerRef: WindowManager | null = null;
+let pendingDeepLinkUrl = findDeepLinkArg(process.argv);
+
+function handleDeepLink(url: string): void {
+  const win = windowManagerRef?.getPrimaryWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
+  if (!win) {
+    pendingDeepLinkUrl = url;
+    return;
+  }
+  dispatchDeepLink(win, url);
+}
+
+// macOS delivers a cold-start deep link via the open-url Apple Event ahead of
+// whenReady() — registering the listener inside will-finish-launching is the
+// documented way to catch it instead of losing it; the same listener keeps
+// handling every later open-url call once the app is already running.
+app.on('will-finish-launching', () => {
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
+  });
+});
+
+app.on('second-instance', (_event, argv) => {
+  const url = findDeepLinkArg(argv);
+  if (url) {
+    handleDeepLink(url);
+    return;
+  }
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win) {
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  }
+});
 
 interface InstallAppMenuOptions {
   checkForUpdates: () => void;
@@ -229,6 +277,20 @@ app.whenReady().then(async () => {
       rendererCalls: createRendererCallClient(),
     });
     windowManager.restoreWindows();
+    windowManagerRef = windowManager;
+
+    if (pendingDeepLinkUrl) {
+      const url = pendingDeepLinkUrl;
+      pendingDeepLinkUrl = undefined;
+      const win = windowManager.getPrimaryWindow();
+      if (win) {
+        if (win.webContents.isLoading()) {
+          win.webContents.once('did-finish-load', () => dispatchDeepLink(win, url));
+        } else {
+          dispatchDeepLink(win, url);
+        }
+      }
+    }
 
     app.on('activate', () => {
       if (windowManager.windowCount() === 0) windowManager.restoreWindows();

--- a/apps/desktop/src/platform/deepLink/deepLink.ts
+++ b/apps/desktop/src/platform/deepLink/deepLink.ts
@@ -1,0 +1,39 @@
+export const DEEP_LINK_SCHEME = 'kansoku:';
+export const DEEP_LINK_HOST = 'route';
+export const DEEP_LINK_NAVIGATE_CHANNEL = 'deep-link:navigate';
+
+export interface DeepLinkTarget {
+  path: string;
+  search: string;
+}
+
+export function parseDeepLink(url: string): DeepLinkTarget | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== DEEP_LINK_SCHEME || parsed.host !== DEEP_LINK_HOST) return null;
+  return { path: parsed.pathname || '/', search: parsed.search };
+}
+
+export function findDeepLinkArg(argv: string[]): string | undefined {
+  return argv.find((arg) => arg.startsWith(`${DEEP_LINK_SCHEME}//`));
+}
+
+export interface DeepLinkWindow {
+  webContents: { send: (channel: string, payload: DeepLinkTarget) => void };
+  isMinimized(): boolean;
+  restore(): void;
+  focus(): void;
+}
+
+export function dispatchDeepLink(win: DeepLinkWindow, url: string): boolean {
+  const target = parseDeepLink(url);
+  if (!target) return false;
+  win.webContents.send(DEEP_LINK_NAVIGATE_CHANNEL, target);
+  if (win.isMinimized()) win.restore();
+  win.focus();
+  return true;
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -2,6 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { CREDENTIALS_CHANNELS } from './data/credentials/channels.js';
 import { IPC_GROUPS } from './kernel/ipc/groups.js';
 import {
+  DEEP_LINK_NAVIGATE_CHANNEL,
+  type DeepLinkTarget,
+} from './platform/deepLink/deepLink.js';
+import {
   RENDERER_CALL_REQUEST_CHANNEL,
   RENDERER_CALL_RESPONSE_CHANNEL,
   type RendererCallRequest,
@@ -102,6 +106,14 @@ if (isPrivilegedOrigin) {
       const listener = (_event: Electron.IpcRendererEvent, status: unknown) => cb(status);
       ipcRenderer.on(UPDATER_CHANNELS.status, listener);
       return () => ipcRenderer.removeListener(UPDATER_CHANNELS.status, listener);
+    },
+  };
+
+  desktopApi.deepLink = {
+    onNavigate(cb: (target: DeepLinkTarget) => void) {
+      const listener = (_event: Electron.IpcRendererEvent, target: DeepLinkTarget) => cb(target);
+      ipcRenderer.on(DEEP_LINK_NAVIGATE_CHANNEL, listener);
+      return () => ipcRenderer.removeListener(DEEP_LINK_NAVIGATE_CHANNEL, listener);
     },
   };
 }

--- a/apps/desktop/src/shell/window/windowManager.ts
+++ b/apps/desktop/src/shell/window/windowManager.ts
@@ -24,6 +24,7 @@ export interface WindowManager {
   restoreWindows(): void;
   windowCount(): number;
   flushSync(): void;
+  getPrimaryWindow(): BrowserWindow | null;
 }
 
 export async function createWindowManager(options: WindowManagerOptions): Promise<WindowManager> {
@@ -120,6 +121,10 @@ export async function createWindowManager(options: WindowManagerOptions): Promis
 
     flushSync(): void {
       fileStore.flushSync();
+    },
+
+    getPrimaryWindow(): BrowserWindow | null {
+      return registry.values().next().value ?? null;
     },
   };
 }

--- a/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
+++ b/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
@@ -1,0 +1,121 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstatSync, readlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDb, type Db } from '@kansoku/core/db/index';
+import { watchedMarketsSettings } from '@kansoku/core/db/schema';
+import { ensureAgentKit } from '@desktop/agent-kit/ensureAgentKit.js';
+import { readState } from '@desktop/agent-kit/state.js';
+
+async function buildResourcesFixture(resourcesPath: string): Promise<void> {
+  const kitRoot = join(resourcesPath, 'kansoku-agent-kit');
+  await mkdir(join(kitRoot, 'templates'), { recursive: true });
+  await mkdir(join(kitRoot, 'bin'), { recursive: true });
+  await writeFile(join(kitRoot, 'templates', 'CLAUDE.md.tpl'), 'CLAUDE TEMPLATE\n', 'utf8');
+  await writeFile(join(kitRoot, 'templates', 'AGENTS.md.tpl'), 'AGENTS TEMPLATE\n', 'utf8');
+  await writeFile(join(kitRoot, 'bin', 'kansoku-cli'), '#!/bin/sh\necho cli\n', 'utf8');
+  await writeFile(
+    join(kitRoot, 'manifest.json'),
+    JSON.stringify(
+      {
+        kitVersion: '1.0.0+20260722',
+        appVersion: '1.0.0',
+        templates: [
+          { path: 'templates/CLAUDE.md.tpl', dest: 'CLAUDE.md', sha256: 'sha-claude-v1' },
+          { path: 'templates/AGENTS.md.tpl', dest: 'AGENTS.md', sha256: 'sha-agents-v1' },
+          {
+            path: '<runtime>',
+            dest: 'journal/personal.md',
+            sha256: 'app-config-v1',
+            source: 'app-config',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+}
+
+describe('ensureAgentKit', () => {
+  let dataRoot: string;
+  let resourcesPath: string;
+  let db: Db;
+  const now = () => new Date('2026-07-22T00:00:00.000Z');
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-data-root-'));
+    resourcesPath = await mkdtemp(join(tmpdir(), 'agent-kit-resources-'));
+    await buildResourcesFixture(resourcesPath);
+    db = createDb(':memory:');
+    db.insert(watchedMarketsSettings)
+      .values({ id: 1, markets: ['US'], updatedAt: '2026-07-22T00:00:00.000Z' })
+      .run();
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(resourcesPath, { recursive: true, force: true });
+  });
+
+  it('provisions runtime.env, the CLI symlink, templates, and state on a clean data root', async () => {
+    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    expect(result).toEqual({ conflicts: [], updates: [] });
+
+    const kitDir = join(dataRoot, '.kansoku-agent-kit');
+    const envContent = await readFile(join(kitDir, 'runtime.env'), 'utf8');
+    expect(envContent).toBe(
+      [
+        `KANSOKU_CLI=${join(kitDir, 'bin', 'kansoku-cli')}`,
+        `KANSOKU_DATA_ROOT=${dataRoot}`,
+        'KANSOKU_APP_VERSION=1.0.0',
+        'KANSOKU_KIT_VERSION=1.0.0+20260722',
+        '',
+      ].join('\n'),
+    );
+
+    const shimPath = join(kitDir, 'bin', 'kansoku-cli');
+    expect(lstatSync(shimPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(shimPath)).toBe(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'));
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('CLAUDE TEMPLATE\n');
+    expect(await readFile(join(dataRoot, 'AGENTS.md'), 'utf8')).toBe('AGENTS TEMPLATE\n');
+    const personalMd = await readFile(join(dataRoot, 'journal', 'personal.md'), 'utf8');
+    expect(personalMd).toContain('关注市场：US');
+
+    const state = readState(dataRoot);
+    expect(state?.kitVersion).toBe('1.0.0+20260722');
+    expect(state?.appVersion).toBe('1.0.0');
+    expect(state?.syncedAt).toBe('2026-07-22T00:00:00.000Z');
+    expect(Object.keys(state?.templates ?? {}).sort()).toEqual([
+      'AGENTS.md',
+      'CLAUDE.md',
+      'journal/personal.md',
+    ]);
+    expect(state?.pendingConflicts).toBeUndefined();
+    expect(state?.pendingUpdates).toBeUndefined();
+  });
+
+  it('replaces a stale CLI symlink on re-run instead of throwing', async () => {
+    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+
+    const shimPath = join(dataRoot, '.kansoku-agent-kit', 'bin', 'kansoku-cli');
+    await rm(shimPath, { force: true });
+    await symlink('/nonexistent/stale-target', shimPath);
+
+    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+
+    expect(readlinkSync(shimPath)).toBe(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'));
+  });
+
+  it('leaves an unmodified template untouched and reports no pending items on a second pass', async () => {
+    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    const claudeMdBefore = await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8');
+
+    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    expect(result).toEqual({ conflicts: [], updates: [] });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(claudeMdBefore);
+  });
+});

--- a/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
+++ b/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
@@ -61,7 +61,7 @@ describe('ensureAgentKit', () => {
   });
 
   it('provisions runtime.env, the CLI symlink, templates, and state on a clean data root', async () => {
-    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    const result = await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now });
     expect(result).toEqual({ conflicts: [], updates: [] });
 
     const kitDir = join(dataRoot, '.kansoku-agent-kit');
@@ -70,6 +70,7 @@ describe('ensureAgentKit', () => {
       [
         `KANSOKU_CLI=${join(kitDir, 'bin', 'kansoku-cli')}`,
         `KANSOKU_DATA_ROOT=${dataRoot}`,
+        `KANSOKU_AGENT_KIT_DIR=${dataRoot}`,
         'KANSOKU_APP_VERSION=1.0.0',
         'KANSOKU_KIT_VERSION=1.0.0+20260722',
         `TRADE_MIGRATIONS_DIR=${join(resourcesPath, 'drizzle')}`,
@@ -100,22 +101,22 @@ describe('ensureAgentKit', () => {
   });
 
   it('replaces a stale CLI symlink on re-run instead of throwing', async () => {
-    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now });
 
     const shimPath = join(dataRoot, '.kansoku-agent-kit', 'bin', 'kansoku-cli');
     await rm(shimPath, { force: true });
     await symlink('/nonexistent/stale-target', shimPath);
 
-    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now });
 
     expect(readlinkSync(shimPath)).toBe(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'));
   });
 
   it('leaves an unmodified template untouched and reports no pending items on a second pass', async () => {
-    await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now });
     const claudeMdBefore = await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8');
 
-    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now });
+    const result = await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now });
     expect(result).toEqual({ conflicts: [], updates: [] });
     expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(claudeMdBefore);
   });
@@ -124,10 +125,10 @@ describe('ensureAgentKit', () => {
     const nowFirst = () => new Date('2026-07-22T00:00:00.000Z');
     const nowSecond = () => new Date('2026-07-23T00:00:00.000Z');
 
-    await ensureAgentKit({ dataRoot, resourcesPath, db, now: nowFirst });
+    await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now: nowFirst });
     const writtenAtFirst = readState(dataRoot)?.templates['CLAUDE.md']?.writtenAt;
 
-    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now: nowSecond });
+    const result = await ensureAgentKit({ agentKitDir: dataRoot, dataRoot, resourcesPath, db, now: nowSecond });
     expect(result).toEqual({ conflicts: [], updates: [] });
 
     const stateAfterSecond = readState(dataRoot);
@@ -138,5 +139,26 @@ describe('ensureAgentKit', () => {
       'CLAUDE.md',
       'journal/personal.md',
     ]);
+  });
+
+  it('writes templates and state under a custom agentKitDir, distinct from dataRoot', async () => {
+    const agentKitDir = await mkdtemp(join(tmpdir(), 'agent-kit-custom-location-'));
+    try {
+      const result = await ensureAgentKit({ agentKitDir, dataRoot, resourcesPath, db, now });
+      expect(result).toEqual({ conflicts: [], updates: [] });
+
+      const kitDir = join(agentKitDir, '.kansoku-agent-kit');
+      const envContent = await readFile(join(kitDir, 'runtime.env'), 'utf8');
+      expect(envContent).toContain(`KANSOKU_DATA_ROOT=${dataRoot}`);
+      expect(envContent).toContain(`KANSOKU_AGENT_KIT_DIR=${agentKitDir}`);
+
+      expect(await readFile(join(agentKitDir, 'CLAUDE.md'), 'utf8')).toBe('CLAUDE TEMPLATE\n');
+      await expect(readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).rejects.toThrow();
+
+      expect(readState(agentKitDir)?.kitVersion).toBe('1.0.0+20260722');
+      expect(readState(dataRoot)).toBeNull();
+    } finally {
+      await rm(agentKitDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
+++ b/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
@@ -72,6 +72,7 @@ describe('ensureAgentKit', () => {
         `KANSOKU_DATA_ROOT=${dataRoot}`,
         'KANSOKU_APP_VERSION=1.0.0',
         'KANSOKU_KIT_VERSION=1.0.0+20260722',
+        `TRADE_MIGRATIONS_DIR=${join(resourcesPath, 'drizzle')}`,
         '',
       ].join('\n'),
     );

--- a/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
+++ b/apps/desktop/test/agent-kit/ensureAgentKit.test.ts
@@ -119,4 +119,24 @@ describe('ensureAgentKit', () => {
     expect(result).toEqual({ conflicts: [], updates: [] });
     expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(claudeMdBefore);
   });
+
+  it('does not re-write template state or duplicate entries on a second, up-to-date pass', async () => {
+    const nowFirst = () => new Date('2026-07-22T00:00:00.000Z');
+    const nowSecond = () => new Date('2026-07-23T00:00:00.000Z');
+
+    await ensureAgentKit({ dataRoot, resourcesPath, db, now: nowFirst });
+    const writtenAtFirst = readState(dataRoot)?.templates['CLAUDE.md']?.writtenAt;
+
+    const result = await ensureAgentKit({ dataRoot, resourcesPath, db, now: nowSecond });
+    expect(result).toEqual({ conflicts: [], updates: [] });
+
+    const stateAfterSecond = readState(dataRoot);
+    expect(stateAfterSecond?.templates['CLAUDE.md']?.writtenAt).toBe(writtenAtFirst);
+    expect(stateAfterSecond?.syncedAt).toBe(nowSecond().toISOString());
+    expect(Object.keys(stateAfterSecond?.templates ?? {}).sort()).toEqual([
+      'AGENTS.md',
+      'CLAUDE.md',
+      'journal/personal.md',
+    ]);
+  });
 });

--- a/apps/desktop/test/agent-kit/ipc-state.test.ts
+++ b/apps/desktop/test/agent-kit/ipc-state.test.ts
@@ -9,11 +9,28 @@ vi.mock('electron-ipc-decorator', () => ({
   IpcService: class {},
 }));
 
-const env = vi.hoisted(() => ({ dataRoot: '', userDataPath: '' }));
-vi.mock('electron', () => ({ app: { getPath: () => env.userDataPath } }));
+const env = vi.hoisted(() => ({
+  dataRoot: '',
+  userDataPath: '',
+  dataRootMode: 'custom' as 'custom' | 'default',
+}));
+const dialogMock = vi.hoisted(() => ({ showOpenDialog: vi.fn() }));
+vi.mock('electron', () => ({
+  app: { getPath: () => env.userDataPath },
+  BrowserWindow: { getFocusedWindow: vi.fn(() => null) },
+  dialog: dialogMock,
+}));
 vi.mock('../../src/boot/env.js', () => ({
   get dataRoot() {
     return env.dataRoot;
+  },
+  get dataRootStatus() {
+    return {
+      mode: env.dataRootMode,
+      effectivePath: env.dataRoot,
+      configuredPath: null,
+      degraded: false,
+    };
   },
 }));
 vi.mock('@kansoku/core/db/index', () => ({ getDb: () => ({}) }));
@@ -55,6 +72,8 @@ describe('agent-kit ipc state mutations', () => {
     userDataPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-userdata-'));
     env.dataRoot = dataRoot;
     env.userDataPath = userDataPath;
+    env.dataRootMode = 'custom';
+    dialogMock.showOpenDialog.mockReset();
     setResourcesPath(resourcesPath);
 
     await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'templates'), { recursive: true });
@@ -71,7 +90,11 @@ describe('agent-kit ipc state mutations', () => {
   });
 
   it('setEnabled(true) syncs from a disabled store and persists enabled + lastSyncAt', async () => {
-    await writeFile(join(userDataPath, 'agent-kit.json'), JSON.stringify({ enabled: false }), 'utf8');
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: false, location: { kind: 'follow-data-root' } }),
+      'utf8',
+    );
 
     const instance = new AgentKitIpc();
     const result = await instance.setEnabled({ enabled: true });
@@ -89,7 +112,11 @@ describe('agent-kit ipc state mutations', () => {
   it('setEnabled(false) persists disabled without running a sync', async () => {
     await writeFile(
       join(userDataPath, 'agent-kit.json'),
-      JSON.stringify({ enabled: true, lastSyncAt: '2026-01-01T00:00:00.000Z' }),
+      JSON.stringify({
+        enabled: true,
+        location: { kind: 'follow-data-root' },
+        lastSyncAt: '2026-01-01T00:00:00.000Z',
+      }),
       'utf8',
     );
 
@@ -98,7 +125,11 @@ describe('agent-kit ipc state mutations', () => {
     expect(result).toEqual({ ok: true, data: { enabled: false } });
 
     const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
-    expect(storeRaw).toEqual({ enabled: false, lastSyncAt: '2026-01-01T00:00:00.000Z' });
+    expect(storeRaw).toEqual({
+      enabled: false,
+      location: { kind: 'follow-data-root' },
+      lastSyncAt: '2026-01-01T00:00:00.000Z',
+    });
     expect(existsSync(join(dataRoot, '.kansoku-agent-kit', 'state.json'))).toBe(false);
   });
 
@@ -189,6 +220,121 @@ describe('agent-kit ipc state mutations', () => {
   });
 });
 
+describe('agent-kit ipc location handling', () => {
+  let dataRoot: string;
+  let resourcesPath: string;
+  let userDataPath: string;
+  let customDir: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-data-'));
+    resourcesPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-resources-'));
+    userDataPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-userdata-'));
+    customDir = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-custom-'));
+    env.dataRoot = dataRoot;
+    env.userDataPath = userDataPath;
+    env.dataRootMode = 'custom';
+    dialogMock.showOpenDialog.mockReset();
+    setResourcesPath(resourcesPath);
+
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'templates'), { recursive: true });
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'bin'), { recursive: true });
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'templates', 'CLAUDE.md.tpl'), TEMPLATE_V1, 'utf8');
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'), '#!/bin/sh\necho cli\n', 'utf8');
+    await writeManifest(resourcesPath, 'sha-claude-v1');
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(resourcesPath, { recursive: true, force: true });
+    await rm(userDataPath, { recursive: true, force: true });
+    await rm(customDir, { recursive: true, force: true });
+  });
+
+  it('a custom location is used instead of dataRoot when set', async () => {
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: true, location: { kind: 'custom', path: customDir } }),
+      'utf8',
+    );
+
+    const instance = new AgentKitIpc();
+    const result = await instance.forceSync();
+    expect(result).toEqual({ ok: true, data: { conflicts: [], updates: [] } });
+
+    expect(await readFile(join(customDir, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+    expect(existsSync(join(dataRoot, 'CLAUDE.md'))).toBe(false);
+    expect(readState(customDir)?.templates['CLAUDE.md']).toBeDefined();
+    expect(readState(dataRoot)).toBeNull();
+  });
+
+  it('followDataRoot switches location back to follow-data-root and re-syncs', async () => {
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: true, location: { kind: 'custom', path: customDir } }),
+      'utf8',
+    );
+
+    const instance = new AgentKitIpc();
+    const result = await instance.followDataRoot();
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        enabled: true,
+        location: { kind: 'follow-data-root' },
+        resolvedPath: dataRoot,
+      }),
+    });
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw.location).toEqual({ kind: 'follow-data-root' });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+  });
+
+  it('pickCustomLocation stores the picked path and re-syncs there', async () => {
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: true, location: { kind: 'follow-data-root' } }),
+      'utf8',
+    );
+    dialogMock.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [customDir] });
+
+    const instance = new AgentKitIpc();
+    const result = await instance.pickCustomLocation();
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        enabled: true,
+        location: { kind: 'custom', path: customDir },
+        resolvedPath: customDir,
+      }),
+    });
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw.location).toEqual({ kind: 'custom', path: customDir });
+    expect(await readFile(join(customDir, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+  });
+
+  it('pickCustomLocation leaves the store untouched when the dialog is canceled', async () => {
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: true, location: { kind: 'follow-data-root' } }),
+      'utf8',
+    );
+    dialogMock.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+
+    const instance = new AgentKitIpc();
+    const result = await instance.pickCustomLocation();
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({ location: { kind: 'follow-data-root' } }),
+    });
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw.location).toEqual({ kind: 'follow-data-root' });
+  });
+});
+
 describe('agent-kit ipc clean', () => {
   let dataRoot: string;
   let resourcesPath: string;
@@ -200,6 +346,8 @@ describe('agent-kit ipc clean', () => {
     userDataPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-userdata-'));
     env.dataRoot = dataRoot;
     env.userDataPath = userDataPath;
+    env.dataRootMode = 'custom';
+    dialogMock.showOpenDialog.mockReset();
     setResourcesPath(resourcesPath);
 
     await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'templates'), { recursive: true });

--- a/apps/desktop/test/agent-kit/ipc-state.test.ts
+++ b/apps/desktop/test/agent-kit/ipc-state.test.ts
@@ -1,0 +1,167 @@
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron-ipc-decorator', () => ({
+  IpcMethod: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => descriptor,
+  IpcService: class {},
+}));
+
+const env = vi.hoisted(() => ({ dataRoot: '', userDataPath: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => env.userDataPath } }));
+vi.mock('../../src/boot/env.js', () => ({
+  get dataRoot() {
+    return env.dataRoot;
+  },
+}));
+vi.mock('@kansoku/core/db/index', () => ({ getDb: () => ({}) }));
+
+const { AgentKitIpc } = await import('../../src/agent-kit/ipc.js');
+const { readState } = await import('../../src/agent-kit/state.js');
+
+const TEMPLATE_V1 = 'CLAUDE TEMPLATE V1\n';
+const TEMPLATE_V2 = 'CLAUDE TEMPLATE V2\n';
+
+function setResourcesPath(path: string): void {
+  (process as unknown as { resourcesPath: string }).resourcesPath = path;
+}
+
+async function writeManifest(resourcesPath: string, sha256: string): Promise<void> {
+  await writeFile(
+    join(resourcesPath, 'kansoku-agent-kit', 'manifest.json'),
+    JSON.stringify(
+      {
+        kitVersion: '1.0.0+20260722',
+        appVersion: '1.0.0',
+        templates: [{ path: 'templates/CLAUDE.md.tpl', dest: 'CLAUDE.md', sha256 }],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+}
+
+describe('agent-kit ipc state mutations', () => {
+  let dataRoot: string;
+  let resourcesPath: string;
+  let userDataPath: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-data-'));
+    resourcesPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-resources-'));
+    userDataPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-userdata-'));
+    env.dataRoot = dataRoot;
+    env.userDataPath = userDataPath;
+    setResourcesPath(resourcesPath);
+
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'templates'), { recursive: true });
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'bin'), { recursive: true });
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'templates', 'CLAUDE.md.tpl'), TEMPLATE_V1, 'utf8');
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'), '#!/bin/sh\necho cli\n', 'utf8');
+    await writeManifest(resourcesPath, 'sha-claude-v1');
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(resourcesPath, { recursive: true, force: true });
+    await rm(userDataPath, { recursive: true, force: true });
+  });
+
+  it('setEnabled(true) syncs from a disabled store and persists enabled + lastSyncAt', async () => {
+    await writeFile(join(userDataPath, 'agent-kit.json'), JSON.stringify({ enabled: false }), 'utf8');
+
+    const instance = new AgentKitIpc();
+    const result = await instance.setEnabled({ enabled: true });
+    expect(result).toMatchObject({ ok: true, data: { enabled: true, conflicts: [], updates: [] } });
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw.enabled).toBe(true);
+    expect(typeof storeRaw.lastSyncAt).toBe('string');
+
+    expect(existsSync(join(dataRoot, '.kansoku-agent-kit', 'runtime.env'))).toBe(true);
+    const state = readState(dataRoot);
+    expect(state?.templates['CLAUDE.md']).toBeDefined();
+  });
+
+  it('setEnabled(false) persists disabled without running a sync', async () => {
+    await writeFile(
+      join(userDataPath, 'agent-kit.json'),
+      JSON.stringify({ enabled: true, lastSyncAt: '2026-01-01T00:00:00.000Z' }),
+      'utf8',
+    );
+
+    const instance = new AgentKitIpc();
+    const result = await instance.setEnabled({ enabled: false });
+    expect(result).toEqual({ ok: true, data: { enabled: false } });
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw).toEqual({ enabled: false, lastSyncAt: '2026-01-01T00:00:00.000Z' });
+    expect(existsSync(join(dataRoot, '.kansoku-agent-kit', 'state.json'))).toBe(false);
+  });
+
+  it('resolveConflict(use-template) backs up the target, writes the template, and clears the pending conflict', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER OWNED CONTENT\n', 'utf8');
+
+    const instance = new AgentKitIpc();
+    const syncResult = await instance.forceSync();
+    expect(syncResult).toMatchObject({
+      ok: true,
+      data: { conflicts: [{ dest: 'CLAUDE.md', reason: 'target-exists-no-state' }] },
+    });
+
+    const resolveResult = await instance.resolveConflict({ dest: 'CLAUDE.md', choice: 'use-template' });
+    expect(resolveResult).toEqual({ ok: true, data: { dest: 'CLAUDE.md' } });
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe('USER OWNED CONTENT\n');
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+
+    const state = readState(dataRoot);
+    expect(state?.templates['CLAUDE.md']?.sourceTemplateHash).toBe('sha-claude-v1');
+    expect(state?.pendingConflicts).toBeUndefined();
+  });
+
+  it('resolveConflict(keep-original) leaves the target untouched and marks it kept', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER OWNED CONTENT\n', 'utf8');
+
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+
+    const resolveResult = await instance.resolveConflict({ dest: 'CLAUDE.md', choice: 'keep-original' });
+    expect(resolveResult).toEqual({ ok: true, data: { dest: 'CLAUDE.md' } });
+
+    expect(existsSync(join(dataRoot, 'CLAUDE.md.bak'))).toBe(false);
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('USER OWNED CONTENT\n');
+
+    const state = readState(dataRoot);
+    expect(state?.templates['CLAUDE.md']?.kept).toBe(true);
+    expect(state?.pendingConflicts).toBeUndefined();
+  });
+
+  it('applyUpdate backs up the target, writes the new template, and clears the pending update', async () => {
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'templates', 'CLAUDE.md.tpl'), TEMPLATE_V2, 'utf8');
+    await writeManifest(resourcesPath, 'sha-claude-v2');
+
+    const syncResult = await instance.forceSync();
+    expect(syncResult).toMatchObject({
+      ok: true,
+      data: { updates: [{ dest: 'CLAUDE.md', oldTemplateHash: 'sha-claude-v1', newTemplateHash: 'sha-claude-v2' }] },
+    });
+
+    const applyResult = await instance.applyUpdate({ dest: 'CLAUDE.md' });
+    expect(applyResult).toEqual({ ok: true, data: { dest: 'CLAUDE.md' } });
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe(TEMPLATE_V1);
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V2);
+
+    const state = readState(dataRoot);
+    expect(state?.templates['CLAUDE.md']?.sourceTemplateHash).toBe('sha-claude-v2');
+    expect(state?.pendingUpdates).toBeUndefined();
+  });
+});

--- a/apps/desktop/test/agent-kit/ipc-state.test.ts
+++ b/apps/desktop/test/agent-kit/ipc-state.test.ts
@@ -140,7 +140,7 @@ describe('agent-kit ipc state mutations', () => {
     expect(state?.pendingConflicts).toBeUndefined();
   });
 
-  it('applyUpdate backs up the target, writes the new template, and clears the pending update', async () => {
+  it('applyUpdate backs up the target under a hash-suffixed name, writes the new template, and clears the pending update', async () => {
     const instance = new AgentKitIpc();
     await instance.forceSync();
     expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
@@ -157,11 +157,113 @@ describe('agent-kit ipc state mutations', () => {
     const applyResult = await instance.applyUpdate({ dest: 'CLAUDE.md' });
     expect(applyResult).toEqual({ ok: true, data: { dest: 'CLAUDE.md' } });
 
-    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe(TEMPLATE_V1);
+    const expectedSuffix = 'sha-claude-v1'.slice(0, 8);
+    expect(await readFile(join(dataRoot, `CLAUDE.md.bak.${expectedSuffix}`), 'utf8')).toBe(TEMPLATE_V1);
+    expect(existsSync(join(dataRoot, 'CLAUDE.md.bak'))).toBe(false);
     expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V2);
 
     const state = readState(dataRoot);
     expect(state?.templates['CLAUDE.md']?.sourceTemplateHash).toBe('sha-claude-v2');
     expect(state?.pendingUpdates).toBeUndefined();
+  });
+
+  it('applyUpdate after a resolved conflict backs up under a distinct suffix, not the conflict .bak', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'PRE-KIT USER FILE\n', 'utf8');
+
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    await instance.resolveConflict({ dest: 'CLAUDE.md', choice: 'use-template' });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe('PRE-KIT USER FILE\n');
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V1);
+
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'templates', 'CLAUDE.md.tpl'), TEMPLATE_V2, 'utf8');
+    await writeManifest(resourcesPath, 'sha-claude-v2');
+    await instance.forceSync();
+
+    await instance.applyUpdate({ dest: 'CLAUDE.md' });
+
+    const expectedSuffix = 'sha-claude-v1'.slice(0, 8);
+    expect(await readFile(join(dataRoot, `CLAUDE.md.bak.${expectedSuffix}`), 'utf8')).toBe(TEMPLATE_V1);
+    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe('PRE-KIT USER FILE\n');
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe(TEMPLATE_V2);
+  });
+});
+
+describe('agent-kit ipc clean', () => {
+  let dataRoot: string;
+  let resourcesPath: string;
+  let userDataPath: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-data-'));
+    resourcesPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-resources-'));
+    userDataPath = await mkdtemp(join(tmpdir(), 'agent-kit-ipc-userdata-'));
+    env.dataRoot = dataRoot;
+    env.userDataPath = userDataPath;
+    setResourcesPath(resourcesPath);
+
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'templates'), { recursive: true });
+    await mkdir(join(resourcesPath, 'kansoku-agent-kit', 'bin'), { recursive: true });
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'templates', 'CLAUDE.md.tpl'), TEMPLATE_V1, 'utf8');
+    await writeFile(join(resourcesPath, 'kansoku-agent-kit', 'bin', 'kansoku-cli'), '#!/bin/sh\necho cli\n', 'utf8');
+    await writeManifest(resourcesPath, 'sha-claude-v1');
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(resourcesPath, { recursive: true, force: true });
+    await rm(userDataPath, { recursive: true, force: true });
+  });
+
+  it('deletes a Kit-owned template file the user has not modified', async () => {
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    expect(existsSync(join(dataRoot, 'CLAUDE.md'))).toBe(true);
+
+    const result = await instance.clean();
+    expect(result).toEqual({ ok: true, data: { cleaned: true } });
+    expect(existsSync(join(dataRoot, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('leaves a template file the user edited after Kit wrote it', async () => {
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER EDITED AFTER SYNC\n', 'utf8');
+
+    await instance.clean();
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('USER EDITED AFTER SYNC\n');
+  });
+
+  it('leaves a template the user explicitly kept via resolveConflict(keep-original)', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER OWNED CONTENT\n', 'utf8');
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    await instance.resolveConflict({ dest: 'CLAUDE.md', choice: 'keep-original' });
+
+    await instance.clean();
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('USER OWNED CONTENT\n');
+  });
+
+  it('removes the .kansoku-agent-kit directory', async () => {
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+    expect(existsSync(join(dataRoot, '.kansoku-agent-kit'))).toBe(true);
+
+    await instance.clean();
+
+    expect(existsSync(join(dataRoot, '.kansoku-agent-kit'))).toBe(false);
+  });
+
+  it('flips store.enabled to false', async () => {
+    await writeFile(join(userDataPath, 'agent-kit.json'), JSON.stringify({ enabled: true }), 'utf8');
+    const instance = new AgentKitIpc();
+    await instance.forceSync();
+
+    await instance.clean();
+
+    const storeRaw = JSON.parse(await readFile(join(userDataPath, 'agent-kit.json'), 'utf8'));
+    expect(storeRaw.enabled).toBe(false);
   });
 });

--- a/apps/desktop/test/agent-kit/ipc.test.ts
+++ b/apps/desktop/test/agent-kit/ipc.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron-ipc-decorator', () => ({
+  IpcMethod: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => descriptor,
+  IpcService: class {},
+}));
+
+vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/tmp/agent-kit-ipc-smoke') } }));
+
+const getDb = vi.hoisted(() => vi.fn(() => ({})));
+vi.mock('@kansoku/core/db/index', () => ({ getDb }));
+
+vi.mock('../../src/boot/env.js', () => ({ dataRoot: '/tmp/agent-kit-ipc-smoke-dataroot' }));
+
+const store = vi.hoisted(() => ({
+  read: vi.fn(() => ({ enabled: true, lastSyncAt: undefined })),
+  write: vi.fn(),
+}));
+vi.mock('../../src/agent-kit/store.js', () => ({ defaultAgentKitStore: () => store }));
+
+const state = vi.hoisted(() => ({
+  kitVersion: '1.0.0+20260722',
+  appVersion: '1.0.0',
+  syncedAt: '2026-07-22T00:00:00.000Z',
+  templates: {},
+}));
+const readState = vi.hoisted(() => vi.fn(() => state));
+const writeState = vi.hoisted(() => vi.fn());
+vi.mock('../../src/agent-kit/state.js', () => ({ readState, writeState }));
+
+const ensureAgentKit = vi.hoisted(() => vi.fn(async () => ({ conflicts: [], updates: [] })));
+vi.mock('../../src/agent-kit/ensureAgentKit.js', () => ({ ensureAgentKit }));
+
+const { AgentKitIpc } = await import('../../src/agent-kit/ipc.js');
+
+beforeEach(() => {
+  store.read.mockClear();
+  store.write.mockClear();
+  readState.mockClear();
+  writeState.mockClear();
+  ensureAgentKit.mockClear();
+});
+
+describe('agent-kit ipc', () => {
+  it('registers under the agentKit group', () => {
+    expect(AgentKitIpc.groupName).toBe('agentKit');
+  });
+
+  it('getStatus reports the store state plus data-root state', async () => {
+    const instance = new AgentKitIpc();
+    const result = await instance.getStatus();
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        enabled: true,
+        lastSyncAt: undefined,
+        kitVersion: '1.0.0+20260722',
+        pendingConflicts: undefined,
+        pendingUpdates: undefined,
+      },
+    });
+  });
+
+  it('forceSync runs ensureAgentKit and stamps lastSyncAt on the store', async () => {
+    const instance = new AgentKitIpc();
+    const result = await instance.forceSync();
+    expect(ensureAgentKit).toHaveBeenCalledTimes(1);
+    expect(store.write).toHaveBeenCalledWith(expect.objectContaining({ lastSyncAt: expect.any(String) }));
+    expect(result).toEqual({ ok: true, data: { conflicts: [], updates: [] } });
+  });
+
+  it('clean removes the kit directory without touching user files', async () => {
+    const instance = new AgentKitIpc();
+    const result = await instance.clean();
+    expect(result).toEqual({ ok: true, data: { cleaned: true } });
+  });
+});

--- a/apps/desktop/test/agent-kit/ipc.test.ts
+++ b/apps/desktop/test/agent-kit/ipc.test.ts
@@ -5,15 +5,22 @@ vi.mock('electron-ipc-decorator', () => ({
   IpcService: class {},
 }));
 
-vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/tmp/agent-kit-ipc-smoke') } }));
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp/agent-kit-ipc-smoke') },
+  BrowserWindow: { getFocusedWindow: vi.fn(() => null) },
+  dialog: { showOpenDialog: vi.fn() },
+}));
 
 const getDb = vi.hoisted(() => vi.fn(() => ({})));
 vi.mock('@kansoku/core/db/index', () => ({ getDb }));
 
-vi.mock('../../src/boot/env.js', () => ({ dataRoot: '/tmp/agent-kit-ipc-smoke-dataroot' }));
+vi.mock('../../src/boot/env.js', () => ({
+  dataRoot: '/tmp/agent-kit-ipc-smoke-dataroot',
+  dataRootStatus: { mode: 'custom', effectivePath: '/tmp/agent-kit-ipc-smoke-dataroot', configuredPath: null, degraded: false },
+}));
 
 const store = vi.hoisted(() => ({
-  read: vi.fn(() => ({ enabled: true, lastSyncAt: undefined })),
+  read: vi.fn(() => ({ enabled: true, location: { kind: 'follow-data-root' as const }, lastSyncAt: undefined })),
   write: vi.fn(),
 }));
 vi.mock('../../src/agent-kit/store.js', () => ({ defaultAgentKitStore: () => store }));
@@ -53,6 +60,10 @@ describe('agent-kit ipc', () => {
       ok: true,
       data: {
         enabled: true,
+        location: { kind: 'follow-data-root' },
+        resolvedPath: '/tmp/agent-kit-ipc-smoke-dataroot',
+        followBlocked: false,
+        dataRoot: '/tmp/agent-kit-ipc-smoke-dataroot',
         lastSyncAt: undefined,
         kitVersion: '1.0.0+20260722',
         pendingConflicts: undefined,

--- a/apps/desktop/test/agent-kit/renderPersonalMd.test.ts
+++ b/apps/desktop/test/agent-kit/renderPersonalMd.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createDb } from '@kansoku/core/db/index';
+import { watchedMarketsSettings } from '@kansoku/core/db/schema';
+import { renderPersonalMd, PERSONAL_MD_RENDER_VERSION } from '@desktop/agent-kit/renderPersonalMd.js';
+
+describe('renderPersonalMd', () => {
+  it('includes the watched markets from the settings table', () => {
+    const db = createDb(':memory:');
+    db.insert(watchedMarketsSettings)
+      .values({ id: 1, markets: ['US', 'HK'], updatedAt: '2026-07-22T00:00:00.000Z' })
+      .run();
+
+    const md = renderPersonalMd(db);
+    expect(md).toContain('US, HK');
+    expect(md).toContain('# 个人研究配置');
+  });
+
+  it('falls back to the default watched market when no settings row exists', () => {
+    const db = createDb(':memory:');
+    const md = renderPersonalMd(db);
+    expect(md).toContain('关注市场：US');
+  });
+
+  it('exposes a stable render-version constant matching the manifest app-config sentinel', () => {
+    expect(PERSONAL_MD_RENDER_VERSION).toBe('app-config-v1');
+  });
+});

--- a/apps/desktop/test/agent-kit/renderPersonalMd.test.ts
+++ b/apps/desktop/test/agent-kit/renderPersonalMd.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createDb } from '@kansoku/core/db/index';
 import { watchedMarketsSettings } from '@kansoku/core/db/schema';
@@ -23,5 +25,12 @@ describe('renderPersonalMd', () => {
 
   it('exposes a stable render-version constant matching the manifest app-config sentinel', () => {
     expect(PERSONAL_MD_RENDER_VERSION).toBe('app-config-v1');
+  });
+
+  it('matches the shared render-version.json that stageAgentKit.mjs reads at build time', () => {
+    const shared = JSON.parse(
+      readFileSync(join(import.meta.dirname, '../../agent-kit-src/render-version.json'), 'utf8'),
+    ) as { personalMd: string };
+    expect(PERSONAL_MD_RENDER_VERSION).toBe(shared.personalMd);
   });
 });

--- a/apps/desktop/test/agent-kit/state.test.ts
+++ b/apps/desktop/test/agent-kit/state.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readState, sha256, writeState } from '@desktop/agent-kit/state.js';
+
+describe('agent-kit state store', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-state-'));
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  it('returns null when no state.json exists', () => {
+    expect(readState(dataRoot)).toBeNull();
+  });
+
+  it('writes and reads state back', () => {
+    const state = {
+      kitVersion: '1.0.0+20260722',
+      appVersion: '1.0.0',
+      syncedAt: '2026-07-22T00:00:00.000Z',
+      templates: {
+        'CLAUDE.md': {
+          initialContentHash: sha256('hello'),
+          sourceTemplateHash: 'abc',
+          writtenAt: '2026-07-22T00:00:00.000Z',
+        },
+      },
+    };
+    writeState(dataRoot, state);
+    expect(readState(dataRoot)).toEqual(state);
+  });
+
+  it('returns null when state.json is corrupt', async () => {
+    const { writeFile, mkdir } = await import('node:fs/promises');
+    await mkdir(join(dataRoot, '.kansoku-agent-kit'), { recursive: true });
+    await writeFile(join(dataRoot, '.kansoku-agent-kit', 'state.json'), 'not json', 'utf8');
+    expect(readState(dataRoot)).toBeNull();
+  });
+
+  it('sha256 is deterministic for the same content', () => {
+    expect(sha256('same')).toBe(sha256('same'));
+    expect(sha256('a')).not.toBe(sha256('b'));
+  });
+});

--- a/apps/desktop/test/agent-kit/state.test.ts
+++ b/apps/desktop/test/agent-kit/state.test.ts
@@ -2,7 +2,15 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readState, sha256, writeState } from '@desktop/agent-kit/state.js';
+import {
+  readState,
+  removeConflict,
+  removeUpdate,
+  sha256,
+  upsertTemplate,
+  writeState,
+  type AgentKitDataState,
+} from '@desktop/agent-kit/state.js';
 
 describe('agent-kit state store', () => {
   let dataRoot: string;
@@ -46,5 +54,56 @@ describe('agent-kit state store', () => {
   it('sha256 is deterministic for the same content', () => {
     expect(sha256('same')).toBe(sha256('same'));
     expect(sha256('a')).not.toBe(sha256('b'));
+  });
+});
+
+describe('agent-kit state helpers', () => {
+  const base: AgentKitDataState = {
+    kitVersion: '1.0.0+20260722',
+    appVersion: '1.0.0',
+    syncedAt: '2026-07-22T00:00:00.000Z',
+    templates: {},
+  };
+
+  it('upsertTemplate adds a template entry without disturbing the rest of the state', () => {
+    const next = upsertTemplate(base, 'CLAUDE.md', {
+      initialContentHash: 'hash-a',
+      sourceTemplateHash: 'sha-a',
+      writtenAt: '2026-07-22T00:00:00.000Z',
+    });
+    expect(next.templates['CLAUDE.md']).toEqual({
+      initialContentHash: 'hash-a',
+      sourceTemplateHash: 'sha-a',
+      writtenAt: '2026-07-22T00:00:00.000Z',
+    });
+    expect(base.templates['CLAUDE.md']).toBeUndefined();
+  });
+
+  it('removeConflict drops the matching entry and clears an emptied array', () => {
+    const withConflicts: AgentKitDataState = {
+      ...base,
+      pendingConflicts: [
+        { dest: 'CLAUDE.md', templatePath: 'templates/CLAUDE.md.tpl', reason: 'target-exists-no-state' },
+        { dest: 'AGENTS.md', templatePath: 'templates/AGENTS.md.tpl', reason: 'target-exists-no-state' },
+      ],
+    };
+    const oneLeft = removeConflict(withConflicts, 'CLAUDE.md');
+    expect(oneLeft.pendingConflicts).toEqual([
+      { dest: 'AGENTS.md', templatePath: 'templates/AGENTS.md.tpl', reason: 'target-exists-no-state' },
+    ]);
+
+    const emptied = removeConflict(oneLeft, 'AGENTS.md');
+    expect(emptied.pendingConflicts).toBeUndefined();
+  });
+
+  it('removeUpdate drops the matching entry and clears an emptied array', () => {
+    const withUpdates: AgentKitDataState = {
+      ...base,
+      pendingUpdates: [
+        { dest: 'CLAUDE.md', templatePath: 'templates/CLAUDE.md.tpl', oldTemplateHash: 'v1', newTemplateHash: 'v2' },
+      ],
+    };
+    const emptied = removeUpdate(withUpdates, 'CLAUDE.md');
+    expect(emptied.pendingUpdates).toBeUndefined();
   });
 });

--- a/apps/desktop/test/agent-kit/store.test.ts
+++ b/apps/desktop/test/agent-kit/store.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAgentKitStore } from '@desktop/agent-kit/store.js';
+
+describe('createAgentKitStore', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'agent-kit-store-'));
+    path = join(dir, 'agent-kit.json');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('defaults to enabled true when the file is absent', () => {
+    const store = createAgentKitStore(path);
+    expect(store.read()).toEqual({ enabled: true });
+  });
+
+  it('persists state and reads it back', () => {
+    const store = createAgentKitStore(path);
+    store.write({ enabled: false, lastSyncAt: '2026-07-22T00:00:00.000Z' });
+    expect(store.read()).toEqual({ enabled: false, lastSyncAt: '2026-07-22T00:00:00.000Z' });
+    expect(createAgentKitStore(path).read()).toEqual({
+      enabled: false,
+      lastSyncAt: '2026-07-22T00:00:00.000Z',
+    });
+  });
+
+  it('treats corrupt JSON as the default state', async () => {
+    await writeFile(path, 'not json', 'utf8');
+    expect(createAgentKitStore(path).read()).toEqual({ enabled: true });
+  });
+
+  it('treats a missing enabled field as true', async () => {
+    await writeFile(path, JSON.stringify({ lastSyncAt: 'x' }), 'utf8');
+    expect(createAgentKitStore(path).read()).toEqual({ enabled: true, lastSyncAt: 'x' });
+  });
+});

--- a/apps/desktop/test/agent-kit/store.test.ts
+++ b/apps/desktop/test/agent-kit/store.test.ts
@@ -17,28 +17,60 @@ describe('createAgentKitStore', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it('defaults to enabled true when the file is absent', () => {
+  it('defaults to disabled, following the data root, when the file is absent', () => {
     const store = createAgentKitStore(path);
-    expect(store.read()).toEqual({ enabled: true });
+    expect(store.read()).toEqual({ enabled: false, location: { kind: 'follow-data-root' } });
   });
 
   it('persists state and reads it back', () => {
     const store = createAgentKitStore(path);
-    store.write({ enabled: false, lastSyncAt: '2026-07-22T00:00:00.000Z' });
-    expect(store.read()).toEqual({ enabled: false, lastSyncAt: '2026-07-22T00:00:00.000Z' });
+    store.write({
+      enabled: false,
+      location: { kind: 'follow-data-root' },
+      lastSyncAt: '2026-07-22T00:00:00.000Z',
+    });
+    expect(store.read()).toEqual({
+      enabled: false,
+      location: { kind: 'follow-data-root' },
+      lastSyncAt: '2026-07-22T00:00:00.000Z',
+    });
     expect(createAgentKitStore(path).read()).toEqual({
       enabled: false,
+      location: { kind: 'follow-data-root' },
       lastSyncAt: '2026-07-22T00:00:00.000Z',
     });
   });
 
   it('treats corrupt JSON as the default state', async () => {
     await writeFile(path, 'not json', 'utf8');
-    expect(createAgentKitStore(path).read()).toEqual({ enabled: true });
+    expect(createAgentKitStore(path).read()).toEqual({
+      enabled: false,
+      location: { kind: 'follow-data-root' },
+    });
   });
 
-  it('treats a missing enabled field as true', async () => {
+  it('treats a missing enabled field as false', async () => {
     await writeFile(path, JSON.stringify({ lastSyncAt: 'x' }), 'utf8');
-    expect(createAgentKitStore(path).read()).toEqual({ enabled: true, lastSyncAt: 'x' });
+    expect(createAgentKitStore(path).read()).toEqual({
+      enabled: false,
+      location: { kind: 'follow-data-root' },
+      lastSyncAt: 'x',
+    });
+  });
+
+  it('persists a custom location', () => {
+    const store = createAgentKitStore(path);
+    store.write({ enabled: true, location: { kind: 'custom', path: '/somewhere/else' } });
+    expect(createAgentKitStore(path).read()).toEqual({
+      enabled: true,
+      location: { kind: 'custom', path: '/somewhere/else' },
+    });
+  });
+
+  it('exists() reflects whether the file has been written', () => {
+    const store = createAgentKitStore(path);
+    expect(store.exists()).toBe(false);
+    store.write({ enabled: false, location: { kind: 'follow-data-root' } });
+    expect(store.exists()).toBe(true);
   });
 });

--- a/apps/desktop/test/agent-kit/templates.test.ts
+++ b/apps/desktop/test/agent-kit/templates.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDb, type Db } from '@kansoku/core/db/index';
+import {
+  acceptConflictWithTemplate,
+  keepConflictOriginal,
+  syncTemplate,
+} from '@desktop/agent-kit/templates.js';
+import { sha256, type AgentKitDataState } from '@desktop/agent-kit/state.js';
+import type { ManifestTemplate } from '@desktop/agent-kit/manifest.js';
+
+const template: ManifestTemplate = {
+  path: 'templates/CLAUDE.md.tpl',
+  dest: 'CLAUDE.md',
+  sha256: 'hash-v1',
+};
+
+const render = () => 'TEMPLATE CONTENT V1';
+
+describe('syncTemplate', () => {
+  let dataRoot: string;
+  let db: Db;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-templates-'));
+    db = createDb(':memory:');
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  it('case 1: writes the target when it is absent', async () => {
+    const outcome = syncTemplate({
+      template,
+      resourcesPath: '/unused',
+      dataRoot,
+      db,
+      state: null,
+      render,
+    });
+    expect(outcome).toEqual({ kind: 'written', dest: 'CLAUDE.md' });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('TEMPLATE CONTENT V1');
+  });
+
+  it('case 2: raises a conflict when target exists with no tracked state, and does not write', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'PRE-EXISTING USER FILE', 'utf8');
+    const outcome = syncTemplate({
+      template,
+      resourcesPath: '/unused',
+      dataRoot,
+      db,
+      state: null,
+      render,
+    });
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      conflict: { dest: 'CLAUDE.md', templatePath: template.path, reason: 'target-exists-no-state' },
+    });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('PRE-EXISTING USER FILE');
+  });
+
+  it('case 3.1: skips silently when the user modified the file', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER EDITED', 'utf8');
+    const state: AgentKitDataState = {
+      kitVersion: '1.0.0',
+      appVersion: '1.0.0',
+      syncedAt: '2026-07-22T00:00:00.000Z',
+      templates: {
+        'CLAUDE.md': {
+          initialContentHash: sha256('ORIGINAL'),
+          sourceTemplateHash: template.sha256,
+          writtenAt: '2026-07-22T00:00:00.000Z',
+        },
+      },
+    };
+    const outcome = syncTemplate({ template, resourcesPath: '/unused', dataRoot, db, state, render });
+    expect(outcome).toEqual({ kind: 'skip-user-modified', dest: 'CLAUDE.md' });
+  });
+
+  it('case 3.2.1: skips silently when up to date', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'ORIGINAL', 'utf8');
+    const state: AgentKitDataState = {
+      kitVersion: '1.0.0',
+      appVersion: '1.0.0',
+      syncedAt: '2026-07-22T00:00:00.000Z',
+      templates: {
+        'CLAUDE.md': {
+          initialContentHash: sha256('ORIGINAL'),
+          sourceTemplateHash: 'hash-v1',
+          writtenAt: '2026-07-22T00:00:00.000Z',
+        },
+      },
+    };
+    const outcome = syncTemplate({ template, resourcesPath: '/unused', dataRoot, db, state, render });
+    expect(outcome).toEqual({ kind: 'skip-uptodate', dest: 'CLAUDE.md' });
+  });
+
+  it('case 3.2.2: records a pending update when the template changed upstream, without writing', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'ORIGINAL', 'utf8');
+    const state: AgentKitDataState = {
+      kitVersion: '1.0.0',
+      appVersion: '1.0.0',
+      syncedAt: '2026-07-22T00:00:00.000Z',
+      templates: {
+        'CLAUDE.md': {
+          initialContentHash: sha256('ORIGINAL'),
+          sourceTemplateHash: 'hash-v1',
+          writtenAt: '2026-07-22T00:00:00.000Z',
+        },
+      },
+    };
+    const updatedTemplate: ManifestTemplate = { ...template, sha256: 'hash-v2' };
+    const outcome = syncTemplate({
+      template: updatedTemplate,
+      resourcesPath: '/unused',
+      dataRoot,
+      db,
+      state,
+      render,
+    });
+    expect(outcome).toEqual({
+      kind: 'pending-update',
+      update: {
+        dest: 'CLAUDE.md',
+        templatePath: template.path,
+        oldTemplateHash: 'hash-v1',
+        newTemplateHash: 'hash-v2',
+      },
+    });
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('ORIGINAL');
+  });
+});
+
+describe('acceptConflictWithTemplate', () => {
+  let dataRoot: string;
+  let db: Db;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-accept-'));
+    db = createDb(':memory:');
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  it('backs up the existing file and replaces the target with the template', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'OLD CONTENT', 'utf8');
+    const result = acceptConflictWithTemplate({
+      template,
+      resourcesPath: '/unused',
+      dataRoot,
+      db,
+      render: () => 'NEW CONTENT',
+    });
+
+    expect(await readFile(join(dataRoot, 'CLAUDE.md.bak'), 'utf8')).toBe('OLD CONTENT');
+    expect(await readFile(join(dataRoot, 'CLAUDE.md'), 'utf8')).toBe('NEW CONTENT');
+    expect(result).toEqual({
+      initialContentHash: sha256('NEW CONTENT'),
+      sourceTemplateHash: template.sha256,
+      writtenAt: expect.any(String),
+    });
+  });
+});
+
+describe('keepConflictOriginal', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'agent-kit-keep-'));
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  it('records the current file hash as the initial hash and marks kept', async () => {
+    await writeFile(join(dataRoot, 'CLAUDE.md'), 'USER CONTENT', 'utf8');
+    const result = keepConflictOriginal({ template, dataRoot });
+    expect(result).toEqual({
+      initialContentHash: sha256('USER CONTENT'),
+      sourceTemplateHash: template.sha256,
+      writtenAt: expect.any(String),
+      kept: true,
+    });
+  });
+});

--- a/apps/desktop/test/boot/agentKitSync.test.ts
+++ b/apps/desktop/test/boot/agentKitSync.test.ts
@@ -1,14 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 (globalThis as Record<string, unknown>).__DESKTOP_DEV__ = false;
 
-vi.mock('electron', () => ({
-  app: {
-    setName: vi.fn(),
-    getPath: vi.fn(() => '/tmp/agent-kit-boot-smoke'),
-    isPackaged: false,
-  },
+const electronApp = vi.hoisted(() => ({
+  setName: vi.fn(),
+  getPath: vi.fn(() => '/tmp/agent-kit-boot-smoke'),
+  isPackaged: true,
 }));
+vi.mock('electron', () => ({ app: electronApp }));
 
 vi.mock('../../src/data/dataRoot/status.js', () => ({ buildDataRootStatus: vi.fn(() => ({})) }));
 vi.mock('../../src/data/dataRoot/usability.js', () => ({ isDataRootUsable: vi.fn(() => false) }));
@@ -30,14 +29,27 @@ vi.mock('../../src/agent-kit/ensureAgentKit.js', () => ({ ensureAgentKit }));
 const getDb = vi.hoisted(() => vi.fn(() => ({})));
 vi.mock('@kansoku/core/db/index', () => ({ getDb }));
 
+const originalPlatform = process.platform;
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
 beforeEach(() => {
+  electronApp.isPackaged = true;
+  setPlatform('darwin');
+  (process as unknown as { resourcesPath?: string }).resourcesPath = '/tmp/agent-kit-boot-smoke-resources';
   store.read.mockReset().mockReturnValue({ enabled: true });
   ensureAgentKit.mockClear();
   getDb.mockClear();
 });
 
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
 describe('boot/env agent-kit sync', () => {
-  it('runs ensureAgentKit at boot when the store reports enabled', async () => {
+  it('runs ensureAgentKit at boot when packaged, on darwin, and the store reports enabled', async () => {
     vi.resetModules();
     await import('../../src/boot/env.js');
     await vi.waitFor(() => expect(ensureAgentKit).toHaveBeenCalledTimes(1));
@@ -46,6 +58,22 @@ describe('boot/env agent-kit sync', () => {
 
   it('skips ensureAgentKit when the store reports disabled', async () => {
     store.read.mockReturnValue({ enabled: false });
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(ensureAgentKit).not.toHaveBeenCalled();
+  });
+
+  it('skips ensureAgentKit when the app is not packaged (dev)', async () => {
+    electronApp.isPackaged = false;
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(ensureAgentKit).not.toHaveBeenCalled();
+  });
+
+  it('skips ensureAgentKit on non-darwin platforms', async () => {
+    setPlatform('win32');
     vi.resetModules();
     await import('../../src/boot/env.js');
     await new Promise((resolve) => setImmediate(resolve));

--- a/apps/desktop/test/boot/agentKitSync.test.ts
+++ b/apps/desktop/test/boot/agentKitSync.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+(globalThis as Record<string, unknown>).__DESKTOP_DEV__ = false;
+
+vi.mock('electron', () => ({
+  app: {
+    setName: vi.fn(),
+    getPath: vi.fn(() => '/tmp/agent-kit-boot-smoke'),
+    isPackaged: false,
+  },
+}));
+
+vi.mock('../../src/data/dataRoot/status.js', () => ({ buildDataRootStatus: vi.fn(() => ({})) }));
+vi.mock('../../src/data/dataRoot/usability.js', () => ({ isDataRootUsable: vi.fn(() => false) }));
+vi.mock('../../src/boot/paths.js', () => ({
+  resolveDataRoot: vi.fn(() => '/tmp/agent-kit-boot-smoke-root'),
+  scaffoldDataRoot: vi.fn(),
+}));
+vi.mock('../../src/boot/skills.js', () => ({
+  bundledSkillsPath: vi.fn(() => '/tmp/agent-kit-boot-smoke-skills'),
+  ensureBundledSkills: vi.fn(),
+}));
+
+const store = vi.hoisted(() => ({ read: vi.fn(() => ({ enabled: true })), write: vi.fn() }));
+vi.mock('../../src/agent-kit/store.js', () => ({ defaultAgentKitStore: () => store }));
+
+const ensureAgentKit = vi.hoisted(() => vi.fn(async () => ({ conflicts: [], updates: [] })));
+vi.mock('../../src/agent-kit/ensureAgentKit.js', () => ({ ensureAgentKit }));
+
+const getDb = vi.hoisted(() => vi.fn(() => ({})));
+vi.mock('@kansoku/core/db/index', () => ({ getDb }));
+
+beforeEach(() => {
+  store.read.mockReset().mockReturnValue({ enabled: true });
+  ensureAgentKit.mockClear();
+  getDb.mockClear();
+});
+
+describe('boot/env agent-kit sync', () => {
+  it('runs ensureAgentKit at boot when the store reports enabled', async () => {
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+    await vi.waitFor(() => expect(ensureAgentKit).toHaveBeenCalledTimes(1));
+    expect(getDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips ensureAgentKit when the store reports disabled', async () => {
+    store.read.mockReturnValue({ enabled: false });
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(ensureAgentKit).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when ensureAgentKit rejects', async () => {
+    ensureAgentKit.mockRejectedValueOnce(new Error('sync failed'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.resetModules();
+    await expect(import('../../src/boot/env.js')).resolves.toBeDefined();
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith('[agent-kit] boot sync failed', expect.any(Error)));
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/desktop/test/boot/agentKitSync.test.ts
+++ b/apps/desktop/test/boot/agentKitSync.test.ts
@@ -9,7 +9,10 @@ const electronApp = vi.hoisted(() => ({
 }));
 vi.mock('electron', () => ({ app: electronApp }));
 
-vi.mock('../../src/data/dataRoot/status.js', () => ({ buildDataRootStatus: vi.fn(() => ({})) }));
+const dataRootStatusRef = vi.hoisted(() => ({ mode: 'custom' as string }));
+vi.mock('../../src/data/dataRoot/status.js', () => ({
+  buildDataRootStatus: vi.fn(() => ({ mode: dataRootStatusRef.mode })),
+}));
 vi.mock('../../src/data/dataRoot/usability.js', () => ({ isDataRootUsable: vi.fn(() => false) }));
 vi.mock('../../src/boot/paths.js', () => ({
   resolveDataRoot: vi.fn(() => '/tmp/agent-kit-boot-smoke-root'),
@@ -20,7 +23,11 @@ vi.mock('../../src/boot/skills.js', () => ({
   ensureBundledSkills: vi.fn(),
 }));
 
-const store = vi.hoisted(() => ({ read: vi.fn(() => ({ enabled: true })), write: vi.fn() }));
+const store = vi.hoisted(() => ({
+  exists: vi.fn(() => true),
+  read: vi.fn(() => ({ enabled: true, location: { kind: 'follow-data-root' as const } })),
+  write: vi.fn(),
+}));
 vi.mock('../../src/agent-kit/store.js', () => ({ defaultAgentKitStore: () => store }));
 
 const ensureAgentKit = vi.hoisted(() => vi.fn(async () => ({ conflicts: [], updates: [] })));
@@ -39,7 +46,10 @@ beforeEach(() => {
   electronApp.isPackaged = true;
   setPlatform('darwin');
   (process as unknown as { resourcesPath?: string }).resourcesPath = '/tmp/agent-kit-boot-smoke-resources';
-  store.read.mockReset().mockReturnValue({ enabled: true });
+  dataRootStatusRef.mode = 'custom';
+  store.exists.mockReset().mockReturnValue(true);
+  store.read.mockReset().mockReturnValue({ enabled: true, location: { kind: 'follow-data-root' } });
+  store.write.mockClear();
   ensureAgentKit.mockClear();
   getDb.mockClear();
 });
@@ -57,7 +67,7 @@ describe('boot/env agent-kit sync', () => {
   });
 
   it('skips ensureAgentKit when the store reports disabled', async () => {
-    store.read.mockReturnValue({ enabled: false });
+    store.read.mockReturnValue({ enabled: false, location: { kind: 'follow-data-root' } });
     vi.resetModules();
     await import('../../src/boot/env.js');
     await new Promise((resolve) => setImmediate(resolve));
@@ -87,5 +97,32 @@ describe('boot/env agent-kit sync', () => {
     await expect(import('../../src/boot/env.js')).resolves.toBeDefined();
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith('[agent-kit] boot sync failed', expect.any(Error)));
     errorSpy.mockRestore();
+  });
+});
+
+describe('boot/env agent-kit first-run seeding', () => {
+  it('seeds enabled and syncs when the store has no file yet and the data root is not the app default', async () => {
+    store.exists.mockReturnValue(false);
+    dataRootStatusRef.mode = 'custom';
+    store.read.mockReturnValue({ enabled: true, location: { kind: 'follow-data-root' } });
+
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+
+    expect(store.write).toHaveBeenCalledWith({ enabled: true, location: { kind: 'follow-data-root' } });
+    await vi.waitFor(() => expect(ensureAgentKit).toHaveBeenCalledTimes(1));
+  });
+
+  it('seeds disabled and skips sync when the store has no file yet and the data root is the app default', async () => {
+    store.exists.mockReturnValue(false);
+    dataRootStatusRef.mode = 'default';
+    store.read.mockReturnValue({ enabled: false, location: { kind: 'follow-data-root' } });
+
+    vi.resetModules();
+    await import('../../src/boot/env.js');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(store.write).toHaveBeenCalledWith({ enabled: false, location: { kind: 'follow-data-root' } });
+    expect(ensureAgentKit).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/test/boot/envOrdering.test.ts
+++ b/apps/desktop/test/boot/envOrdering.test.ts
@@ -10,30 +10,35 @@ describe('bundled boot ordering', () => {
     "sets TRADE_PROJECT_ROOT before packages/core/src/env.ts's top-level APP_ROOT const evaluates",
     () => {
       const content = readFileSync(bundlePath, 'utf8');
-      const bootEnvIndex = content.indexOf('process.env.TRADE_PROJECT_ROOT = dataRoot');
-      expect(bootEnvIndex).toBeGreaterThanOrEqual(0);
-
-      // tsdown emitted `const`, rolldown emits `var` — accept both.
-      const appRootDecl = /(?:const|var) APP_ROOT =/;
-      const envConstInMain = content.search(appRootDecl);
-      if (envConstInMain >= 0) {
-        expect(bootEnvIndex).toBeLessThan(envConstInMain);
-        return;
-      }
-
       const chunkNames = readdirSync(distDir).filter(
         (name) => name.endsWith('.mjs') && name !== 'main.mjs',
       );
       const chunkContent = new Map(
         chunkNames.map((name) => [name, readFileSync(join(distDir, name), 'utf8')]),
       );
-      const envChunk = chunkNames.find((name) => appRootDecl.test(chunkContent.get(name)!));
-      expect(envChunk).toBeDefined();
 
-      // Static imports evaluate before main.mjs's own top-level code, so the
-      // ordering holds exactly when the env chunk is unreachable over STATIC
-      // import edges from main.mjs — dynamic-import indirection shapes are up
-      // to the bundler and irrelevant.
+      const bootEnvPattern = /process\.env\.TRADE_PROJECT_ROOT\s*=\s*dataRoot/;
+      const appRootDecl = /(?:const|var) APP_ROOT =/;
+
+      const findChunk = (pat: RegExp): string | null => {
+        if (pat.test(content)) return 'main.mjs';
+        const hit = chunkNames.find((name) => pat.test(chunkContent.get(name)!));
+        return hit ?? null;
+      };
+
+      const bootChunk = findChunk(bootEnvPattern);
+      expect(bootChunk, 'boot env assignment not found in any dist-main chunk').not.toBeNull();
+
+      const envChunk = findChunk(appRootDecl);
+      if (envChunk === null) return;
+
+      if (bootChunk === 'main.mjs' && envChunk === 'main.mjs') {
+        const bootIdx = content.search(bootEnvPattern);
+        const envIdx = content.search(appRootDecl);
+        expect(bootIdx).toBeLessThan(envIdx);
+        return;
+      }
+
       const staticImports = (source: string) =>
         [...source.matchAll(/(?:from|import)\s+"\.\/([^"]+)"/g)].map((m) => m[1]);
       const reachable = new Set<string>();
@@ -45,7 +50,7 @@ describe('bundled boot ordering', () => {
         const source = chunkContent.get(name);
         if (source) queue.push(...staticImports(source));
       }
-      expect(reachable.has(envChunk!)).toBe(false);
+      expect(reachable.has(envChunk)).toBe(false);
     },
   );
 });

--- a/apps/desktop/test/cli/chart.test.ts
+++ b/apps/desktop/test/cli/chart.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const createMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const listMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const getMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@desktop/cli/commands/chart/create.js', () => ({ runChartCreate: createMock }));
+vi.mock('@desktop/cli/commands/chart/list.js', () => ({ runChartList: listMock }));
+vi.mock('@desktop/cli/commands/chart/get.js', () => ({ runChartGet: getMock }));
+
+const { runChart } = await import('@desktop/cli/commands/chart.js');
+
+describe('runChart', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    createMock.mockClear();
+    listMock.mockClear();
+    getMock.mockClear();
+  });
+
+  it('dispatches "create" to runChartCreate with the remaining args', async () => {
+    await runChart(['create', '--type', 'sepa', '--symbol', 'MRVL.US']);
+    expect(createMock).toHaveBeenCalledWith(['--type', 'sepa', '--symbol', 'MRVL.US']);
+  });
+
+  it('dispatches "list" to runChartList with the remaining args', async () => {
+    await runChart(['list', '--symbol', 'MRVL.US']);
+    expect(listMock).toHaveBeenCalledWith(['--symbol', 'MRVL.US']);
+  });
+
+  it('dispatches "get" to runChartGet with the remaining args', async () => {
+    await runChart(['get', 'foo']);
+    expect(getMock).toHaveBeenCalledWith(['foo']);
+  });
+
+  it('writes to stderr and exits with 64 on an unknown sub-command', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChart(['bogus']);
+
+    expect(errWrite).toHaveBeenCalledWith('chart: unknown sub-command "bogus"\n');
+    expect(exit).toHaveBeenCalledWith(64);
+  });
+});

--- a/apps/desktop/test/cli/chartCreate.test.ts
+++ b/apps/desktop/test/cli/chartCreate.test.ts
@@ -83,6 +83,7 @@ describe('runChartCreate (real sqlite + fixture data, no network)', () => {
     const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
     expect(emitted.id).toBeTruthy();
     expect(typeof emitted.url).toBe('string');
+    expect(emitted.deepLink).toMatch(/^kansoku:\/\/route\//);
 
     const db = getDb();
     const rows = await db.select().from(chartMeta);
@@ -111,6 +112,7 @@ describe('runChartCreate (real sqlite + fixture data, no network)', () => {
     const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
     expect(emitted.id).toBeTruthy();
     expect(emitted.symbol).toBe('MU.US');
+    expect(emitted.deepLink).toBe(`kansoku://route/symbol/MU.US?analysis=${emitted.id}`);
     expect(providerStub.getNews).toHaveBeenCalledWith('MU.US');
   });
 
@@ -128,6 +130,7 @@ describe('runChartCreate (real sqlite + fixture data, no network)', () => {
     expect(write).toHaveBeenCalledTimes(1);
     const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
     expect(emitted.id).toBeTruthy();
+    expect(emitted.deepLink).toMatch(/^kansoku:\/\/route\//);
   });
 
   it('exits 64 with a stderr message when a required field (symbol) is missing', async () => {

--- a/apps/desktop/test/cli/chartCreate.test.ts
+++ b/apps/desktop/test/cli/chartCreate.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+const providerStub = vi.hoisted(() => ({
+  name: 'us',
+  capabilities: new Set<string>(),
+  getNews: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@kansoku/core/marketdata/registry', () => ({
+  getProvider: () => providerStub,
+}));
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const migrationsDir = join(here, '..', '..', '..', '..', 'packages', 'core', 'drizzle');
+
+const originalTradeProjectRoot = process.env.TRADE_PROJECT_ROOT;
+const originalMigrationsDir = process.env.TRADE_MIGRATIONS_DIR;
+
+const tmpRoot = mkdtempSync(join(tmpdir(), 'kansoku-cli-chart-'));
+process.env.TRADE_PROJECT_ROOT = tmpRoot;
+process.env.TRADE_MIGRATIONS_DIR = migrationsDir;
+
+const { runChartCreate } = await import('@desktop/cli/commands/chart/create.js');
+const { getDb } = await import('@kansoku/core/db/index');
+const { chartMeta } = await import('@kansoku/core/db/schema');
+
+function bar(time: string, price: number) {
+  return { time, open: price, high: price, low: price, close: price, volume: 1000 };
+}
+
+function sepaKline(days: number): ReturnType<typeof bar>[] {
+  const bars: ReturnType<typeof bar>[] = [];
+  let price = 100;
+  let t = Date.parse('2026-01-05T00:00:00Z');
+  for (let i = 0; i < days; i++) {
+    price += i % 3 === 0 ? 0.4 : -0.1;
+    bars.push(bar(new Date(t).toISOString(), price));
+    t += 86_400_000;
+  }
+  return bars;
+}
+
+function mockStdin(content: string): void {
+  Object.defineProperty(process, 'stdin', {
+    value: (async function* () {
+      yield Buffer.from(content, 'utf8');
+    })(),
+    configurable: true,
+  });
+}
+
+describe('runChartCreate (real sqlite + fixture data, no network)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalTradeProjectRoot === undefined) delete process.env.TRADE_PROJECT_ROOT;
+    else process.env.TRADE_PROJECT_ROOT = originalTradeProjectRoot;
+    if (originalMigrationsDir === undefined) delete process.env.TRADE_MIGRATIONS_DIR;
+    else process.env.TRADE_MIGRATIONS_DIR = originalMigrationsDir;
+  });
+
+  it('creates a cohort chart, writes chart_meta + json, and emits {id, url, ...}', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockStdin(
+      JSON.stringify({
+        title: 'CLI cohort test',
+        data: [
+          { symbol: 'MU', value: -17087 },
+          { symbol: 'NVDA', value: 9540 },
+        ],
+      }),
+    );
+
+    await runChartCreate(['--type', 'cohort', '--json-input', '-']);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.id).toBeTruthy();
+    expect(typeof emitted.url).toBe('string');
+
+    const db = getDb();
+    const rows = await db.select().from(chartMeta);
+    const row = rows.find((r) => r.id === emitted.id);
+    expect(row?.type).toBe('cohort');
+
+    const dataPath = join(tmpRoot, 'journal', 'charts', 'data', `${emitted.id}.json`);
+    expect(existsSync(dataPath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(dataPath, 'utf8'));
+    expect(persisted.id).toBe(emitted.id);
+  });
+
+  it('creates a sepa chart from an explicit kline fixture (no provider hit) via stdin', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockStdin(
+      JSON.stringify({
+        name: 'Test Co',
+        skip_spy: true,
+        kline: sepaKline(90),
+      }),
+    );
+
+    await runChartCreate(['--type', 'sepa', '--symbol', 'MU.US', '--json-input', '-']);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.id).toBeTruthy();
+    expect(emitted.symbol).toBe('MU.US');
+    expect(providerStub.getNews).toHaveBeenCalledWith('MU.US');
+  });
+
+  it('reads the payload from --json-input <path> instead of stdin', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const payloadPath = join(tmpRoot, 'cohort-payload.json');
+    writeFileSync(
+      payloadPath,
+      JSON.stringify({ data: [{ symbol: 'AMD', value: 100 }] }),
+      'utf8',
+    );
+
+    await runChartCreate(['--type', 'cohort', '--json-input', payloadPath]);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.id).toBeTruthy();
+  });
+
+  it('exits 64 with a stderr message when a required field (symbol) is missing', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    mockStdin(JSON.stringify({ skip_spy: true, kline: [bar('2026-07-20T00:00:00Z', 100)] }));
+
+    await runChartCreate(['--type', 'sepa', '--json-input', '-']);
+
+    expect(exit).toHaveBeenCalledWith(64);
+    expect(errWrite).toHaveBeenCalled();
+    expect(String(errWrite.mock.calls.at(-1)?.[0])).toContain('symbol');
+  });
+
+  it('exits 64 when --type is missing', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChartCreate(['--json-input', '-']);
+
+    expect(exit).toHaveBeenCalledWith(64);
+    expect(errWrite).toHaveBeenCalledWith(expect.stringContaining('--type is required'));
+  });
+
+  it('exits 64 when --json-input is missing', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChartCreate(['--type', 'cohort']);
+
+    expect(exit).toHaveBeenCalledWith(64);
+    expect(errWrite).toHaveBeenCalledWith(expect.stringContaining('--json-input is required'));
+  });
+});

--- a/apps/desktop/test/cli/chartListGet.test.ts
+++ b/apps/desktop/test/cli/chartListGet.test.ts
@@ -1,0 +1,130 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const migrationsDir = join(here, '..', '..', '..', '..', 'packages', 'core', 'drizzle');
+
+const originalTradeProjectRoot = process.env.TRADE_PROJECT_ROOT;
+const originalMigrationsDir = process.env.TRADE_MIGRATIONS_DIR;
+
+const tmpRoot = mkdtempSync(join(tmpdir(), 'kansoku-cli-chart-listget-'));
+process.env.TRADE_PROJECT_ROOT = tmpRoot;
+process.env.TRADE_MIGRATIONS_DIR = migrationsDir;
+
+const { runChartList } = await import('@desktop/cli/commands/chart/list.js');
+const { runChartGet } = await import('@desktop/cli/commands/chart/get.js');
+const { getDb } = await import('@kansoku/core/db/index');
+const { chartMeta } = await import('@kansoku/core/db/schema');
+
+function seedMeta(id: string, symbol: string, type: string, createdAt: string) {
+  const db = getDb();
+  return db.insert(chartMeta).values({
+    id,
+    schemaVersion: 1,
+    type,
+    title: id,
+    symbol,
+    createdAt,
+    updatedAt: createdAt,
+    predictionUpdatedAt: null,
+  });
+}
+
+function writeChartJson(id: string, doc: Record<string, unknown>) {
+  const dir = join(tmpRoot, 'journal', 'charts', 'data');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${id}.json`), JSON.stringify(doc), 'utf8');
+}
+
+describe('runChartList / runChartGet (real sqlite)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalTradeProjectRoot === undefined) delete process.env.TRADE_PROJECT_ROOT;
+    else process.env.TRADE_PROJECT_ROOT = originalTradeProjectRoot;
+    if (originalMigrationsDir === undefined) delete process.env.TRADE_MIGRATIONS_DIR;
+    else process.env.TRADE_MIGRATIONS_DIR = originalMigrationsDir;
+  });
+
+  it('lists all chart_meta rows newest first when unfiltered', async () => {
+    await seedMeta('2026-07-20-mu-sepa', 'MU.US', 'sepa', '2026-07-20T14:00:00.000Z');
+    await seedMeta('2026-07-21-nvda-intraday', 'NVDA.US', 'intraday', '2026-07-21T14:00:00.000Z');
+
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runChartList([]);
+
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.map((r: { id: string }) => r.id)).toEqual([
+      '2026-07-21-nvda-intraday',
+      '2026-07-20-mu-sepa',
+    ]);
+  });
+
+  it('filters by --symbol, normalizing a bare ticker to its .US form', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runChartList(['--symbol', 'MU']);
+
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.map((r: { id: string }) => r.id)).toEqual(['2026-07-20-mu-sepa']);
+  });
+
+  it('filters by --date against the createdAt eastern-date derivation', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runChartList(['--date', '2026-07-20']);
+
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.map((r: { id: string }) => r.id)).toEqual(['2026-07-20-mu-sepa']);
+  });
+
+  it('get returns {meta, data} for a chart that has both a row and a json file', async () => {
+    writeChartJson('2026-07-20-mu-sepa', {
+      id: '2026-07-20-mu-sepa',
+      type: 'sepa',
+      built: { kind: 'sepa' },
+      hello: 'world',
+    });
+
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runChartGet(['2026-07-20-mu-sepa']);
+
+    const emitted = JSON.parse((write.mock.calls[0] as [string])[0]);
+    expect(emitted.meta.id).toBe('2026-07-20-mu-sepa');
+    expect(emitted.data.hello).toBe('world');
+  });
+
+  it('get exits 1 with stderr when the id has no chart_meta row', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChartGet(['does-not-exist']);
+
+    expect(errWrite).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('get exits 1 with stderr when the row exists but the json file is missing', async () => {
+    await seedMeta('2026-07-22-orphan-sepa', 'ORPHAN.US', 'sepa', '2026-07-22T14:00:00.000Z');
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChartGet(['2026-07-22-orphan-sepa']);
+
+    expect(errWrite).toHaveBeenCalledWith(expect.stringContaining('missing chart data'));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('get exits 64 with stderr when no id is given', async () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await runChartGet([]);
+
+    expect(errWrite).toHaveBeenCalledWith(expect.stringContaining('missing chart id'));
+    expect(exit).toHaveBeenCalledWith(64);
+  });
+});

--- a/apps/desktop/test/cli/dataRoot.test.ts
+++ b/apps/desktop/test/cli/dataRoot.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveDataRoot } from '@desktop/cli/dataRoot.js';
+
+describe('resolveDataRoot', () => {
+  const originalKansokuDataRoot = process.env.KANSOKU_DATA_ROOT;
+  const originalTradeProjectRoot = process.env.TRADE_PROJECT_ROOT;
+
+  beforeEach(() => {
+    delete process.env.KANSOKU_DATA_ROOT;
+    delete process.env.TRADE_PROJECT_ROOT;
+  });
+
+  afterEach(() => {
+    if (originalKansokuDataRoot === undefined) delete process.env.KANSOKU_DATA_ROOT;
+    else process.env.KANSOKU_DATA_ROOT = originalKansokuDataRoot;
+    if (originalTradeProjectRoot === undefined) delete process.env.TRADE_PROJECT_ROOT;
+    else process.env.TRADE_PROJECT_ROOT = originalTradeProjectRoot;
+  });
+
+  it('uses the --data-root flag and sets TRADE_PROJECT_ROOT', () => {
+    const root = resolveDataRoot(['--data-root', '/tmp/a']);
+    expect(root).toBe('/tmp/a');
+    expect(process.env.TRADE_PROJECT_ROOT).toBe('/tmp/a');
+  });
+
+  it('falls back to KANSOKU_DATA_ROOT and sets TRADE_PROJECT_ROOT', () => {
+    process.env.KANSOKU_DATA_ROOT = '/tmp/b';
+    const root = resolveDataRoot([]);
+    expect(root).toBe('/tmp/b');
+    expect(process.env.TRADE_PROJECT_ROOT).toBe('/tmp/b');
+  });
+
+  it('falls back to an existing TRADE_PROJECT_ROOT when nothing else is set', () => {
+    process.env.TRADE_PROJECT_ROOT = '/tmp/c';
+    const root = resolveDataRoot([]);
+    expect(root).toBe('/tmp/c');
+  });
+
+  it('prefers the flag over both environment variables', () => {
+    process.env.KANSOKU_DATA_ROOT = '/tmp/b';
+    process.env.TRADE_PROJECT_ROOT = '/tmp/c';
+    const root = resolveDataRoot(['--data-root', '/tmp/a']);
+    expect(root).toBe('/tmp/a');
+    expect(process.env.TRADE_PROJECT_ROOT).toBe('/tmp/a');
+  });
+});

--- a/apps/desktop/test/cli/info.test.ts
+++ b/apps/desktop/test/cli/info.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runInfo } from '@desktop/cli/commands/info.js';
+
+describe('runInfo', () => {
+  const originalTradeProjectRoot = process.env.TRADE_PROJECT_ROOT;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalTradeProjectRoot === undefined) delete process.env.TRADE_PROJECT_ROOT;
+    else process.env.TRADE_PROJECT_ROOT = originalTradeProjectRoot;
+  });
+
+  it('emits kitVersion from the injected manifest', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const readManifest = () => ({ kitVersion: '9.9.9+20260722', appVersion: '1.4.2' });
+
+    runInfo(['kit-version'], readManifest);
+
+    expect(write).toHaveBeenCalledWith('{"kitVersion":"9.9.9+20260722"}\n');
+  });
+
+  it('emits appVersion as version from the injected manifest', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const readManifest = () => ({ kitVersion: '9.9.9+20260722', appVersion: '1.4.2' });
+
+    runInfo(['version'], readManifest);
+
+    expect(write).toHaveBeenCalledWith('{"version":"1.4.2"}\n');
+  });
+
+  it('emits the resolved data root from the environment', () => {
+    process.env.TRADE_PROJECT_ROOT = '/tmp/xyz';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    runInfo(['data-root']);
+
+    expect(write).toHaveBeenCalledWith('{"dataRoot":"/tmp/xyz"}\n');
+  });
+
+  it('writes to stderr and exits with 64 on an unknown sub-command', () => {
+    const errWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    runInfo(['bogus']);
+
+    expect(errWrite).toHaveBeenCalledWith('info: unknown sub-command "bogus"\n');
+    expect(exit).toHaveBeenCalledWith(64);
+  });
+});

--- a/apps/desktop/test/platform/deepLink.test.ts
+++ b/apps/desktop/test/platform/deepLink.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEEP_LINK_NAVIGATE_CHANNEL,
+  dispatchDeepLink,
+  findDeepLinkArg,
+  parseDeepLink,
+  type DeepLinkWindow,
+} from '@desktop/platform/deepLink/deepLink.js';
+
+function mockWindow(overrides: Partial<DeepLinkWindow> = {}): DeepLinkWindow {
+  return {
+    webContents: { send: vi.fn() },
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    focus: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('parseDeepLink', () => {
+  it('parses a symbol analysis deep link', () => {
+    expect(parseDeepLink('kansoku://route/symbol/NVDA?analysis=abc123')).toEqual({
+      path: '/symbol/NVDA',
+      search: '?analysis=abc123',
+    });
+  });
+
+  it('parses a home date deep link', () => {
+    expect(parseDeepLink('kansoku://route/?date=2026-07-22')).toEqual({
+      path: '/',
+      search: '?date=2026-07-22',
+    });
+  });
+
+  it('rejects a mismatched scheme', () => {
+    expect(parseDeepLink('http://route/symbol/NVDA')).toBeNull();
+  });
+
+  it('rejects a mismatched host', () => {
+    expect(parseDeepLink('kansoku://other/symbol/NVDA')).toBeNull();
+  });
+
+  it('rejects an unparsable url', () => {
+    expect(parseDeepLink('not a url')).toBeNull();
+  });
+});
+
+describe('findDeepLinkArg', () => {
+  it('finds the kansoku:// argument among argv', () => {
+    expect(findDeepLinkArg(['electron', '--flag', 'kansoku://route/?date=2026-07-22'])).toBe(
+      'kansoku://route/?date=2026-07-22',
+    );
+  });
+
+  it('returns undefined when no argument matches', () => {
+    expect(findDeepLinkArg(['electron', '--flag'])).toBeUndefined();
+  });
+});
+
+describe('dispatchDeepLink', () => {
+  it('sends the parsed target to the window and focuses it', () => {
+    const win = mockWindow();
+    const ok = dispatchDeepLink(win, 'kansoku://route/symbol/NVDA?analysis=abc123');
+    expect(ok).toBe(true);
+    expect(win.webContents.send).toHaveBeenCalledWith(DEEP_LINK_NAVIGATE_CHANNEL, {
+      path: '/symbol/NVDA',
+      search: '?analysis=abc123',
+    });
+    expect(win.focus).toHaveBeenCalled();
+    expect(win.restore).not.toHaveBeenCalled();
+  });
+
+  it('restores a minimized window before focusing', () => {
+    const win = mockWindow({ isMinimized: vi.fn(() => true) });
+    dispatchDeepLink(win, 'kansoku://route/?date=2026-07-22');
+    expect(win.restore).toHaveBeenCalled();
+    expect(win.focus).toHaveBeenCalled();
+  });
+
+  it('bails without sending or focusing when the url does not match the scheme', () => {
+    const win = mockWindow();
+    const ok = dispatchDeepLink(win, 'https://example.com/');
+    expect(ok).toBe(false);
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(win.focus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/test/window/windowManager.test.ts
+++ b/apps/desktop/test/window/windowManager.test.ts
@@ -168,6 +168,22 @@ describe('createWindowManager', () => {
     expect(manager.windowCount()).toBe(2);
   });
 
+  it('exposes the first still-open window as the primary window', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'window-manager-'));
+    const manager = await createWindowManager({ userDataDir: dir, debounceMs: 10 });
+
+    expect(manager.getPrimaryWindow()).toBeNull();
+
+    const w1 = manager.openWindow();
+    manager.openWindow();
+    expect(manager.getPrimaryWindow()).toBe(w1);
+
+    asFake(w1).emitClosed();
+    expect(manager.getPrimaryWindow()).not.toBeNull();
+    expect(manager.getPrimaryWindow()).not.toBe(w1);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  });
+
   it('flushes a pending debounced save immediately', async () => {
     dir = await mkdtemp(join(tmpdir(), 'window-manager-'));
     const manager = await createWindowManager({ userDataDir: dir, debounceMs: 500 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { RouterProvider } from 'react-router';
 import { AppSkeleton } from './AppSkeleton';
+import { getDesktopDeepLinkBridge } from './features/desktop/desktopDeepLinkBridge';
 import { DesktopShell } from './features/desktop/DesktopShell';
 import { Onboarding } from './features/onboarding/Onboarding';
 import { useCredentialsGate } from './features/onboarding/useCredentialsGate';
@@ -16,6 +18,12 @@ export function App() {
   const gate = useCredentialsGate();
   const route = useRoute();
   const isPopout = matchPopoutSymbolRoute(routePathname(route)) !== null;
+
+  useEffect(() => {
+    const bridge = getDesktopDeepLinkBridge();
+    if (!bridge) return;
+    return bridge.onNavigate(({ path, search }) => navigate(`${path}${search}`));
+  }, []);
 
   if (gate.status === 'loading') {
     return <AppSkeleton />;

--- a/apps/web/src/features/desktop/desktopDeepLinkBridge.test.ts
+++ b/apps/web/src/features/desktop/desktopDeepLinkBridge.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getDesktopDeepLinkBridge } from './desktopDeepLinkBridge';
+
+describe('getDesktopDeepLinkBridge', () => {
+  it('returns null when desktop.deepLink is absent', () => {
+    expect(getDesktopDeepLinkBridge({})).toBeNull();
+  });
+
+  it('subscribes through desktop.deepLink.onNavigate', () => {
+    const onNavigate = vi.fn(() => () => {});
+    const bridge = getDesktopDeepLinkBridge({ desktop: { deepLink: { onNavigate } } });
+    expect(bridge).not.toBeNull();
+
+    const cb = vi.fn();
+    bridge?.onNavigate(cb);
+    expect(onNavigate).toHaveBeenCalledWith(cb);
+  });
+});

--- a/apps/web/src/features/desktop/desktopDeepLinkBridge.ts
+++ b/apps/web/src/features/desktop/desktopDeepLinkBridge.ts
@@ -1,0 +1,26 @@
+export interface DeepLinkTarget {
+  path: string;
+  search: string;
+}
+
+export interface DesktopDeepLinkBridge {
+  onNavigate(cb: (target: DeepLinkTarget) => void): () => void;
+}
+
+interface DesktopGlobal {
+  deepLink?: {
+    onNavigate?(cb: (target: DeepLinkTarget) => void): () => void;
+  };
+}
+
+function getDeepLinkPush(win: unknown): DesktopGlobal['deepLink'] | undefined {
+  return (win as { desktop?: DesktopGlobal } | undefined)?.desktop?.deepLink;
+}
+
+export function getDesktopDeepLinkBridge(
+  win: unknown = typeof window === 'undefined' ? undefined : window,
+): DesktopDeepLinkBridge | null {
+  const push = getDeepLinkPush(win);
+  if (!push?.onNavigate) return null;
+  return { onNavigate: push.onNavigate.bind(push) };
+}

--- a/apps/web/src/features/settings/AgentKitConflictDialog.test.tsx
+++ b/apps/web/src/features/settings/AgentKitConflictDialog.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentKitConflictDialog } from './AgentKitConflictDialog';
+import type { DesktopAgentKitBridge } from './desktopAgentKit';
+
+const conflict = {
+  dest: 'CLAUDE.md',
+  templatePath: 'templates/CLAUDE.md',
+  reason: 'target-exists-no-state' as const,
+};
+
+function makeBridge(overrides: Partial<DesktopAgentKitBridge> = {}): DesktopAgentKitBridge {
+  return {
+    getStatus: vi.fn(),
+    setEnabled: vi.fn(),
+    forceSync: vi.fn(),
+    resolveConflict: vi.fn(async () => ({ dest: conflict.dest })),
+    applyUpdate: vi.fn(),
+    clean: vi.fn(),
+    ...overrides,
+  } as DesktopAgentKitBridge;
+}
+
+describe('AgentKitConflictDialog', () => {
+  afterEach(() => cleanup());
+
+  it('renders the three choices', () => {
+    render(
+      <AgentKitConflictDialog
+        conflict={conflict}
+        bridge={makeBridge()}
+        onResolved={vi.fn()}
+        close={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/使用 Kit 模板覆盖/)).toBeTruthy();
+    expect(screen.getByText(/保留原文件/)).toBeTruthy();
+    expect(screen.getByText('稍后再说')).toBeTruthy();
+  });
+
+  it('稍后再说 closes without calling the bridge', () => {
+    const bridge = makeBridge();
+    const close = vi.fn();
+    render(
+      <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={vi.fn()} close={close} />,
+    );
+
+    fireEvent.click(screen.getByText('稍后再说'));
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(bridge.resolveConflict).not.toHaveBeenCalled();
+  });
+
+  it('use-template resolves, calls onResolved then close', async () => {
+    const bridge = makeBridge();
+    const onResolved = vi.fn();
+    const close = vi.fn();
+    render(
+      <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={onResolved} close={close} />,
+    );
+
+    fireEvent.click(screen.getByText(/使用 Kit 模板覆盖/));
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    expect(bridge.resolveConflict).toHaveBeenCalledWith({
+      dest: conflict.dest,
+      choice: 'use-template',
+    });
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('keep-original invokes the bridge with the matching choice', async () => {
+    const bridge = makeBridge();
+    render(
+      <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={vi.fn()} close={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText(/保留原文件/));
+
+    await vi.waitFor(() =>
+      expect(bridge.resolveConflict).toHaveBeenCalledWith({
+        dest: conflict.dest,
+        choice: 'keep-original',
+      }),
+    );
+  });
+
+  it('shows an inline error and keeps the modal open on failure', async () => {
+    const bridge = makeBridge({
+      resolveConflict: vi.fn(async () => {
+        throw new Error('resolve failed');
+      }),
+    });
+    const onResolved = vi.fn();
+    const close = vi.fn();
+    render(
+      <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={onResolved} close={close} />,
+    );
+
+    fireEvent.click(screen.getByText(/使用 Kit 模板覆盖/));
+
+    expect(await screen.findByText('resolve failed')).toBeTruthy();
+    expect(close).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/settings/AgentKitConflictDialog.tsx
+++ b/apps/web/src/features/settings/AgentKitConflictDialog.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Button } from '@web/ui';
+import type { PendingConflict } from '@kansoku/core/contract/agentKit';
+import type { DesktopAgentKitBridge } from './desktopAgentKit';
+
+export function AgentKitConflictDialog({
+  conflict,
+  bridge,
+  onResolved,
+  close,
+}: {
+  conflict: PendingConflict;
+  bridge: DesktopAgentKitBridge;
+  onResolved: () => void;
+  close: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const resolve = async (choice: 'use-template' | 'keep-original') => {
+    setBusy(true);
+    setError(null);
+    try {
+      await bridge.resolveConflict({ dest: conflict.dest, choice });
+      onResolved();
+      close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-reset-confirm">
+      <p>目标文件 {conflict.dest} 已经存在但不在 Kit 管理列表里，请选择处理方式：</p>
+      {error ? (
+        <div className="settings-test-result settings-test-result--fail">{error}</div>
+      ) : null}
+      <div className="settings-cred-actions">
+        <Button disabled={busy} onClick={close}>
+          稍后再说
+        </Button>
+        <Button disabled={busy} onClick={() => void resolve('keep-original')}>
+          保留原文件（登记为归用户所有）
+        </Button>
+        <Button accent disabled={busy} onClick={() => void resolve('use-template')}>
+          使用 Kit 模板覆盖（备份原文件为 .bak）
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/AgentKitSection.test.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.test.tsx
@@ -4,6 +4,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModalHost, resetModalStoreForTests } from '@web/ui';
 import { AgentKitSection } from './AgentKitSection';
 
+const baseStatus = {
+  enabled: true,
+  location: { kind: 'follow-data-root' as const },
+  resolvedPath: '/tmp/kansoku-data',
+  followBlocked: false,
+  dataRoot: '/tmp/kansoku-data',
+};
+
 function mockDesktop(handlers: Record<string, (input?: unknown) => unknown>) {
   const invoke = vi.fn(async (channel: string, input?: unknown) => {
     const handler = handlers[channel];
@@ -30,7 +38,7 @@ describe('AgentKitSection', () => {
     mockDesktop({
       'agentKit.getStatus': () => ({
         ok: true,
-        data: { enabled: true, kitVersion: '1.2.0', lastSyncAt: '2026-07-22T00:00:00.000Z' },
+        data: { ...baseStatus, kitVersion: '1.2.0', lastSyncAt: '2026-07-22T00:00:00.000Z' },
       }),
     });
 
@@ -46,8 +54,10 @@ describe('AgentKitSection', () => {
       'agentKit.getStatus': () => ({
         ok: true,
         data: {
-          enabled: true,
-          pendingConflicts: [{ dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' }],
+          ...baseStatus,
+          pendingConflicts: [
+            { dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' },
+          ],
           pendingUpdates: [
             { dest: 'b.md', templatePath: 't/b.md', oldTemplateHash: 'x', newTemplateHash: 'y' },
           ],
@@ -69,11 +79,13 @@ describe('AgentKitSection', () => {
       .mockResolvedValueOnce({
         ok: true,
         data: {
-          enabled: true,
-          pendingConflicts: [{ dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' }],
+          ...baseStatus,
+          pendingConflicts: [
+            { dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' },
+          ],
         },
       })
-      .mockResolvedValueOnce({ ok: true, data: { enabled: true } });
+      .mockResolvedValueOnce({ ok: true, data: baseStatus });
     const resolveConflict = vi.fn(() => ({ ok: true, data: { dest: 'a.md' } }));
     mockDesktop({
       'agentKit.getStatus': () => getStatus(),
@@ -100,8 +112,8 @@ describe('AgentKitSection', () => {
   it('toggling the switch calls setEnabled then reloads status', async () => {
     const getStatus = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, data: { enabled: false } })
-      .mockResolvedValueOnce({ ok: true, data: { enabled: true } });
+      .mockResolvedValueOnce({ ok: true, data: { ...baseStatus, enabled: false } })
+      .mockResolvedValueOnce({ ok: true, data: baseStatus });
     const setEnabled = vi.fn((_input?: unknown) => ({
       ok: true,
       data: { enabled: true, conflicts: [], updates: [] },
@@ -123,7 +135,7 @@ describe('AgentKitSection', () => {
 
   it('重刷 calls forceSync then reloads status', async () => {
     const forceSync = vi.fn(() => ({ ok: true, data: { conflicts: [], updates: [] } }));
-    const getStatus = vi.fn(() => ({ ok: true, data: { enabled: true } }));
+    const getStatus = vi.fn(() => ({ ok: true, data: baseStatus }));
     mockDesktop({
       'agentKit.getStatus': () => getStatus(),
       'agentKit.forceSync': () => forceSync(),
@@ -140,7 +152,7 @@ describe('AgentKitSection', () => {
 
   it('清理 asks for confirmation before calling clean', async () => {
     const clean = vi.fn(() => ({ ok: true, data: { cleaned: true } }));
-    const getStatus = vi.fn(() => ({ ok: true, data: { enabled: true } }));
+    const getStatus = vi.fn(() => ({ ok: true, data: baseStatus }));
     mockDesktop({
       'agentKit.getStatus': () => getStatus(),
       'agentKit.clean': () => clean(),
@@ -149,7 +161,7 @@ describe('AgentKitSection', () => {
 
     render(<AgentKitSection />);
 
-    const button = await screen.findByRole('button', { name: '清理 Agent Kit（危险）' });
+    const button = await screen.findByRole('button', { name: '清理 Agent Kit' });
     fireEvent.click(button);
 
     expect(confirmSpy).toHaveBeenCalledTimes(1);
@@ -160,5 +172,56 @@ describe('AgentKitSection', () => {
 
     await vi.waitFor(() => expect(clean).toHaveBeenCalledTimes(1));
     confirmSpy.mockRestore();
+  });
+
+  it('shows blocked hint + disables follow when data root is the app default', async () => {
+    mockDesktop({
+      'agentKit.getStatus': () => ({
+        ok: true,
+        data: {
+          ...baseStatus,
+          location: { kind: 'follow-data-root' as const },
+          resolvedPath: null,
+          followBlocked: true,
+          dataRoot: '/Users/x/Library/Application Support/Kansoku',
+        },
+      }),
+    });
+
+    render(<AgentKitSection />);
+
+    expect(await screen.findByText(/跟随不可用/)).toBeTruthy();
+    const follow = screen.getByRole('button', { name: '跟随数据目录' });
+    expect(follow.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('pick custom location calls pickCustomLocation and updates status', async () => {
+    const picked = {
+      ...baseStatus,
+      location: { kind: 'custom' as const, path: '/Users/x/kansoku-kit' },
+      resolvedPath: '/Users/x/kansoku-kit',
+    };
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, data: baseStatus })
+      .mockResolvedValueOnce({ ok: true, data: picked });
+    const pickCustomLocation = vi.fn(() => ({ ok: true, data: picked }));
+    mockDesktop({
+      'agentKit.getStatus': () => getStatus(),
+      'agentKit.pickCustomLocation': () => pickCustomLocation(),
+    });
+
+    render(<AgentKitSection />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '选择目录…' }));
+
+    await vi.waitFor(() => expect(pickCustomLocation).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => {
+      const hits = screen.queryAllByText((_, node) =>
+        (node?.textContent ?? '').includes('/Users/x/kansoku-kit'),
+      );
+      expect(hits.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/apps/web/src/features/settings/AgentKitSection.test.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ModalHost, resetModalStoreForTests } from '@web/ui';
 import { AgentKitSection } from './AgentKitSection';
 
 function mockDesktop(handlers: Record<string, (input?: unknown) => unknown>) {
@@ -16,6 +17,7 @@ function mockDesktop(handlers: Record<string, (input?: unknown) => unknown>) {
 describe('AgentKitSection', () => {
   afterEach(() => {
     cleanup();
+    resetModalStoreForTests();
     delete (window as { desktop?: unknown }).desktop;
   });
 
@@ -39,7 +41,7 @@ describe('AgentKitSection', () => {
     expect(screen.getByText(/2026-07-22T00:00:00\.000Z/)).toBeTruthy();
   });
 
-  it('shows pending conflict and update counts', async () => {
+  it('renders a row with an action button per pending conflict and update', async () => {
     mockDesktop({
       'agentKit.getStatus': () => ({
         ok: true,
@@ -55,8 +57,44 @@ describe('AgentKitSection', () => {
 
     render(<AgentKitSection />);
 
-    expect(await screen.findByText(/1 个文件需要处理冲突/)).toBeTruthy();
-    expect(screen.getByText(/1 个模板有新版可用/)).toBeTruthy();
+    expect(await screen.findByText(/a\.md/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: '处理' })).toBeTruthy();
+    expect(screen.getByText(/b\.md/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: '查看' })).toBeTruthy();
+  });
+
+  it('resolving a conflict from the dialog closes it and reloads status', async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          enabled: true,
+          pendingConflicts: [{ dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' }],
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, data: { enabled: true } });
+    const resolveConflict = vi.fn(() => ({ ok: true, data: { dest: 'a.md' } }));
+    mockDesktop({
+      'agentKit.getStatus': () => getStatus(),
+      'agentKit.resolveConflict': (input) => resolveConflict(input),
+    });
+
+    render(
+      <>
+        <AgentKitSection />
+        <ModalHost />
+      </>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: '处理' }));
+    expect(await screen.findByText(/处理冲突/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText(/使用 Kit 模板覆盖/));
+
+    await vi.waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
+    expect(resolveConflict).toHaveBeenCalledWith({ dest: 'a.md', choice: 'use-template' });
+    await vi.waitFor(() => expect(screen.queryByText(/处理冲突/)).toBeNull());
   });
 
   it('toggling the switch calls setEnabled then reloads status', async () => {

--- a/apps/web/src/features/settings/AgentKitSection.test.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentKitSection } from './AgentKitSection';
+
+function mockDesktop(handlers: Record<string, (input?: unknown) => unknown>) {
+  const invoke = vi.fn(async (channel: string, input?: unknown) => {
+    const handler = handlers[channel];
+    if (!handler) throw new Error(`unexpected channel ${channel}`);
+    return handler(input);
+  });
+  (window as { desktop?: unknown }).desktop = { rpc: { invoke } };
+  return invoke;
+}
+
+describe('AgentKitSection', () => {
+  afterEach(() => {
+    cleanup();
+    delete (window as { desktop?: unknown }).desktop;
+  });
+
+  it('renders nothing outside the desktop runtime', () => {
+    const { container } = render(<AgentKitSection />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows enabled status, kit version and last sync', async () => {
+    mockDesktop({
+      'agentKit.getStatus': () => ({
+        ok: true,
+        data: { enabled: true, kitVersion: '1.2.0', lastSyncAt: '2026-07-22T00:00:00.000Z' },
+      }),
+    });
+
+    render(<AgentKitSection />);
+
+    expect(await screen.findByText('已启用')).toBeTruthy();
+    expect(screen.getByText(/1\.2\.0/)).toBeTruthy();
+    expect(screen.getByText(/2026-07-22T00:00:00\.000Z/)).toBeTruthy();
+  });
+
+  it('shows pending conflict and update counts', async () => {
+    mockDesktop({
+      'agentKit.getStatus': () => ({
+        ok: true,
+        data: {
+          enabled: true,
+          pendingConflicts: [{ dest: 'a.md', templatePath: 't/a.md', reason: 'target-exists-no-state' }],
+          pendingUpdates: [
+            { dest: 'b.md', templatePath: 't/b.md', oldTemplateHash: 'x', newTemplateHash: 'y' },
+          ],
+        },
+      }),
+    });
+
+    render(<AgentKitSection />);
+
+    expect(await screen.findByText(/1 个文件需要处理冲突/)).toBeTruthy();
+    expect(screen.getByText(/1 个模板有新版可用/)).toBeTruthy();
+  });
+
+  it('toggling the switch calls setEnabled then reloads status', async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, data: { enabled: false } })
+      .mockResolvedValueOnce({ ok: true, data: { enabled: true } });
+    const setEnabled = vi.fn((_input?: unknown) => ({
+      ok: true,
+      data: { enabled: true, conflicts: [], updates: [] },
+    }));
+    mockDesktop({
+      'agentKit.getStatus': () => getStatus(),
+      'agentKit.setEnabled': (input) => setEnabled(input),
+    });
+
+    render(<AgentKitSection />);
+
+    const toggle = await screen.findByRole('switch');
+    fireEvent.click(toggle);
+
+    await screen.findByText('已启用');
+    expect(setEnabled).toHaveBeenCalledWith({ enabled: true });
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('重刷 calls forceSync then reloads status', async () => {
+    const forceSync = vi.fn(() => ({ ok: true, data: { conflicts: [], updates: [] } }));
+    const getStatus = vi.fn(() => ({ ok: true, data: { enabled: true } }));
+    mockDesktop({
+      'agentKit.getStatus': () => getStatus(),
+      'agentKit.forceSync': () => forceSync(),
+    });
+
+    render(<AgentKitSection />);
+
+    const button = await screen.findByRole('button', { name: '重刷 Agent Kit' });
+    fireEvent.click(button);
+
+    await vi.waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
+    expect(forceSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('清理 asks for confirmation before calling clean', async () => {
+    const clean = vi.fn(() => ({ ok: true, data: { cleaned: true } }));
+    const getStatus = vi.fn(() => ({ ok: true, data: { enabled: true } }));
+    mockDesktop({
+      'agentKit.getStatus': () => getStatus(),
+      'agentKit.clean': () => clean(),
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<AgentKitSection />);
+
+    const button = await screen.findByRole('button', { name: '清理 Agent Kit（危险）' });
+    fireEvent.click(button);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(clean).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    fireEvent.click(button);
+
+    await vi.waitFor(() => expect(clean).toHaveBeenCalledTimes(1));
+    confirmSpy.mockRestore();
+  });
+});

--- a/apps/web/src/features/settings/AgentKitSection.test.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.test.tsx
@@ -44,9 +44,9 @@ describe('AgentKitSection', () => {
 
     render(<AgentKitSection />);
 
-    expect(await screen.findByText('已启用')).toBeTruthy();
-    expect(screen.getByText(/1\.2\.0/)).toBeTruthy();
+    expect(await screen.findByText(/1\.2\.0/)).toBeTruthy();
     expect(screen.getByText(/2026-07-22T00:00:00\.000Z/)).toBeTruthy();
+    expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
   });
 
   it('renders a row with an action button per pending conflict and update', async () => {
@@ -128,7 +128,9 @@ describe('AgentKitSection', () => {
     const toggle = await screen.findByRole('switch');
     fireEvent.click(toggle);
 
-    await screen.findByText('已启用');
+    await vi.waitFor(() =>
+      expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true'),
+    );
     expect(setEnabled).toHaveBeenCalledWith({ enabled: true });
     expect(getStatus).toHaveBeenCalledTimes(2);
   });
@@ -143,7 +145,7 @@ describe('AgentKitSection', () => {
 
     render(<AgentKitSection />);
 
-    const button = await screen.findByRole('button', { name: '重刷 Agent Kit' });
+    const button = await screen.findByRole('button', { name: '重刷' });
     fireEvent.click(button);
 
     await vi.waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
@@ -161,7 +163,7 @@ describe('AgentKitSection', () => {
 
     render(<AgentKitSection />);
 
-    const button = await screen.findByRole('button', { name: '清理 Agent Kit' });
+    const button = await screen.findByRole('button', { name: '清理' });
     fireEvent.click(button);
 
     expect(confirmSpy).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/settings/AgentKitSection.test.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.test.tsx
@@ -86,7 +86,7 @@ describe('AgentKitSection', () => {
         },
       })
       .mockResolvedValueOnce({ ok: true, data: baseStatus });
-    const resolveConflict = vi.fn(() => ({ ok: true, data: { dest: 'a.md' } }));
+    const resolveConflict = vi.fn((_input?: unknown) => ({ ok: true, data: { dest: 'a.md' } }));
     mockDesktop({
       'agentKit.getStatus': () => getStatus(),
       'agentKit.resolveConflict': (input) => resolveConflict(input),

--- a/apps/web/src/features/settings/AgentKitSection.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.tsx
@@ -17,6 +17,14 @@ const pendingRowStyle: CSSProperties = {
   gap: 8,
 };
 
+const locationRowStyle: CSSProperties = { display: 'flex', gap: 8, alignItems: 'center' };
+
+const pathStyle: CSSProperties = {
+  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+  fontSize: '0.85em',
+  wordBreak: 'break-all',
+};
+
 export function AgentKitSection() {
   const [bridge] = useState(() => getDesktopAgentKitBridge());
   const [status, setStatus] = useState<AgentKitStatus | null>(null);
@@ -40,11 +48,11 @@ export function AgentKitSection() {
 
   if (!bridge) return null;
 
-  const toggle = async (enabled: boolean) => {
+  const withBusy = async (fn: () => Promise<unknown>) => {
     setBusy(true);
     setError(null);
     try {
-      await bridge.setEnabled({ enabled });
+      await fn();
       await reload();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -53,11 +61,28 @@ export function AgentKitSection() {
     }
   };
 
+  const toggle = (enabled: boolean) => void withBusy(() => bridge.setEnabled({ enabled }));
+  const follow = () => void withBusy(() => bridge.followDataRoot());
+  const pick = () => void withBusy(() => bridge.pickCustomLocation());
+  const forceSync = () => void withBusy(() => bridge.forceSync());
+  const clean = () => {
+    if (
+      !window.confirm('确定要清理 Agent Kit 吗？这会删除本地生成的引导文件与 kansoku-cli 入口。')
+    )
+      return;
+    void withBusy(() => bridge.clean());
+  };
+
   const openConflict = (conflict: PendingConflict) =>
     openModal({
       title: <>处理冲突 · {conflict.dest}</>,
       body: (close) => (
-        <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={reload} close={close} />
+        <AgentKitConflictDialog
+          conflict={conflict}
+          bridge={bridge}
+          onResolved={reload}
+          close={close}
+        />
       ),
     });
 
@@ -68,23 +93,6 @@ export function AgentKitSection() {
         <AgentKitUpdateDialog update={update} bridge={bridge} onResolved={reload} close={close} />
       ),
     });
-
-  const run = async (action: 'forceSync' | 'clean') => {
-    if (action === 'clean' && !window.confirm('确定要清理 Agent Kit 吗？这会删除本地生成的引导文件与 kansoku-cli 入口。')) {
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    try {
-      if (action === 'forceSync') await bridge.forceSync();
-      else await bridge.clean();
-      await reload();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  };
 
   return (
     <section className="settings-conn-section settings-conn-longbridge">
@@ -106,9 +114,39 @@ export function AgentKitSection() {
           ariaLabel="启用 Agent Kit"
           checked={status?.enabled ?? false}
           disabled={busy || !status}
-          onCheckedChange={(checked) => void toggle(checked)}
+          onCheckedChange={(checked) => toggle(checked)}
         />
       </div>
+
+      {status ? (
+        <div className="settings-provider-meta">
+          位置：
+          {status.location.kind === 'follow-data-root'
+            ? `跟随数据目录（${status.dataRoot}）`
+            : status.location.path}
+          {status.resolvedPath === null ? '（未生效）' : null}
+        </div>
+      ) : null}
+
+      {status ? (
+        <div className="settings-cred-actions" style={locationRowStyle}>
+          <Button
+            disabled={busy || status.location.kind === 'follow-data-root' || status.followBlocked}
+            onClick={follow}
+          >
+            跟随数据目录
+          </Button>
+          <Button disabled={busy} onClick={pick}>
+            选择目录…
+          </Button>
+        </div>
+      ) : null}
+
+      {status?.followBlocked ? (
+        <div className="note-block">
+          数据目录是 App 默认位置（Application Support），跟随不可用——请选择一个自定义目录，或先切换数据目录。
+        </div>
+      ) : null}
 
       {status ? (
         <div className="settings-provider-meta">
@@ -132,14 +170,22 @@ export function AgentKitSection() {
         </div>
       ))}
 
-      {error ? <div className="settings-test-result settings-test-result--fail">{error}</div> : null}
+      {status?.enabled && status.resolvedPath ? (
+        <div className="settings-provider-meta" style={pathStyle}>
+          生效路径：{status.resolvedPath}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="settings-test-result settings-test-result--fail">{error}</div>
+      ) : null}
 
       <div className="settings-cred-actions">
-        <Button disabled={busy} onClick={() => void run('forceSync')}>
+        <Button disabled={busy || !status?.resolvedPath} onClick={forceSync}>
           重刷 Agent Kit
         </Button>
-        <Button disabled={busy} onClick={() => void run('clean')}>
-          清理 Agent Kit（危险）
+        <Button disabled={busy} onClick={clean}>
+          清理 Agent Kit
         </Button>
       </div>
     </section>

--- a/apps/web/src/features/settings/AgentKitSection.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
-import { Badge, Button, openModal, Switch } from '@web/ui';
+import { Button, openModal, Switch } from '@web/ui';
 import { AgentKitConflictDialog } from './AgentKitConflictDialog';
 import { AgentKitUpdateDialog } from './AgentKitUpdateDialog';
 import {
@@ -15,15 +15,21 @@ const pendingRowStyle: CSSProperties = {
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: 8,
+  marginTop: 6,
 };
 
-const locationRowStyle: CSSProperties = { display: 'flex', gap: 8, alignItems: 'center' };
-
-const pathStyle: CSSProperties = {
-  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
-  fontSize: '0.85em',
-  wordBreak: 'break-all',
+const actionsBar: CSSProperties = {
+  display: 'flex',
+  gap: 6,
+  marginTop: 10,
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
 };
+
+function locationLabel(status: AgentKitStatus): string {
+  if (status.location.kind === 'custom') return status.location.path;
+  return `跟随数据目录 · ${status.dataRoot}`;
+}
 
 export function AgentKitSection() {
   const [bridge] = useState(() => getDesktopAgentKitBridge());
@@ -94,22 +100,12 @@ export function AgentKitSection() {
       ),
     });
 
+  const canSync = Boolean(status?.enabled && status?.resolvedPath);
+
   return (
     <section className="settings-conn-section settings-conn-longbridge">
       <div className="settings-conn-title">
         <span>Agent Kit</span>
-        {status ? (
-          <Badge tone={status.enabled ? 'accent' : undefined}>
-            {status.enabled ? '已启用' : '已停用'}
-          </Badge>
-        ) : null}
-      </div>
-
-      <div className="note-block">
-        为外部 Claude Code / Codex 打开数据目录时提供 skill 引导 + kansoku-cli 入口
-      </div>
-
-      <div className="settings-cred-actions">
         <Switch
           ariaLabel="启用 Agent Kit"
           checked={status?.enabled ?? false}
@@ -118,74 +114,65 @@ export function AgentKitSection() {
         />
       </div>
 
+      <div className="settings-conn-summary">
+        为外部 Claude Code / Codex 提供 skill 引导 + kansoku-cli 入口
+      </div>
+
       {status ? (
         <div className="settings-provider-meta">
-          位置：
-          {status.location.kind === 'follow-data-root'
-            ? `跟随数据目录（${status.dataRoot}）`
-            : status.location.path}
+          位置：{locationLabel(status)}
           {status.resolvedPath === null ? '（未生效）' : null}
-        </div>
-      ) : null}
-
-      {status ? (
-        <div className="settings-cred-actions" style={locationRowStyle}>
-          <Button
-            disabled={busy || status.location.kind === 'follow-data-root' || status.followBlocked}
-            onClick={follow}
-          >
-            跟随数据目录
-          </Button>
-          <Button disabled={busy} onClick={pick}>
-            选择目录…
-          </Button>
-        </div>
-      ) : null}
-
-      {status?.followBlocked ? (
-        <div className="note-block">
-          数据目录是 App 默认位置（Application Support），跟随不可用——请选择一个自定义目录，或先切换数据目录。
-        </div>
-      ) : null}
-
-      {status ? (
-        <div className="settings-provider-meta">
-          当前 Kit 版本：{status.kitVersion ?? '—'} · 上次同步：{status.lastSyncAt ?? '—'}
         </div>
       ) : (
         <div className="note-block">加载中…</div>
       )}
 
+      {status?.followBlocked ? (
+        <div className="settings-warning-strip">
+          数据目录是 App 默认位置（Application Support），跟随不可用——请选择自定义目录或先切换数据目录。
+        </div>
+      ) : null}
+
+      {status ? (
+        <div className="settings-provider-meta">
+          版本 {status.kitVersion ?? '—'} · 上次同步 {status.lastSyncAt ?? '—'}
+        </div>
+      ) : null}
+
       {status?.pendingConflicts?.map((conflict) => (
         <div key={conflict.dest} style={pendingRowStyle}>
-          <span>⚠ {conflict.dest}</span>
+          <span>⚠ 冲突 · {conflict.dest}</span>
           <Button onClick={() => openConflict(conflict)}>处理</Button>
         </div>
       ))}
 
       {status?.pendingUpdates?.map((update) => (
         <div key={update.dest} style={pendingRowStyle}>
-          <span>ℹ {update.dest}</span>
+          <span>ℹ 更新 · {update.dest}</span>
           <Button onClick={() => openUpdate(update)}>查看</Button>
         </div>
       ))}
-
-      {status?.enabled && status.resolvedPath ? (
-        <div className="settings-provider-meta" style={pathStyle}>
-          生效路径：{status.resolvedPath}
-        </div>
-      ) : null}
 
       {error ? (
         <div className="settings-test-result settings-test-result--fail">{error}</div>
       ) : null}
 
-      <div className="settings-cred-actions">
-        <Button disabled={busy || !status?.resolvedPath} onClick={forceSync}>
-          重刷 Agent Kit
+      <div style={actionsBar}>
+        <Button
+          disabled={busy || status?.location.kind === 'follow-data-root' || status?.followBlocked}
+          onClick={follow}
+        >
+          跟随数据目录
+        </Button>
+        <Button disabled={busy} onClick={pick}>
+          选择目录…
+        </Button>
+        <span style={{ flex: 1 }} />
+        <Button disabled={busy || !canSync} onClick={forceSync}>
+          重刷
         </Button>
         <Button disabled={busy} onClick={clean}>
-          清理 Agent Kit
+          清理
         </Button>
       </div>
     </section>

--- a/apps/web/src/features/settings/AgentKitSection.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Badge, Button, Switch } from '@web/ui';
+import { getDesktopAgentKitBridge, type AgentKitStatus } from './desktopAgentKit';
+
+export function AgentKitSection() {
+  const [bridge] = useState(() => getDesktopAgentKitBridge());
+  const [status, setStatus] = useState<AgentKitStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!bridge) return;
+    try {
+      const next = await bridge.getStatus();
+      setStatus(next);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [bridge]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  if (!bridge) return null;
+
+  const toggle = async (enabled: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await bridge.setEnabled({ enabled });
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const run = async (action: 'forceSync' | 'clean') => {
+    if (action === 'clean' && !window.confirm('确定要清理 Agent Kit 吗？这会删除本地生成的引导文件与 kansoku-cli 入口。')) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      if (action === 'forceSync') await bridge.forceSync();
+      else await bridge.clean();
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const conflictCount = status?.pendingConflicts?.length ?? 0;
+  const updateCount = status?.pendingUpdates?.length ?? 0;
+
+  return (
+    <section className="settings-conn-section settings-conn-longbridge">
+      <div className="settings-conn-title">
+        <span>Agent Kit</span>
+        {status ? (
+          <Badge tone={status.enabled ? 'accent' : undefined}>
+            {status.enabled ? '已启用' : '已停用'}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div className="note-block">
+        为外部 Claude Code / Codex 打开数据目录时提供 skill 引导 + kansoku-cli 入口
+      </div>
+
+      <div className="settings-cred-actions">
+        <Switch
+          ariaLabel="启用 Agent Kit"
+          checked={status?.enabled ?? false}
+          disabled={busy || !status}
+          onCheckedChange={(checked) => void toggle(checked)}
+        />
+      </div>
+
+      {status ? (
+        <div className="settings-provider-meta">
+          当前 Kit 版本：{status.kitVersion ?? '—'} · 上次同步：{status.lastSyncAt ?? '—'}
+        </div>
+      ) : (
+        <div className="note-block">加载中…</div>
+      )}
+
+      {conflictCount > 0 ? (
+        <div className="settings-warning-strip">
+          {conflictCount} 个文件需要处理冲突，待 T7 实现对话框
+        </div>
+      ) : null}
+
+      {updateCount > 0 ? (
+        <div className="settings-test-result settings-test-result--ok">
+          {updateCount} 个模板有新版可用，待 T7 实现对话框
+        </div>
+      ) : null}
+
+      {error ? <div className="settings-test-result settings-test-result--fail">{error}</div> : null}
+
+      <div className="settings-cred-actions">
+        <Button disabled={busy} onClick={() => void run('forceSync')}>
+          重刷 Agent Kit
+        </Button>
+        <Button disabled={busy} onClick={() => void run('clean')}>
+          清理 Agent Kit（危险）
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/settings/AgentKitSection.tsx
+++ b/apps/web/src/features/settings/AgentKitSection.tsx
@@ -1,6 +1,21 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Badge, Button, Switch } from '@web/ui';
-import { getDesktopAgentKitBridge, type AgentKitStatus } from './desktopAgentKit';
+import type { CSSProperties } from 'react';
+import { Badge, Button, openModal, Switch } from '@web/ui';
+import { AgentKitConflictDialog } from './AgentKitConflictDialog';
+import { AgentKitUpdateDialog } from './AgentKitUpdateDialog';
+import {
+  getDesktopAgentKitBridge,
+  type AgentKitStatus,
+  type PendingConflict,
+  type PendingUpdate,
+} from './desktopAgentKit';
+
+const pendingRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+};
 
 export function AgentKitSection() {
   const [bridge] = useState(() => getDesktopAgentKitBridge());
@@ -38,6 +53,22 @@ export function AgentKitSection() {
     }
   };
 
+  const openConflict = (conflict: PendingConflict) =>
+    openModal({
+      title: <>处理冲突 · {conflict.dest}</>,
+      body: (close) => (
+        <AgentKitConflictDialog conflict={conflict} bridge={bridge} onResolved={reload} close={close} />
+      ),
+    });
+
+  const openUpdate = (update: PendingUpdate) =>
+    openModal({
+      title: <>新模板可用 · {update.dest}</>,
+      body: (close) => (
+        <AgentKitUpdateDialog update={update} bridge={bridge} onResolved={reload} close={close} />
+      ),
+    });
+
   const run = async (action: 'forceSync' | 'clean') => {
     if (action === 'clean' && !window.confirm('确定要清理 Agent Kit 吗？这会删除本地生成的引导文件与 kansoku-cli 入口。')) {
       return;
@@ -54,9 +85,6 @@ export function AgentKitSection() {
       setBusy(false);
     }
   };
-
-  const conflictCount = status?.pendingConflicts?.length ?? 0;
-  const updateCount = status?.pendingUpdates?.length ?? 0;
 
   return (
     <section className="settings-conn-section settings-conn-longbridge">
@@ -90,17 +118,19 @@ export function AgentKitSection() {
         <div className="note-block">加载中…</div>
       )}
 
-      {conflictCount > 0 ? (
-        <div className="settings-warning-strip">
-          {conflictCount} 个文件需要处理冲突，待 T7 实现对话框
+      {status?.pendingConflicts?.map((conflict) => (
+        <div key={conflict.dest} style={pendingRowStyle}>
+          <span>⚠ {conflict.dest}</span>
+          <Button onClick={() => openConflict(conflict)}>处理</Button>
         </div>
-      ) : null}
+      ))}
 
-      {updateCount > 0 ? (
-        <div className="settings-test-result settings-test-result--ok">
-          {updateCount} 个模板有新版可用，待 T7 实现对话框
+      {status?.pendingUpdates?.map((update) => (
+        <div key={update.dest} style={pendingRowStyle}>
+          <span>ℹ {update.dest}</span>
+          <Button onClick={() => openUpdate(update)}>查看</Button>
         </div>
-      ) : null}
+      ))}
 
       {error ? <div className="settings-test-result settings-test-result--fail">{error}</div> : null}
 

--- a/apps/web/src/features/settings/AgentKitUpdateDialog.test.tsx
+++ b/apps/web/src/features/settings/AgentKitUpdateDialog.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentKitUpdateDialog } from './AgentKitUpdateDialog';
+import type { DesktopAgentKitBridge } from './desktopAgentKit';
+
+const update = {
+  dest: 'CLAUDE.md',
+  templatePath: 'templates/CLAUDE.md',
+  oldTemplateHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  newTemplateHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+};
+
+function makeBridge(overrides: Partial<DesktopAgentKitBridge> = {}): DesktopAgentKitBridge {
+  return {
+    getStatus: vi.fn(),
+    setEnabled: vi.fn(),
+    forceSync: vi.fn(),
+    resolveConflict: vi.fn(),
+    applyUpdate: vi.fn(async () => ({ dest: update.dest })),
+    clean: vi.fn(),
+    ...overrides,
+  } as DesktopAgentKitBridge;
+}
+
+describe('AgentKitUpdateDialog', () => {
+  afterEach(() => cleanup());
+
+  it('renders both actions and the hash prefixes', () => {
+    render(
+      <AgentKitUpdateDialog update={update} bridge={makeBridge()} onResolved={vi.fn()} close={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/使用新模板覆盖/)).toBeTruthy();
+    expect(screen.getByText('继续保留')).toBeTruthy();
+    expect(screen.getByText(/a{12}/)).toBeTruthy();
+    expect(screen.getByText(/b{12}/)).toBeTruthy();
+  });
+
+  it('继续保留 closes without calling the bridge', () => {
+    const bridge = makeBridge();
+    const close = vi.fn();
+    render(<AgentKitUpdateDialog update={update} bridge={bridge} onResolved={vi.fn()} close={close} />);
+
+    fireEvent.click(screen.getByText('继续保留'));
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(bridge.applyUpdate).not.toHaveBeenCalled();
+  });
+
+  it('applies the update, then calls onResolved and close', async () => {
+    const bridge = makeBridge();
+    const onResolved = vi.fn();
+    const close = vi.fn();
+    render(
+      <AgentKitUpdateDialog update={update} bridge={bridge} onResolved={onResolved} close={close} />,
+    );
+
+    fireEvent.click(screen.getByText(/使用新模板覆盖/));
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    expect(bridge.applyUpdate).toHaveBeenCalledWith({ dest: update.dest });
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an inline error and keeps the modal open on failure', async () => {
+    const bridge = makeBridge({
+      applyUpdate: vi.fn(async () => {
+        throw new Error('apply failed');
+      }),
+    });
+    const onResolved = vi.fn();
+    const close = vi.fn();
+    render(
+      <AgentKitUpdateDialog update={update} bridge={bridge} onResolved={onResolved} close={close} />,
+    );
+
+    fireEvent.click(screen.getByText(/使用新模板覆盖/));
+
+    expect(await screen.findByText('apply failed')).toBeTruthy();
+    expect(close).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/settings/AgentKitUpdateDialog.tsx
+++ b/apps/web/src/features/settings/AgentKitUpdateDialog.tsx
@@ -47,7 +47,7 @@ export function AgentKitUpdateDialog({
           继续保留
         </Button>
         <Button accent disabled={busy} onClick={() => void apply()}>
-          使用新模板覆盖（备份当前为 .bak）
+          使用新模板覆盖（备份当前为 .bak.&lt;旧模板 hash&gt;）
         </Button>
       </div>
     </div>

--- a/apps/web/src/features/settings/AgentKitUpdateDialog.tsx
+++ b/apps/web/src/features/settings/AgentKitUpdateDialog.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Button } from '@web/ui';
+import type { PendingUpdate } from '@kansoku/core/contract/agentKit';
+import type { DesktopAgentKitBridge } from './desktopAgentKit';
+
+export function AgentKitUpdateDialog({
+  update,
+  bridge,
+  onResolved,
+  close,
+}: {
+  update: PendingUpdate;
+  bridge: DesktopAgentKitBridge;
+  onResolved: () => void;
+  close: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apply = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await bridge.applyUpdate({ dest: update.dest });
+      onResolved();
+      close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-reset-confirm">
+      <p>{update.dest} 有新版本的模板可用。</p>
+      <div className="settings-provider-meta">
+        旧模板 hash：{update.oldTemplateHash.slice(0, 12)}
+        <br />
+        新模板 hash：{update.newTemplateHash.slice(0, 12)}
+      </div>
+      {error ? (
+        <div className="settings-test-result settings-test-result--fail">{error}</div>
+      ) : null}
+      <div className="settings-cred-actions">
+        <Button disabled={busy} onClick={close}>
+          继续保留
+        </Button>
+        <Button accent disabled={busy} onClick={() => void apply()}>
+          使用新模板覆盖（备份当前为 .bak）
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/SettingsPage.tsx
+++ b/apps/web/src/features/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { client } from '@web/lib/client';
 import { navigate } from '@web/lib/router';
 import { Button, Card, ErrorBox, SectionTitle } from '@web/ui';
 import { useTitle } from '@web/lib/useTitle';
+import { AgentKitSection } from './AgentKitSection';
 import { DataRootSection } from './DataRootSection';
 import { DiagnosticsSection } from './DiagnosticsSection';
 import { LicenseSection } from './LicenseSection';
@@ -100,6 +101,7 @@ function SettingsWorkspace({
             </div>
             <LongbridgeSection />
             <DataRootSection />
+            <AgentKitSection />
             <DiagnosticsSection />
           </Card>
         </div>

--- a/apps/web/src/features/settings/desktopAgentKit.test.ts
+++ b/apps/web/src/features/settings/desktopAgentKit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getDesktopAgentKitBridge } from './desktopAgentKit';
+
+describe('getDesktopAgentKitBridge', () => {
+  it('returns null outside desktop', () => {
+    expect(getDesktopAgentKitBridge({})).toBeNull();
+  });
+
+  it('invokes each channel and unwraps a successful envelope', async () => {
+    const responses: Record<string, unknown> = {
+      'agentKit.getStatus': { ok: true, data: { enabled: true } },
+      'agentKit.setEnabled': { ok: true, data: { enabled: false } },
+      'agentKit.forceSync': { ok: true, data: { conflicts: [], updates: [] } },
+      'agentKit.resolveConflict': { ok: true, data: { dest: 'CLAUDE.md' } },
+      'agentKit.applyUpdate': { ok: true, data: { dest: 'CLAUDE.md' } },
+      'agentKit.clean': { ok: true, data: { cleaned: true } },
+    };
+    const invoke = vi.fn(async (channel: string) => {
+      if (!(channel in responses)) throw new Error(`unexpected channel ${channel}`);
+      return responses[channel];
+    });
+    const bridge = getDesktopAgentKitBridge({ desktop: { rpc: { invoke } } });
+    expect(bridge).not.toBeNull();
+
+    expect(await bridge?.getStatus()).toEqual({ enabled: true });
+    expect(invoke).toHaveBeenCalledWith('agentKit.getStatus');
+
+    expect(await bridge?.setEnabled({ enabled: false })).toEqual({ enabled: false });
+    expect(invoke).toHaveBeenCalledWith('agentKit.setEnabled', { enabled: false });
+
+    expect(await bridge?.forceSync()).toEqual({ conflicts: [], updates: [] });
+    expect(invoke).toHaveBeenCalledWith('agentKit.forceSync');
+
+    expect(
+      await bridge?.resolveConflict({ dest: 'CLAUDE.md', choice: 'use-template' }),
+    ).toEqual({ dest: 'CLAUDE.md' });
+    expect(invoke).toHaveBeenCalledWith('agentKit.resolveConflict', {
+      dest: 'CLAUDE.md',
+      choice: 'use-template',
+    });
+
+    expect(await bridge?.applyUpdate({ dest: 'CLAUDE.md' })).toEqual({ dest: 'CLAUDE.md' });
+    expect(invoke).toHaveBeenCalledWith('agentKit.applyUpdate', { dest: 'CLAUDE.md' });
+
+    expect(await bridge?.clean()).toEqual({ cleaned: true });
+    expect(invoke).toHaveBeenCalledWith('agentKit.clean');
+  });
+
+  it('throws when the envelope reports failure', async () => {
+    const invoke = vi.fn(async () => ({ ok: false, error: 'boom' }));
+    const bridge = getDesktopAgentKitBridge({ desktop: { rpc: { invoke } } });
+
+    await expect(bridge?.getStatus()).rejects.toThrow('boom');
+  });
+});

--- a/apps/web/src/features/settings/desktopAgentKit.ts
+++ b/apps/web/src/features/settings/desktopAgentKit.ts
@@ -8,6 +8,7 @@ import type { TransportEnvelope } from '@kansoku/core/contract/index';
 import { getShellRpc } from '../desktop/shellRpc';
 
 export type {
+  AgentKitLocation,
   AgentKitSetEnabledResult,
   AgentKitStatus,
   AgentKitSyncResult,
@@ -48,5 +49,11 @@ export function getDesktopAgentKitBridge(
       ),
     clean: async () =>
       unwrap((await rpc.invoke('agentKit.clean')) as TransportEnvelope<{ cleaned: true }>),
+    followDataRoot: async () =>
+      unwrap((await rpc.invoke('agentKit.followDataRoot')) as TransportEnvelope<AgentKitStatus>),
+    pickCustomLocation: async () =>
+      unwrap(
+        (await rpc.invoke('agentKit.pickCustomLocation')) as TransportEnvelope<AgentKitStatus>,
+      ),
   };
 }

--- a/apps/web/src/features/settings/desktopAgentKit.ts
+++ b/apps/web/src/features/settings/desktopAgentKit.ts
@@ -1,0 +1,52 @@
+import type {
+  AgentKitApi,
+  AgentKitSetEnabledResult,
+  AgentKitStatus,
+  AgentKitSyncResult,
+} from '@kansoku/core/contract/agentKit';
+import type { TransportEnvelope } from '@kansoku/core/contract/index';
+import { getShellRpc } from '../desktop/shellRpc';
+
+export type {
+  AgentKitSetEnabledResult,
+  AgentKitStatus,
+  AgentKitSyncResult,
+  PendingConflict,
+  PendingUpdate,
+} from '@kansoku/core/contract/agentKit';
+
+export type DesktopAgentKitBridge = AgentKitApi;
+
+function unwrap<T>(envelope: TransportEnvelope<T>): T {
+  if (!envelope.ok) throw new Error(envelope.error);
+  return envelope.data;
+}
+
+export function getDesktopAgentKitBridge(
+  win: unknown = typeof window === 'undefined' ? undefined : window,
+): DesktopAgentKitBridge | null {
+  const rpc = getShellRpc(win);
+  if (!rpc) return null;
+  return {
+    getStatus: async () =>
+      unwrap((await rpc.invoke('agentKit.getStatus')) as TransportEnvelope<AgentKitStatus>),
+    setEnabled: async (input) =>
+      unwrap(
+        (await rpc.invoke('agentKit.setEnabled', input)) as TransportEnvelope<AgentKitSetEnabledResult>,
+      ),
+    forceSync: async () =>
+      unwrap((await rpc.invoke('agentKit.forceSync')) as TransportEnvelope<AgentKitSyncResult>),
+    resolveConflict: async (input) =>
+      unwrap(
+        (await rpc.invoke('agentKit.resolveConflict', input)) as TransportEnvelope<{
+          dest: string;
+        }>,
+      ),
+    applyUpdate: async (input) =>
+      unwrap(
+        (await rpc.invoke('agentKit.applyUpdate', input)) as TransportEnvelope<{ dest: string }>,
+      ),
+    clean: async () =>
+      unwrap((await rpc.invoke('agentKit.clean')) as TransportEnvelope<{ cleaned: true }>),
+  };
+}

--- a/packages/core/src/ai/settings/credentialStore.ts
+++ b/packages/core/src/ai/settings/credentialStore.ts
@@ -7,7 +7,8 @@ import type { Db } from '../../db/index.js';
 import { providerCredentials } from '../../db/schema.js';
 import type { SecretBox } from './secretBox.js';
 
-export const LICENSE_PROVIDER_KEY = 'kansoku-license';
+import { LICENSE_PROVIDER_KEY } from '../../license/constants.js';
+export { LICENSE_PROVIDER_KEY };
 
 const CODEX_PROVIDER = 'openai-codex';
 

--- a/packages/core/src/contract/agentKit.ts
+++ b/packages/core/src/contract/agentKit.ts
@@ -13,8 +13,16 @@ export type PendingUpdate = {
   newTemplateHash: string;
 };
 
+export type AgentKitLocation =
+  | { kind: 'follow-data-root' }
+  | { kind: 'custom'; path: string };
+
 export type AgentKitStatus = {
   enabled: boolean;
+  location: AgentKitLocation;
+  resolvedPath: string | null;
+  followBlocked: boolean;
+  dataRoot: string;
   lastSyncAt?: string;
   kitVersion?: string;
   pendingConflicts?: PendingConflict[];
@@ -40,6 +48,8 @@ export interface AgentKitApi {
   }): Promise<{ dest: string }>;
   applyUpdate(input: { dest: string }): Promise<{ dest: string }>;
   clean(): Promise<{ cleaned: true }>;
+  followDataRoot(): Promise<AgentKitStatus>;
+  pickCustomLocation(): Promise<AgentKitStatus>;
 }
 
 export const agentKitRoutes = defineRoutes<AgentKitApi>('agentKit', {
@@ -49,4 +59,6 @@ export const agentKitRoutes = defineRoutes<AgentKitApi>('agentKit', {
   resolveConflict: { method: 'POST', path: '/conflicts/resolve' },
   applyUpdate: { method: 'POST', path: '/updates/apply' },
   clean: { method: 'POST', path: '/clean' },
+  followDataRoot: { method: 'POST', path: '/location/follow' },
+  pickCustomLocation: { method: 'POST', path: '/location/pick' },
 });

--- a/packages/core/src/contract/agentKit.ts
+++ b/packages/core/src/contract/agentKit.ts
@@ -1,0 +1,52 @@
+import { defineRoutes } from './defineRoutes.js';
+
+export type PendingConflict = {
+  dest: string;
+  templatePath: string;
+  reason: 'target-exists-no-state';
+};
+
+export type PendingUpdate = {
+  dest: string;
+  templatePath: string;
+  oldTemplateHash: string;
+  newTemplateHash: string;
+};
+
+export type AgentKitStatus = {
+  enabled: boolean;
+  lastSyncAt?: string;
+  kitVersion?: string;
+  pendingConflicts?: PendingConflict[];
+  pendingUpdates?: PendingUpdate[];
+};
+
+export type AgentKitSyncResult = {
+  conflicts: PendingConflict[];
+  updates: PendingUpdate[];
+};
+
+export type AgentKitSetEnabledResult =
+  | { enabled: false }
+  | ({ enabled: true } & AgentKitSyncResult);
+
+export interface AgentKitApi {
+  getStatus(): Promise<AgentKitStatus>;
+  setEnabled(input: { enabled: boolean }): Promise<AgentKitSetEnabledResult>;
+  forceSync(): Promise<AgentKitSyncResult>;
+  resolveConflict(input: {
+    dest: string;
+    choice: 'use-template' | 'keep-original';
+  }): Promise<{ dest: string }>;
+  applyUpdate(input: { dest: string }): Promise<{ dest: string }>;
+  clean(): Promise<{ cleaned: true }>;
+}
+
+export const agentKitRoutes = defineRoutes<AgentKitApi>('agentKit', {
+  getStatus: { method: 'GET', path: '/' },
+  setEnabled: { method: 'PUT', path: '/enabled' },
+  forceSync: { method: 'POST', path: '/force-sync' },
+  resolveConflict: { method: 'POST', path: '/conflicts/resolve' },
+  applyUpdate: { method: 'POST', path: '/updates/apply' },
+  clean: { method: 'POST', path: '/clean' },
+});

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,3 +1,4 @@
+import { agentKitRoutes, type AgentKitApi } from './agentKit.js';
 import { annotationsRoutes, type AnnotationsApi } from './annotations.js';
 import { assistantRoutes, type AssistantApi } from './assistant.js';
 import { capabilitiesRoutes, type CapabilitiesApi } from './capabilities.js';
@@ -19,6 +20,7 @@ export interface AppApi {
   charts: ChartsApi;
   chat: ChatApi;
   symbols: SymbolsApi;
+  agentKit: AgentKitApi;
   annotations: AnnotationsApi;
   positions: PositionsApi;
   research: ResearchApi;
@@ -36,6 +38,7 @@ export const allRoutes = {
   charts: chartsRoutes,
   chat: chatRoutes,
   symbols: symbolsRoutes,
+  agentKit: agentKitRoutes,
   annotations: annotationsRoutes,
   positions: positionsRoutes,
   research: researchRoutes,
@@ -47,6 +50,7 @@ export const allRoutes = {
   license: licenseRoutes,
 };
 
+export * from './agentKit.js';
 export * from './annotations.js';
 export * from './assistant.js';
 export * from './capabilities.js';

--- a/packages/core/src/license/constants.ts
+++ b/packages/core/src/license/constants.ts
@@ -1,0 +1,1 @@
+export const LICENSE_PROVIDER_KEY = 'kansoku-license';

--- a/packages/core/src/license/licenseState.ts
+++ b/packages/core/src/license/licenseState.ts
@@ -1,6 +1,6 @@
 import { hostname as osHostname } from "node:os";
 import type { Db } from "../db/index.js";
-import type { SecretBox } from "../ai/settings/secretBox.js";
+import type { SecretBox } from "@kansoku/pro-api";
 import { createDodoClient, type DodoClient } from "./dodoClient.js";
 import { createLicenseStore, type LicenseRecord, type LicenseStore } from "./licenseStore.js";
 

--- a/packages/core/src/license/licenseStore.ts
+++ b/packages/core/src/license/licenseStore.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
 import type { Db } from "../db/index.js";
 import { providerCredentials } from "../db/schema.js";
-import { LICENSE_PROVIDER_KEY } from "../ai/settings/credentialStore.js";
-import type { SecretBox } from "../ai/settings/secretBox.js";
+import type { SecretBox } from "@kansoku/pro-api";
+import { LICENSE_PROVIDER_KEY } from "./constants.js";
 
 const LICENSE_PROVIDER = LICENSE_PROVIDER_KEY;
 

--- a/packages/core/src/marketdata/events.ts
+++ b/packages/core/src/marketdata/events.ts
@@ -1,6 +1,4 @@
 import type { IntradayEventRisk, MacroEventItem } from '@kansoku/shared/types';
-import { filterMacroForSymbol } from '../ai/personas/eventFilter.js';
-import { activeSettingsRevision } from '../ai/settings/settingsStore.js';
 import { getProvider } from './registry.js';
 import { easternDate } from './session.js';
 import { marketOf, type Market } from '../symbols/symbol.utils.js';
@@ -62,12 +60,20 @@ async function relevantMacro(
 ): Promise<MacroEventItem[]> {
   const upcoming = macro.filter((m) => Date.parse(m.ts) > now.getTime());
   if (!upcoming.length) return upcoming;
-  const fingerprint = `${activeSettingsRevision()}|${upcoming.map((m) => `${m.ts}|${m.title}`).join('\n')}`;
-  const hit = relevanceCache.get(symbol);
-  if (hit && hit.fingerprint === fingerprint && Date.now() - hit.at < MACRO_TTL_MS) return hit.val;
-  const val = await filterMacroForSymbol(symbol, upcoming).catch(() => upcoming);
-  relevanceCache.set(symbol, { at: Date.now(), fingerprint, val });
-  return val;
+  try {
+    const [{ activeSettingsRevision }, { filterMacroForSymbol }] = await Promise.all([
+      import('../ai/settings/settingsStore.js'),
+      import('../ai/personas/eventFilter.js'),
+    ]);
+    const fingerprint = `${activeSettingsRevision()}|${upcoming.map((m) => `${m.ts}|${m.title}`).join('\n')}`;
+    const hit = relevanceCache.get(symbol);
+    if (hit && hit.fingerprint === fingerprint && Date.now() - hit.at < MACRO_TTL_MS) return hit.val;
+    const val = await filterMacroForSymbol(symbol, upcoming).catch(() => upcoming);
+    relevanceCache.set(symbol, { at: Date.now(), fingerprint, val });
+    return val;
+  } catch {
+    return upcoming;
+  }
 }
 
 export async function getEventRisk(

--- a/packages/core/src/platform/chartUrl.ts
+++ b/packages/core/src/platform/chartUrl.ts
@@ -4,3 +4,7 @@ import { BASE_URL } from './env.js';
 export function chartUrl(doc: ChartUrlDoc): string {
   return `${BASE_URL}${chartTargetPath(doc)}`;
 }
+
+export function chartDeepLink(doc: ChartUrlDoc): string {
+  return `kansoku://route${chartTargetPath(doc)}`;
+}

--- a/packages/core/test/chartUrl.test.ts
+++ b/packages/core/test/chartUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { chartDeepLink } from '../src/platform/chartUrl.js';
+import type { ChartUrlDoc } from '@kansoku/shared/chartUrl';
+
+function doc(overrides: Partial<ChartUrlDoc>): ChartUrlDoc {
+  return {
+    id: '2026-07-02-mrvl-intraday',
+    type: 'intraday',
+    symbol: 'MRVL.US',
+    created_at: '2026-07-02T13:30:00Z',
+    ...overrides,
+  };
+}
+
+describe('chartDeepLink', () => {
+  it('wraps the symbol analysis path in the kansoku:// route scheme', () => {
+    expect(chartDeepLink(doc({ type: 'intraday' }))).toBe(
+      'kansoku://route/symbol/MRVL.US?analysis=2026-07-02-mrvl-intraday',
+    );
+  });
+
+  it('wraps the home date path in the kansoku:// route scheme', () => {
+    expect(chartDeepLink(doc({ type: 'flow', symbol: null, id: '2026-07-02-flow' }))).toBe(
+      'kansoku://route/?date=2026-07-02',
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
+      tsdown:
+        specifier: ^0.22.13
+        version: 0.22.13(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -464,7 +467,7 @@ importers:
         version: 5.2.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -1164,11 +1167,17 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -1757,6 +1766,9 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
   '@peculiar/asn1-schema@2.8.0':
     resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
 
@@ -1807,6 +1819,9 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -1849,8 +1864,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.1.5':
     resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1861,8 +1888,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.1.5':
     resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1873,8 +1912,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1887,8 +1939,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1901,8 +1967,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1915,8 +1995,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1926,14 +2019,31 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2677,6 +2787,131 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
 
+  '@yuku-codegen/binding-darwin-arm64@0.7.3':
+    resolution: {integrity: sha512-hbssEr7iLNCWWdUbEt8cuOjUQ9loI+U/BVmdhNQ4CV1wAFGvWDO3niK9JD2WwTC9iib7E498qgZ3L/xJnoSb3A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-darwin-x64@0.7.3':
+    resolution: {integrity: sha512-WqwST3vVcNBTd1zaT1vP6pU8NkjJlLWN37Kqomc2c6TG9eky6sbAfHIhZEjSSyqFrMqsAt3mIu0jQZAODi401g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-freebsd-x64@0.7.3':
+    resolution: {integrity: sha512-mCci4UPkZXYflXuHnPGl5sDsotBPLaBryFylDwZcqposktmumoOBIKp2gpzEmxQL/XlGdVWksmpYw9IRY43FNQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.3':
+    resolution: {integrity: sha512-F1QIaRH5SeahrYjZVrVvIb5nHCZQMF7+YWAy6yTJh0Y2r2wLgqOQuhbOWcoKk+AyBiTOO2nAsFHNpVqRq2GjGw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm-musl@0.7.3':
+    resolution: {integrity: sha512-JvkWNmN8MFbboX/5grRsAldGaB8ArRFgAaUYfQoohsqcuJZee8SLtc6itvwuntPbN9MGStn4GzdWk2lmSURqbA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.3':
+    resolution: {integrity: sha512-DUnMTE/HCA7j1BAipWclGZCYfLZ/4SV5lldmV2kDmVMIywcw4PhtQ4Rfd/tO1K82JkjhQ+4a8XApcOIksOacnQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.3':
+    resolution: {integrity: sha512-pNnXMnm9dlqd3V8C7nHaXgZnMLwP/CyM8B4mSAnkqVlhj2t3b8CMjesEV85SCbFlagzJk8FapfSghfxcXKuBow==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.3':
+    resolution: {integrity: sha512-o5GRppYvYvPl4UJbgRSZpXXDh6rOWQzX0yLB+tDzv31T7mOuLitU6zgQZxzw5rwhPJDffCt/AVKMbtizEo+UtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-x64-musl@0.7.3':
+    resolution: {integrity: sha512-GdiyLD1bM3lhTUeGkA9ZZLjqU+xt5uVihgPm0e6TdBjCi6DMZORWe02oDlRbn9OZaV7AZosngXAq2jLk3TrBEw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-win32-arm64@0.7.3':
+    resolution: {integrity: sha512-uQrxQDBQFIAUgHJIxcB/FAAUk0Wkyj3xGpHrp/C258nXnCTAH0KDaqyK5RN/TCkVYrpH+uCl+rGnwDLSGnPBkQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-codegen/binding-win32-x64@0.7.3':
+    resolution: {integrity: sha512-UoF7tqMnVMUmIXPgDjFLhRezea6HaypwLDWNenCFxfJCzQNEa41lcHpxq1AN2Xl6GLzIDfAb+lQDi/O+zPCfyg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-parser/binding-darwin-arm64@0.7.3':
+    resolution: {integrity: sha512-JcFQSNEnjtyHQRjXO0G5rQt5xHq5MR+9nHqh+wt5MP30XIiccUYlcMIa3s7CBmj8E8WPGZC08k7LNGrA1OISTA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.7.3':
+    resolution: {integrity: sha512-U0kNeI3VygP/+8sTOLTeLTjUyTYZfl9Wuq6xVKWPXHb2K7oI0sm8JXJ5xlhAbkUDQRi0N6yK5TKxS0sQT5M6UQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.7.3':
+    resolution: {integrity: sha512-Xc08FQTvxovy6pX+Co9fgv3N1H0OpLpph/ClbwnJkcdphY3kzN2GgIfir35kpPp8mOzlQgtAVQdeDyAYyjwx4w==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.7.3':
+    resolution: {integrity: sha512-6bHeDiUd+0bmoJJ5wZVG+PcJkXQUdjy/AzHsOVcOSUtHtRTX2H3Z5RIHyPAh5OveLtT4RHyqaO3fEQGnHGX5/Q==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.7.3':
+    resolution: {integrity: sha512-trGERNLJGvXkkyvdWBKspTOBATd4lcmpPFPcy5HI5kC3rC3ZMHQDJ356OMSVUsR2NQnl++F0ZTZQucao9hrbeQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.3':
+    resolution: {integrity: sha512-p1ELmzhqAX7SFUvH/tR5zSb8NsWZQ8ulw7PqatfXNmJMy34bkivtL0z2jPpVoMJXf5o2+TwBN29Z31CLL0wvkA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.7.3':
+    resolution: {integrity: sha512-dZ79SrJ002ZXfBDmpQ47SF+06Q5bGOjFeoSK8xO97ter/bjLBgxSO4d7i9hhf+uj4xkrTPc/OFNVaeBAF3L4dA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.7.3':
+    resolution: {integrity: sha512-LjT64hVGWWbOmOYS+Fd8qScgyRxgUbudhFJbw8aeUVnhiNR1np36KnE0VFWrJeu7rTdNxuzVyV5o9JLqhBDTVQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.7.3':
+    resolution: {integrity: sha512-5Nw3v5BqYbOi0ZdV+SImgVYa0KDBVAY/ZNPilTsJJU4phqa2cqEW4+aMgyieE/4bqpojt/B931kM+7pipazP9g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.7.3':
+    resolution: {integrity: sha512-lFYXgHiq8tJKa6/e1/q8Su+IJVV4/CjoXbIJ7/GdPXPp9Hx0gh/8HqmGSsrwlY2w8/ohBcar9wxjm1rQ8D16bg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.7.3':
+    resolution: {integrity: sha512-wy/fs4OrHBhKW8LDyZJRMyMQ3QOfbSQDp0WtMbtzWCVui/vTQEUJMGnwvRCppjchS/qIQfbWzIw/HSjogJqZFA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.7.3':
+    resolution: {integrity: sha512-ezarjq3dcl8Nx3iJ9VeAc7vhzvHyRoSvr7bLX76T+ljRq73IbZ11X2RFCblfK6YxW2DsjkzU6MPnr3JWDYqYYQ==}
+
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2728,6 +2963,10 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -3565,6 +3804,15 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -4176,6 +4424,10 @@ packages:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
 
@@ -4312,6 +4564,9 @@ packages:
     resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
     engines: {node: '>=16.9.0'}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -4364,6 +4619,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  import-without-cache@0.4.0:
+    resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -5243,6 +5502,10 @@ packages:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
@@ -5515,6 +5778,9 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5721,8 +5987,32 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown-plugin-dts@0.27.12:
+    resolution: {integrity: sha512-DJg5ELVEdLAVhirvtak7GS4nbNvBzLNAtYL1M8hLghDURBFKU2MwEH6ncHibYs6khq1NaRQ97iFMiHvzw+WoSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@typescript/native-preview': '*'
+      '@volar/typescript': ~2.4.0
+      rolldown: ^1.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
+      vue-tsc: ~3.2.0 || ~3.3.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      '@volar/typescript':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -6158,6 +6448,40 @@ packages:
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
+  tsdown@0.22.13:
+    resolution: {integrity: sha512-XaYFhtiKRUvTpXv/YAehsHdbEb3LN/iMlzjSINbjlaATtXN2zVPKox2STKhcyFPlh++8Zg7suNN27E679IfAUA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.13
+      '@tsdown/exe': 0.22.13
+      '@vitejs/devtools': '*'
+      publint: ^0.3.8
+      tsx: '*'
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -6232,6 +6556,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -6381,6 +6708,10 @@ packages:
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
+
+  verkit@0.1.2:
+    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
+    engines: {node: '>=18.12.0'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -6724,6 +7055,15 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  yuku-ast@0.7.3:
+    resolution: {integrity: sha512-occyAXtcU4hcl5UPEclWwLqz4J1ZAV8Us4LllmTqAe1YjL5aMbh3GCpzHt6O0sOF+dwBI3BZAcFQqbyX1RiaWg==}
+
+  yuku-codegen@0.7.3:
+    resolution: {integrity: sha512-hhyJW0TIEwm4kex8XVCS4CZIXHS/3TWWNUum+95Ji5/4W+iaLfUnvwSxJwyNfTzS8cxmd1np+EZ4b8ObLguKEA==}
+
+  yuku-parser@0.7.3:
+    resolution: {integrity: sha512-5kZ7HR+W+OsNpVtZ9LHruQsgmcoJl4TETrffPq2GbliThsFiy+zHzbMLmSxQJrokzyJqfJ/TPfFkdUDOodJCgA==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -7587,12 +7927,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8086,6 +8437,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/eslint-plugin-next@16.2.10':
     dependencies:
       fast-glob: 3.3.1
@@ -8115,6 +8473,8 @@ snapshots:
   '@ota-meshi/ast-token-store@0.3.0': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@oxc-project/types@0.140.0': {}
 
   '@peculiar/asn1-schema@2.8.0':
     dependencies:
@@ -8170,6 +8530,10 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
+
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -8204,37 +8568,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.2.0':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.2.0':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -8244,10 +8644,23 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
     optional: true
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
@@ -8258,6 +8671,16 @@ snapshots:
     optionalDependencies:
       '@babel/runtime': 7.29.7
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 8.0.1
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+    optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -8977,6 +9400,14 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      babel-plugin-react-compiler: 1.0.0
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -9022,6 +9453,74 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  '@yuku-codegen/binding-darwin-arm64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-x64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-freebsd-x64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-win32-arm64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-win32-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-arm64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.7.3':
+    optional: true
+
+  '@yuku-toolchain/types@0.7.3': {}
+
   abbrev@4.0.0: {}
 
   abbrev@5.0.0: {}
@@ -9063,6 +9562,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  ansis@4.3.1: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -9954,6 +10455,8 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dts-resolver@3.0.0: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -10816,6 +11319,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   git-hooks-list@4.2.1: {}
 
   github-from-package@0.0.0: {}
@@ -11039,6 +11546,8 @@ snapshots:
 
   hono@4.12.30: {}
 
+  hookable@6.1.1: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -11089,6 +11598,8 @@ snapshots:
   immer@11.1.11: {}
 
   import-meta-resolve@4.2.0: {}
+
+  import-without-cache@0.4.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -12139,6 +12650,8 @@ snapshots:
 
   obug@2.1.3: {}
 
+  obug@2.1.4: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -12418,6 +12931,8 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  quansync@1.0.0: {}
+
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
@@ -12674,6 +13189,20 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown-plugin-dts@0.27.12(rolldown@1.2.0)(typescript@7.0.2):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.0
+      yuku-ast: 0.7.3
+      yuku-codegen: 0.7.3
+      yuku-parser: 0.7.3
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -12694,6 +13223,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.0:
+    dependencies:
+      '@oxc-project/types': 0.140.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
 
   roughjs@4.6.6:
     dependencies:
@@ -13230,6 +13780,32 @@ snapshots:
 
   ts-pattern@5.9.0: {}
 
+  tsdown@0.22.13(tsx@4.23.1)(typescript@7.0.2):
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+      rolldown-plugin-dts: 0.27.12(rolldown@1.2.0)(typescript@7.0.2)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.1.2
+    optionalDependencies:
+      tsx: 4.23.1
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
+
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
@@ -13338,6 +13914,11 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
 
   uncrypto@0.1.3: {}
 
@@ -13468,6 +14049,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
+
+  verkit@0.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -13783,6 +14366,43 @@ snapshots:
       '@speed-highlight/core': 1.2.17
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  yuku-ast@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+
+  yuku-codegen@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+    optionalDependencies:
+      '@yuku-codegen/binding-darwin-arm64': 0.7.3
+      '@yuku-codegen/binding-darwin-x64': 0.7.3
+      '@yuku-codegen/binding-freebsd-x64': 0.7.3
+      '@yuku-codegen/binding-linux-arm-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-arm-musl': 0.7.3
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-arm64-musl': 0.7.3
+      '@yuku-codegen/binding-linux-x64-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-x64-musl': 0.7.3
+      '@yuku-codegen/binding-win32-arm64': 0.7.3
+      '@yuku-codegen/binding-win32-x64': 0.7.3
+
+  yuku-parser@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+      yuku-ast: 0.7.3
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.7.3
+      '@yuku-parser/binding-darwin-x64': 0.7.3
+      '@yuku-parser/binding-freebsd-x64': 0.7.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.7.3
+      '@yuku-parser/binding-linux-arm-musl': 0.7.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.7.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.7.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.7.3
+      '@yuku-parser/binding-linux-x64-musl': 0.7.3
+      '@yuku-parser/binding-win32-arm64': 0.7.3
+      '@yuku-parser/binding-win32-x64': 0.7.3
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       electron-window-state:
         specifier: 5.0.3
         version: 5.0.3
+      esbuild:
+        specifier: ^0.24.2
+        version: 0.24.2
       hono:
         specifier: 4.12.30
         version: 4.12.30
@@ -113,10 +116,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/license-worker:
     devDependencies:
@@ -1176,16 +1179,34 @@ packages:
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -1194,16 +1215,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -1212,10 +1251,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -1224,10 +1275,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -1236,10 +1299,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -1248,10 +1323,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -1260,10 +1347,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -1272,16 +1371,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -1290,10 +1407,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -1308,11 +1437,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
@@ -1320,10 +1461,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -3711,6 +3864,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -7606,64 +7764,127 @@ snapshots:
 
   '@emotion/hash@0.9.2': {}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -7672,13 +7893,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -8983,6 +9216,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -10182,6 +10423,34 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -13536,6 +13805,21 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
+  vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
+      esbuild: 0.24.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
   vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -13554,6 +13838,35 @@ snapshots:
   vitefu@1.1.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 26.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: 5.0.3
         version: 5.0.3
       esbuild:
-        specifier: ^0.24.2
-        version: 0.24.2
+        specifier: ^0.28.0
+        version: 0.28.1
       hono:
         specifier: 4.12.30
         version: 4.12.30
@@ -116,10 +116,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/license-worker:
     devDependencies:
@@ -1179,34 +1179,16 @@ packages:
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.24.2':
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.24.2':
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -1215,34 +1197,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.24.2':
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.24.2':
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.2':
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -1251,22 +1215,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.2':
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -1275,22 +1227,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.24.2':
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.2':
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -1299,22 +1239,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.2':
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.2':
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -1323,22 +1251,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.2':
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.2':
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -1347,22 +1263,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.2':
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.24.2':
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -1371,34 +1275,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.24.2':
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.24.2':
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -1407,22 +1293,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.2':
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -1437,23 +1311,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.24.2':
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.24.2':
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
@@ -1461,22 +1323,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.24.2':
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.24.2':
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -3864,11 +3714,6 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
-
-  esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -7764,127 +7609,64 @@ snapshots:
 
   '@emotion/hash@0.9.2': {}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.24.2':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.24.2':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -7893,25 +7675,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.24.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -9216,14 +8986,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -10423,34 +10185,6 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
-
-  esbuild@0.24.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -13805,21 +13539,6 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.19
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.1.1
-      esbuild: 0.24.2
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.23.1
-      yaml: 2.9.0
-
   vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -13838,35 +13557,6 @@ snapshots:
   vitefu@1.1.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.1
-      jsdom: 29.1.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

Add **Agent Kit** — a data-directory provisioning layer so external Claude Code / Codex sessions can operate on the App's SQLite + chart JSON without touching the HTTP dev server.

- **`agent-kit/` module**: sync engine + kernel-tier IPC + settings UI + template state machine (case 1/2/3.1/3.2.1/3.2.2) + first-boot seeding.
- **`kansoku-cli`**: `ELECTRON_RUN_AS_NODE` shim over App bundle + Kit-side symlink; single-file JS bundle (esbuild → tsdown, 7.4M → 326K after kernel license/AI decoupling); resolves symlink chain so a shim symlinked into user dirs still anchors against the App bundle.
- **User-picked Kit location**: settings UI lets users pick a custom folder or follow the data root; default disabled when the data root is Application Support (auto-populated symlinks in there aren't useful for external agents). Boot seeds enabled=true only when data root isn't the default.
- **`kansoku://` deep link**: custom URL scheme + `open-url` / `second-instance` / cold-start queue + preload bridge + React Router navigation. `kansoku-cli chart create` response now carries a `deepLink` field alongside `url`; `open "$deepLink"` focuses the App and navigates to the target chart page.
- **Chart skill**: `SKILL.md` gains a "Data-root scenario" section with CLI equivalents next to every existing HTTP curl block, plus the deep-link hint.
- **Packaging**: `stageAgentKit.mjs` + `buildCli.mjs` in the pre-package chain; `Resources/kansoku-agent-kit/` in `extraResources`; `dist-agent-kit/` gitignored.

## Cross-repo (needs a separate merge before pin-push)

`kansoku-pro` has a companion branch **`feat/agent-kit-parity-whitelist`** (commit `165ecfe` in that repo) that whitelists the new IPC-only kernel contract group in `apps/pro/test/routeParity.test.ts`. Merge that before pinning kansoku here.

## Test plan

- [x] \`pnpm --filter @kansoku/core test\` — 974 pass / 3 skipped
- [x] \`pnpm --filter @kansoku/desktop test\` — 406 pass
- [x] \`pnpm --filter @kansoku/web test\` — 610 pass
- [x] Packaged App boot syncs Agent Kit into user-picked location; \`kansoku-cli info kit-version\` works from an external shell via the Kit shim
- [x] \`open "kansoku://route/symbol/NVDA"\` focuses App and navigates
- [ ] End-to-end: external Claude Code session in the Kit directory runs the \`chart\` skill and clicks the returned \`deepLink\`
- [ ] Windows / Linux protocol handling (currently macOS-only; \`extendInfo.CFBundleURLTypes\` + gate on \`process.platform === 'darwin'\`)

## Follow-ups (post-merge)

- Repackage under a signed identity; the current build uses \`identity: null\` + \`KANSOKU_BUNDLE_DEV_RANDOM_KEY=1\`
- \`DataRootSection\` shares the same \"bridge changes identity every render → useEffect loop\" latent hazard that this branch fixed inside \`AgentKitSection\` — worth a small polish pass
- If a second IPC-only kernel group appears, promote the pro-side whitelist array to an \`ipcOnly\` marker on \`defineRoutes\`