### PR TITLE
chore(skills): project locked skills into .claude/skills after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "overlay:check": "pnpm --filter @kansoku/build-overlay check",
     "overlay:sync": "pnpm --filter @kansoku/build-overlay sync",
     "package:desktop": "pnpm --filter @kansoku/desktop package",
-    "prepare": "node packages/build-overlay/scripts/sync.mjs || true; skills experimental_install",
+    "prepare": "node packages/build-overlay/scripts/sync.mjs || true; skills experimental_install; python3 scripts/sync-agents-skills.py || true",
     "release:desktop:dry-run": "apps/desktop/scripts/release-dry-run.sh",
     "skills:install": "skills experimental_install",
     "skills:update": "skills update -p -y",

--- a/scripts/sync-agents-skills.py
+++ b/scripts/sync-agents-skills.py
@@ -1,43 +1,131 @@
 #!/usr/bin/env python3
-"""Symlink every first-party skill from .claude/skills into .agents/skills.
+"""Two-way skill projection between .claude/skills and .agents/skills.
 
-First-party = present in .claude/skills but not pinned in skills-lock.json.
-Third-party installs (lock entries) are left untouched. Real-dir copies of
-first-party skills are replaced — a copy is guaranteed to drift.
+First-party skills (in .claude/skills, not pinned in skills-lock.json) are
+symlinked into .agents/skills. Third-party installs (lock entries, restored
+into .agents/skills by `skills experimental_install`, which creates no
+.claude/skills projection itself) are symlinked back into .claude/skills so
+the app dev runtime and Claude Code sessions can see them. Those projections
+point into the git-ignored .agents/skills, so they must never be committed —
+they are appended to the local git info/exclude instead of .gitignore.
+Real-dir copies of first-party skills are replaced — a copy is guaranteed to
+drift; real dirs colliding with lock names are left alone and reported.
 """
 
 import json
 import os
 import shutil
+import subprocess
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLAUDE_ROOT = os.path.join(REPO, ".claude", "skills")
+AGENTS_ROOT = os.path.join(REPO, ".agents", "skills")
+AGENTS_TARGET_PREFIX = os.path.join("..", "..", ".agents", "skills")
+
+
+def locked() -> set[str]:
+    with open(os.path.join(REPO, "skills-lock.json")) as f:
+        return set(json.load(f)["skills"].keys())
 
 
 def first_party() -> list[str]:
-    with open(os.path.join(REPO, "skills-lock.json")) as f:
-        lock = set(json.load(f)["skills"].keys())
-    claude = set(os.listdir(os.path.join(REPO, ".claude", "skills")))
-    return sorted(claude - lock)
+    names = set()
+    for name in os.listdir(CLAUDE_ROOT):
+        path = os.path.join(CLAUDE_ROOT, name)
+        if os.path.islink(path) and os.readlink(path).startswith(AGENTS_TARGET_PREFIX):
+            continue
+        names.add(name)
+    return sorted(names - locked())
+
+
+def ensure_link(dst: str, target: str) -> bool:
+    if os.path.islink(dst):
+        if os.readlink(dst) == target and os.path.exists(dst):
+            return False
+        os.remove(dst)
+    os.symlink(target, dst)
+    return True
+
+
+def sync_first_party() -> int:
+    os.makedirs(AGENTS_ROOT, exist_ok=True)
+    changed = 0
+    for name in first_party():
+        dst = os.path.join(AGENTS_ROOT, name)
+        if not os.path.islink(dst) and os.path.isdir(dst):
+            shutil.rmtree(dst)
+        if ensure_link(dst, os.path.join("..", "..", ".claude", "skills", name)):
+            print(f"linked .agents/skills/{name}")
+            changed += 1
+    return changed
+
+
+def sync_third_party() -> int:
+    changed = 0
+    for name in sorted(locked()):
+        dst = os.path.join(CLAUDE_ROOT, name)
+        if not os.path.islink(dst) and os.path.exists(dst):
+            print(f"skip {name}: .claude/skills/{name} is a real path, not touching it")
+            continue
+        if not os.path.isfile(os.path.join(AGENTS_ROOT, name, "SKILL.md")):
+            print(f"skip {name}: not installed in .agents/skills (run pnpm skills:install)")
+            continue
+        if ensure_link(dst, os.path.join(AGENTS_TARGET_PREFIX, name)):
+            print(f"linked .claude/skills/{name}")
+            changed += 1
+    return changed
+
+
+def prune_dangling() -> int:
+    removed = 0
+    for name in os.listdir(CLAUDE_ROOT):
+        dst = os.path.join(CLAUDE_ROOT, name)
+        if not os.path.islink(dst):
+            continue
+        if not os.readlink(dst).startswith(AGENTS_TARGET_PREFIX):
+            continue
+        if not os.path.exists(dst):
+            os.remove(dst)
+            print(f"pruned dangling .claude/skills/{name}")
+            removed += 1
+    return removed
+
+
+def exclude_projections() -> None:
+    try:
+        path = subprocess.run(
+            ["git", "rev-parse", "--git-path", "info/exclude"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        if not os.path.isabs(path):
+            path = os.path.join(REPO, path)
+        existing: set[str] = set()
+        if os.path.isfile(path):
+            with open(path) as f:
+                existing = {line.strip() for line in f}
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        missing = [
+            f".claude/skills/{name}"
+            for name in sorted(locked())
+            if f".claude/skills/{name}" not in existing
+        ]
+        if missing:
+            with open(path, "a") as f:
+                f.write("".join(f"{line}\n" for line in missing))
+            print(f"excluded {len(missing)} projection(s) in local git info/exclude")
+    except Exception as err:
+        print(f"warning: could not update git info/exclude: {err}", file=sys.stderr)
 
 
 def main() -> int:
-    agents_root = os.path.join(REPO, ".agents", "skills")
-    os.makedirs(agents_root, exist_ok=True)
-    changed = 0
-    for name in first_party():
-        dst = os.path.join(agents_root, name)
-        target = os.path.join("..", "..", ".claude", "skills", name)
-        if os.path.islink(dst):
-            if os.readlink(dst) == target:
-                continue
-            os.remove(dst)
-        elif os.path.isdir(dst):
-            shutil.rmtree(dst)
-        os.symlink(target, dst)
-        print(f"linked {name} -> {target}")
-        changed += 1
-    print(f"done: {changed} link(s) updated, {len(first_party())} first-party skills total")
+    pruned = prune_dangling()
+    changed = sync_first_party() + sync_third_party()
+    exclude_projections()
+    print(f"done: {changed} link(s) updated, {pruned} pruned")
     return 0
 
 


### PR DESCRIPTION
## Summary

`skills experimental_install` restores `skills-lock.json` entries into `.agents/skills/` but creates no `.claude/skills/` projection, so neither the app dev runtime (`skillSearchDirs` only looks at `.claude/skills/`) nor Claude Code project sessions can see installed third-party skills — e.g. the analyst honestly reported 「X 未查」 because `twitter-reader` was invisible in dev, even though the packaged app bundles it fine via `stageSkills.mjs`.

- `scripts/sync-agents-skills.py` becomes a two-way projection: first-party skills → `.agents/skills/` (as before), lock entries → `.claude/skills/` symlinks, dangling projections pruned first (so a stale link can't be misclassified as first-party and get a junk reverse link).
- Projections point into the git-ignored `.agents/`, so they are appended to the local `git info/exclude` (submodule-safe via `git rev-parse --git-path`) instead of the tracked `.gitignore` — they never show up in `git status` and can never be committed as dead links.
- Hooked into `prepare` after `skills experimental_install`, best-effort (`|| true`).

## Test plan

- Ran in a fresh worktree against a populated `.agents/skills`: 18 projections created, first-party sync no-ops, rerun fully idempotent (0 updated / 0 pruned), `git status` stays clean.
- Dangling-link case: stale `.claude/skills` projection pruned before any sync, no junk reverse link created in `.agents/skills`.
- Real-dir collision with a lock name is skipped with a warning, never deleted.