### PR TITLE
fix(core): find opencli under bare Electron PATH

### DIFF
--- a/packages/core/src/ai/agents/agentTools/execTool.ts
+++ b/packages/core/src/ai/agents/agentTools/execTool.ts
@@ -1,9 +1,14 @@
 import { exec as nodeExec } from 'node:child_process';
-import { delimiter, dirname } from 'node:path';
+import { dirname } from 'node:path';
 import { promisify } from 'node:util';
 import type { AgentTool } from '@earendil-works/pi-agent-core';
 import { Type } from 'typebox';
+import { locateOpencli } from '../../../credentials/opencli.js';
 import { locateLongbridgeCli } from '../../../marketdata/longbridgeCli.js';
+import {
+  resolveAugmentedPath,
+  resetUserPathCacheForTests,
+} from '../../../platform/userPath.js';
 import { textResult } from '../dataTools.js';
 
 const OUTPUT_TRUNCATE_CHARS = 30_000;
@@ -16,27 +21,26 @@ export type ExecFn = (command: string) => Promise<ExecResult>;
 
 const nodeExecAsync = promisify(nodeExec);
 
-const EXTRA_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin'];
-
-function mergePathDirs(basePath: string | undefined, extraDirs: string[]): string {
-  const dirs = (basePath ?? '').split(delimiter).filter(Boolean);
-  for (const dir of extraDirs) {
-    if (!dirs.includes(dir)) dirs.push(dir);
-  }
-  return dirs.join(delimiter);
-}
-
 let cachedExecPathPromise: Promise<string> | null = null;
 
-// Finder-launched Electron inherits a bare PATH (/usr/bin:/bin:...), so the
-// longbridge CLI resolvable by the kernel is invisible to plain `sh -c`.
+export function resetExecPathCacheForTests(): void {
+  cachedExecPathPromise = null;
+  resetUserPathCacheForTests();
+}
+
+// Finder-launched Electron inherits a bare PATH (/usr/bin:/bin:...), so CLIs
+// installed via n/nvm/homebrew are invisible to plain `sh -c` without help.
 function resolveExecPath(): Promise<string> {
   cachedExecPathPromise ??= (async () => {
-    const extra = [...EXTRA_BIN_DIRS];
+    const extra: string[] = [];
     try {
       extra.push(dirname(await locateLongbridgeCli()));
     } catch {}
-    return mergePathDirs(process.env.PATH, extra);
+    try {
+      const opencli = await locateOpencli();
+      if (opencli) extra.push(dirname(opencli));
+    } catch {}
+    return resolveAugmentedPath({ extraDirs: extra });
   })();
   return cachedExecPathPromise;
 }

--- a/packages/core/src/credentials/opencli.ts
+++ b/packages/core/src/credentials/opencli.ts
@@ -1,20 +1,27 @@
 import { execFile } from 'node:child_process';
 import { access, constants, stat } from 'node:fs/promises';
-import { delimiter, isAbsolute } from 'node:path';
+import { delimiter, dirname, isAbsolute, join } from 'node:path';
 import { promisify } from 'node:util';
 import type { OpencliStatus } from '../contract/credentials.js';
+import {
+  homeExtraBinDirs,
+  resolveHomeDir,
+  staticAugmentedPath,
+  SYSTEM_EXTRA_BIN_DIRS,
+  type PathExec,
+} from '../platform/userPath.js';
 
 const execFileAsync = promisify(execFile);
 const DOCTOR_TIMEOUT_MS = 20_000;
 const PROFILE_TIMEOUT_MS = 30_000;
 const MAX_ERROR_LENGTH = 200;
-const STANDARD_PATHS = ['/opt/homebrew/bin/opencli', '/usr/local/bin/opencli', '/usr/bin/opencli'];
 
 export interface OpencliDeps {
   env?: NodeJS.ProcessEnv;
-  exec?: typeof execFileAsync;
+  exec?: PathExec;
   shell?: string;
   standardPaths?: string[];
+  homeBinDirs?: string[];
 }
 
 let cachedCliPath: string | null = null;
@@ -34,36 +41,51 @@ async function isExecutable(path: string): Promise<boolean> {
   }
 }
 
-function pathCandidates(env: NodeJS.ProcessEnv, standardPaths: string[]): string[] {
-  const entries = (env.PATH ?? '')
+function pathCandidates(env: NodeJS.ProcessEnv, deps: OpencliDeps): string[] {
+  const home = resolveHomeDir(env);
+  const homeBins = deps.homeBinDirs ?? homeExtraBinDirs(home);
+  const standardPaths =
+    deps.standardPaths ??
+    [...SYSTEM_EXTRA_BIN_DIRS.map((dir) => join(dir, 'opencli')), '/usr/bin/opencli'];
+  const pathEntries = (env.PATH ?? '')
     .split(delimiter)
     .filter(Boolean)
-    .map((dir) => `${dir}/opencli`);
-  return [env.OPENCLI_PATH, ...entries, ...standardPaths].filter(
+    .map((dir) => join(dir, 'opencli'));
+  const homeEntries = homeBins.map((dir) => join(dir, 'opencli'));
+  return [env.OPENCLI_PATH, ...pathEntries, ...standardPaths, ...homeEntries].filter(
     (value): value is string => typeof value === 'string' && value.length > 0,
   );
 }
 
-async function loginShellCandidate(deps: OpencliDeps): Promise<string | null> {
+async function shellCommandCandidate(
+  deps: OpencliDeps,
+  command: string,
+): Promise<string | null> {
   const exec = deps.exec ?? execFileAsync;
-  const shell = deps.shell ?? deps.env?.SHELL ?? process.env.SHELL ?? '/bin/zsh';
+  const env = deps.env ?? process.env;
+  const shell = deps.shell ?? env.SHELL ?? process.env.SHELL ?? '/bin/zsh';
   try {
-    const { stdout } = await exec(shell, ['-lc', 'command -v opencli'], {
+    const { stdout } = await exec(shell, ['-lic', command], {
       timeout: 5_000,
       maxBuffer: 64 * 1024,
+      env: { ...env, TERM: 'dumb' },
     });
-    const candidate = stdout.trim().split('\n')[0];
-    return candidate && isAbsolute(candidate) ? candidate : null;
+    const candidate = stdout
+      .trim()
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => isAbsolute(line));
+    return candidate ?? null;
   } catch {
     return null;
   }
 }
 
-async function locateOpencli(deps: OpencliDeps): Promise<string | null> {
+export async function locateOpencli(deps: OpencliDeps = {}): Promise<string | null> {
   if (cachedCliPath && (await isExecutable(cachedCliPath))) return cachedCliPath;
   const env = deps.env ?? process.env;
   const seen = new Set<string>();
-  for (const candidate of pathCandidates(env, deps.standardPaths ?? STANDARD_PATHS)) {
+  for (const candidate of pathCandidates(env, deps)) {
     if (seen.has(candidate)) continue;
     seen.add(candidate);
     if (await isExecutable(candidate)) {
@@ -71,7 +93,7 @@ async function locateOpencli(deps: OpencliDeps): Promise<string | null> {
       return candidate;
     }
   }
-  const shellCandidate = await loginShellCandidate(deps);
+  const shellCandidate = await shellCommandCandidate(deps, 'command -v opencli');
   if (shellCandidate && (await isExecutable(shellCandidate))) {
     cachedCliPath = shellCandidate;
     return shellCandidate;
@@ -90,9 +112,19 @@ function firstFailingDoctorLine(stdout: string): string | null {
   return (
     stdout
       .split('\n')
-      .find((line) => /^\[(FAIL|WARN)]\s*(Extension|Connectivity):/.test(line.trim()))
+      .find((line) =>
+        /^\[(FAIL|WARN|MISSING)]\s*(Extension|Connectivity):/.test(line.trim()),
+      )
       ?.trim() ?? null
   );
+}
+
+function runEnvForCli(cliPath: string, deps: OpencliDeps): NodeJS.ProcessEnv {
+  const env = deps.env ?? process.env;
+  return {
+    ...env,
+    PATH: staticAugmentedPath(env.PATH, resolveHomeDir(env), [dirname(cliPath)]),
+  };
 }
 
 export async function probeOpencli(deps: OpencliDeps = {}): Promise<OpencliStatus> {
@@ -102,13 +134,14 @@ export async function probeOpencli(deps: OpencliDeps = {}): Promise<OpencliStatu
   }
 
   const exec = deps.exec ?? execFileAsync;
+  const runEnv = runEnvForCli(cliPath, deps);
   let doctorStdout: string;
   let doctorError: unknown = null;
   try {
     const { stdout } = await exec(cliPath, ['doctor'], {
       timeout: DOCTOR_TIMEOUT_MS,
       maxBuffer: 1024 * 1024,
-      env: deps.env ?? process.env,
+      env: runEnv,
     });
     doctorStdout = stdout;
   } catch (error) {
@@ -140,7 +173,7 @@ export async function probeOpencli(deps: OpencliDeps = {}): Promise<OpencliStatu
     await exec(cliPath, ['twitter', 'profile'], {
       timeout: PROFILE_TIMEOUT_MS,
       maxBuffer: 1024 * 1024,
-      env: deps.env ?? process.env,
+      env: runEnv,
     });
     return { state: 'ready', cliPath, lastError: null };
   } catch (error) {

--- a/packages/core/src/platform/userPath.ts
+++ b/packages/core/src/platform/userPath.ts
@@ -1,0 +1,110 @@
+import { execFile } from 'node:child_process';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const SYSTEM_EXTRA_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin'] as const;
+
+export type PathExec = typeof execFileAsync;
+
+export interface UserPathDeps {
+  env?: NodeJS.ProcessEnv;
+  exec?: PathExec;
+  shell?: string;
+}
+
+let cachedShellPathPromise: Promise<string | null> | null = null;
+
+export function resetUserPathCacheForTests(): void {
+  cachedShellPathPromise = null;
+}
+
+export function resolveHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.HOME ?? process.env.HOME ?? homedir();
+}
+
+export function homeExtraBinDirs(home: string = resolveHomeDir()): string[] {
+  if (!home) return [];
+  return [
+    join(home, '.n', 'bin'),
+    join(home, '.local', 'bin'),
+    join(home, '.npm-global', 'bin'),
+    join(home, '.yarn', 'bin'),
+    join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
+    join(home, '.volta', 'bin'),
+    join(home, '.bun', 'bin'),
+    join(home, 'Library', 'pnpm'),
+  ];
+}
+
+export function mergePathDirs(
+  basePath: string | undefined,
+  extraDirs: readonly string[],
+): string {
+  const dirs = (basePath ?? '').split(delimiter).filter(Boolean);
+  for (const dir of extraDirs) {
+    if (dir && !dirs.includes(dir)) dirs.push(dir);
+  }
+  return dirs.join(delimiter);
+}
+
+export function staticAugmentedPath(
+  basePath: string | undefined,
+  home: string = resolveHomeDir(),
+  extraDirs: readonly string[] = [],
+): string {
+  return mergePathDirs(basePath, [
+    ...extraDirs,
+    ...SYSTEM_EXTRA_BIN_DIRS,
+    ...homeExtraBinDirs(home),
+  ]);
+}
+
+export async function resolveShellUserPath(deps: UserPathDeps = {}): Promise<string | null> {
+  const useCache = deps.env === undefined && deps.exec === undefined && deps.shell === undefined;
+  if (useCache && cachedShellPathPromise) return cachedShellPathPromise;
+
+  const run = async (): Promise<string | null> => {
+    const exec = deps.exec ?? execFileAsync;
+    const env = deps.env ?? process.env;
+    const shell = deps.shell ?? env.SHELL ?? process.env.SHELL ?? '/bin/zsh';
+    try {
+      const { stdout } = await exec(shell, ['-lic', 'printenv PATH'], {
+        timeout: 5_000,
+        maxBuffer: 64 * 1024,
+        env: { ...env, TERM: 'dumb' },
+      });
+      const path = stdout
+        .trim()
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .at(-1);
+      if (!path) return null;
+      return path.includes('/') ? path : null;
+    } catch {
+      return null;
+    }
+  };
+
+  if (useCache) {
+    cachedShellPathPromise = run();
+    return cachedShellPathPromise;
+  }
+  return run();
+}
+
+export async function resolveAugmentedPath(
+  deps: UserPathDeps & { extraDirs?: readonly string[] } = {},
+): Promise<string> {
+  const env = deps.env ?? process.env;
+  const home = resolveHomeDir(env);
+  let path = staticAugmentedPath(env.PATH, home, deps.extraDirs ?? []);
+  const shellPath = await resolveShellUserPath(deps);
+  if (shellPath) {
+    path = mergePathDirs(path, shellPath.split(delimiter));
+  }
+  return path;
+}

--- a/packages/core/test/agentTools.test.ts
+++ b/packages/core/test/agentTools.test.ts
@@ -2,18 +2,24 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createDefaultExec } from '../src/ai/agents/agentTools/execTool.js';
+import {
+  createDefaultExec,
+  resetExecPathCacheForTests,
+} from '../src/ai/agents/agentTools/execTool.js';
 import { buildResearchTools } from '../src/ai/agents/agentTools/researchTools.js';
 import type { SkillMeta } from '../src/ai/agents/skills.js';
+import { homeExtraBinDirs } from '../src/platform/userPath.js';
 
 let repoRoot: string;
 
 beforeEach(() => {
   repoRoot = mkdtempSync(join(tmpdir(), 'agent-tools-test-'));
+  resetExecPathCacheForTests();
 });
 
 afterEach(() => {
   rmSync(repoRoot, { recursive: true, force: true });
+  resetExecPathCacheForTests();
 });
 
 function writeSkill(dir: string, name: string, content: string) {
@@ -77,6 +83,9 @@ describe('buildResearchTools', () => {
     const dirs = stdout.trim().split(':');
     expect(dirs).toContain('/opt/homebrew/bin');
     expect(dirs).toContain('/usr/local/bin');
+    for (const dir of homeExtraBinDirs()) {
+      expect(dirs).toContain(dir);
+    }
   });
 
   it('uses a custom exec for the bash tool', async () => {

--- a/packages/core/test/opencli.test.ts
+++ b/packages/core/test/opencli.test.ts
@@ -1,6 +1,6 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { probeOpencli, resetOpencliCacheForTests } from '../src/credentials/opencli.js';
 
@@ -20,6 +20,12 @@ function fakeCli(): string {
   return path;
 }
 
+function isolatedNotFoundEnv(): NodeJS.ProcessEnv {
+  const home = mkdtempSync(join(tmpdir(), 'opencli-home-'));
+  dirs.push(home);
+  return { PATH: '', SHELL: '/bin/false', HOME: home };
+}
+
 const DOCTOR_OK = `opencli v1.8.4 doctor (node v24.16.0)
 
 [OK] Daemon: running on port 19825 (v1.8.4)
@@ -33,11 +39,38 @@ Profiles:
 describe('probeOpencli', () => {
   it('reports not_installed when the binary cannot be located', async () => {
     const result = await probeOpencli({
-      env: { PATH: '', SHELL: '/bin/false' },
+      env: isolatedNotFoundEnv(),
       standardPaths: [],
+      homeBinDirs: [],
     });
     expect(result.state).toBe('not_installed');
     expect(result.cliPath).toBeNull();
+  });
+
+  it('locates opencli under a home bin dir when PATH is bare', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'opencli-home-'));
+    dirs.push(home);
+    const bin = join(home, '.n', 'bin');
+    mkdirSync(bin, { recursive: true });
+    const cli = join(bin, 'opencli');
+    writeFileSync(cli, '#!/bin/sh\nexit 0\n');
+    chmodSync(cli, 0o755);
+
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: DOCTOR_OK, stderr: '' })
+      .mockResolvedValueOnce({ stdout: '@someone', stderr: '' });
+
+    const result = await probeOpencli({
+      env: { PATH: '/usr/bin:/bin', SHELL: '/bin/false', HOME: home },
+      standardPaths: [],
+      homeBinDirs: [bin],
+      exec,
+    });
+
+    expect(result).toEqual({ state: 'ready', cliPath: cli, lastError: null });
+    const doctorOpts = exec.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
+    expect(doctorOpts.env?.PATH?.split(':')).toContain(bin);
   });
 
   it('reports ready when doctor and twitter profile both succeed', async () => {
@@ -46,10 +79,17 @@ describe('probeOpencli', () => {
       .fn()
       .mockResolvedValueOnce({ stdout: DOCTOR_OK, stderr: '' })
       .mockResolvedValueOnce({ stdout: '@someone', stderr: '' });
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result).toEqual({ state: 'ready', cliPath: cli, lastError: null });
     expect(exec).toHaveBeenNthCalledWith(1, cli, ['doctor'], expect.any(Object));
     expect(exec).toHaveBeenNthCalledWith(2, cli, ['twitter', 'profile'], expect.any(Object));
+    const doctorOpts = exec.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
+    expect(doctorOpts.env?.PATH?.split(':')).toContain(dirname(cli));
   });
 
   it('reports extension_missing when doctor output lacks an [OK] Extension line', async () => {
@@ -59,10 +99,36 @@ describe('probeOpencli', () => {
         'opencli v1.8.4 doctor\n\n[OK] Daemon: running on port 19825 (v1.8.4)\n[FAIL] Extension: not connected\n',
       stderr: '',
     });
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result.state).toBe('extension_missing');
     expect(result.cliPath).toBe(cli);
-    expect(result.lastError).toBeTruthy();
+    expect(result.lastError).toContain('[FAIL] Extension');
+  });
+
+  it('reports extension_missing for [MISSING] Extension lines from newer opencli', async () => {
+    const cli = fakeCli();
+    const exec = vi.fn().mockResolvedValueOnce({
+      stdout: `opencli v1.8.4 doctor
+
+[OK] Daemon: running on port 19825 (v1.8.4)
+[MISSING] Extension: not connected
+[FAIL] Connectivity: failed (Browser Bridge extension not connected)
+`,
+      stderr: '',
+    });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
+    expect(result.state).toBe('extension_missing');
+    expect(result.lastError).toContain('[MISSING] Extension');
   });
 
   it('reports extension_missing when doctor exits non-zero, using the stderr excerpt as lastError', async () => {
@@ -72,7 +138,12 @@ describe('probeOpencli', () => {
       .mockRejectedValueOnce(
         Object.assign(new Error('Command failed'), { stdout: DOCTOR_OK, stderr: 'boom', code: 1 }),
       );
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result.state).toBe('extension_missing');
     expect(result.lastError).toContain('boom');
   });
@@ -88,7 +159,12 @@ describe('probeOpencli', () => {
           stderr: 'No session for twitter.com',
         }),
       );
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result.state).toBe('no_session');
     expect(result.cliPath).toBe(cli);
     expect(result.lastError).toContain('No session for twitter.com');
@@ -101,7 +177,12 @@ describe('probeOpencli', () => {
       .mockRejectedValueOnce(
         Object.assign(new Error('Command timed out'), { killed: true, signal: 'SIGTERM' }),
       );
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result.state).toBe('not_installed');
     expect(result.cliPath).toBe(cli);
   });
@@ -115,7 +196,12 @@ describe('probeOpencli', () => {
         stdout: 'opencli v1.8.4 doctor\n\n[OK] Daemon: running on port 19825 (v1.8.4)\n',
       }),
     );
-    const result = await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    const result = await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     expect(result.state).toBe('not_installed');
     expect(result.cliPath).toBe(cli);
   });
@@ -126,11 +212,17 @@ describe('probeOpencli', () => {
       .fn()
       .mockResolvedValueOnce({ stdout: DOCTOR_OK, stderr: '' })
       .mockResolvedValueOnce({ stdout: '@someone', stderr: '' });
-    await probeOpencli({ env: { OPENCLI_PATH: cli, PATH: '' }, exec });
+    await probeOpencli({
+      env: { OPENCLI_PATH: cli, PATH: '', HOME: dirname(cli) },
+      homeBinDirs: [],
+      standardPaths: [],
+      exec,
+    });
     resetOpencliCacheForTests();
     const result = await probeOpencli({
-      env: { PATH: '', SHELL: '/bin/false' },
+      env: isolatedNotFoundEnv(),
       standardPaths: [],
+      homeBinDirs: [],
     });
     expect(result.state).toBe('not_installed');
   });


### PR DESCRIPTION
## Summary

- Dock/Finder-launched Electron inherits a bare `PATH`, so `opencli` installed via `n`/`nvm` (e.g. `~/.n/bin`) was not found by credentials probe or AI bash.
- Shared `userPath` helper adds system + user bin dirs and optional login/interactive shell PATH.
- `probeOpencli` locates home-bin installs, runs doctor/profile with CLI dir on `PATH` (so `node` resolves), and treats doctor `[MISSING] Extension` like a failure.
- AI `createDefaultExec` uses the same augmentation and includes opencli/longbridge directories.

## Test plan

- [x] `pnpm exec vitest run test/opencli.test.ts test/agentTools.test.ts` in `packages/core` (19 passed)
- [x] Bare-PATH simulation: `locateOpencli` → `~/.n/bin/opencli`, `probeOpencli` → `ready`, AI bash `which opencli` + `opencli doctor` OK
- [ ] Restart desktop app, ask chat “你有 OpenCLI 可以调吗?”, confirm `which opencli` succeeds without re-running onboarding