### PR TITLE
feat(training): trainer AI sparring panel, review tab and statistics page

### DIFF
--- a/apps/web/src/features/charts/intraday/replayBandPrimitive.ts
+++ b/apps/web/src/features/charts/intraday/replayBandPrimitive.ts
@@ -9,7 +9,9 @@ import type {
   Time,
 } from 'lightweight-charts';
 
-export type ReplayBandKind = 'given' | 'played' | 'epilogue';
+// `fog` is the stretch the trader never reached — they closed out or were flattened before it.
+// It is drawn on the review chart only, where the whole case is on screen at once.
+export type ReplayBandKind = 'given' | 'played' | 'fog' | 'epilogue';
 
 export interface ReplayBand {
   kind: ReplayBandKind;
@@ -35,6 +37,7 @@ type DrawTarget = Parameters<IPrimitivePaneRenderer['draw']>[0];
 export const REPLAY_BAND_FILL: Record<ReplayBandKind, string> = {
   given: 'rgba(232, 232, 232, 0.045)',
   played: 'rgba(38, 166, 154, 0.10)',
+  fog: 'rgba(232, 232, 232, 0.10)',
   epilogue: 'rgba(255, 176, 0, 0.10)',
 };
 

--- a/apps/web/src/features/desktop/desktopTrainerBridge.ts
+++ b/apps/web/src/features/desktop/desktopTrainerBridge.ts
@@ -1,12 +1,16 @@
 import type {
   TrainerAmendCheck,
   TrainerApi,
+  TrainerCoachCall,
   TrainerEnvelope,
   TrainerFillState,
   TrainerFillTask,
+  TrainerLesson,
   TrainerOpened,
   TrainerPoolCounts,
   TrainerReveal,
+  TrainerReviewPayload,
+  TrainerStats,
   TrainerStepResult,
   WrapTrainerEnvelope,
 } from '@kansoku/pro-api';
@@ -40,5 +44,11 @@ export function getTrainerBridge(
     add: (input) => call<TrainerStepResult>('add', input),
     reduce: (input) => call<TrainerStepResult>('reduce', input),
     reveal: (input) => call<TrainerReveal>('reveal', input),
+    coach: (input) => call<TrainerCoachCall>('coach', input),
+    annotate: (input) => call<TrainerCoachCall>('annotate', input),
+    review: (input) => call<TrainerReviewPayload>('review', input),
+    stats: () => call<TrainerStats>('stats'),
+    saveLesson: (input) => call<TrainerLesson>('saveLesson', input),
+    syncLesson: (input) => call<TrainerLesson>('syncLesson', input),
   };
 }

--- a/apps/web/src/features/home/TrainerCard.test.tsx
+++ b/apps/web/src/features/home/TrainerCard.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TrainerFillState, TrainerFillTask, TrainerPoolCounts } from '@kansoku/pro-api';
 
@@ -58,6 +59,15 @@ vi.mock('@web/lib/ws/wsHub', () => ({ subscribeChannel: () => () => {} }));
 
 const { TrainerCard } = await import('./TrainerCard');
 
+// The card links to the statistics page, so it needs somewhere for that link to resolve against.
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <TrainerCard />
+    </MemoryRouter>,
+  );
+}
+
 afterEach(() => {
   cleanup();
   openTrainer.mockClear();
@@ -72,7 +82,7 @@ afterEach(() => {
 
 describe('TrainerCard', () => {
   it('shows the remaining case count and opens a session', async () => {
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('案例池还有 3 局')).toBeTruthy());
     screen.getByText('开一局').click();
@@ -81,7 +91,7 @@ describe('TrainerCard', () => {
 
   it('offers a refill instead of an empty dead end when the pool is empty', async () => {
     poolCounts = pool(0);
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('案例池是空的')).toBeTruthy());
     screen.getByText('补货').click();
@@ -95,7 +105,7 @@ describe('TrainerCard', () => {
       autoRefillEnabled: true,
       autoRefillSuspended: false,
     };
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('正在采样候选（12/20） · 已入池 3')).toBeTruthy());
     screen.getByText('取消').click();
@@ -109,7 +119,7 @@ describe('TrainerCard', () => {
       autoRefillEnabled: true,
       autoRefillSuspended: false,
     };
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('上次补货失败：长桥未登录')).toBeTruthy());
     expect(screen.getByText('重试补货')).toBeTruthy();
@@ -122,7 +132,7 @@ describe('TrainerCard', () => {
       autoRefillEnabled: true,
       autoRefillSuspended: false,
     };
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('上次补货没找到合规案例')).toBeTruthy());
   });
@@ -134,7 +144,7 @@ describe('TrainerCard', () => {
       autoRefillEnabled: true,
       autoRefillSuspended: true,
     };
-    render(<TrainerCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText('连续两次没补到，自动补货已暂停')).toBeTruthy());
     expect(screen.getByText('手动补货')).toBeTruthy();
@@ -142,7 +152,7 @@ describe('TrainerCard', () => {
 
   it('offers the subscription prompt instead of a count when unlicensed', () => {
     capabilities.licensed = false;
-    render(<TrainerCard />);
+    renderCard();
 
     expect(screen.getByText('订阅后可用')).toBeTruthy();
     screen.getByText('了解订阅').click();
@@ -151,14 +161,14 @@ describe('TrainerCard', () => {
 
   it('renders nothing in a build without the pro module', () => {
     capabilities.pro = false;
-    const { container } = render(<TrainerCard />);
+    const { container } = renderCard();
 
     expect(container.innerHTML).toBe('');
   });
 
   it('renders nothing outside the desktop shell', () => {
     openBridge = null;
-    const { container } = render(<TrainerCard />);
+    const { container } = renderCard();
 
     expect(container.innerHTML).toBe('');
   });

--- a/apps/web/src/features/home/TrainerCard.tsx
+++ b/apps/web/src/features/home/TrainerCard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router';
 import { GraduationCap } from 'lucide-react';
 import type { TrainerFillState } from '@kansoku/pro-api';
 import { getTrainerBridge } from '@web/features/desktop/desktopTrainerBridge';
@@ -113,6 +114,11 @@ export function TrainerCard() {
             <Button className="trainer-card-cancel" onClick={fill.abortFill}>
               取消
             </Button>
+          )}
+          {licensed && (
+            <Link className="trainer-card-stats" to="/training/stats">
+              统计 →
+            </Link>
           )}
         </div>
       </Card>

--- a/apps/web/src/features/training/TrainerAdvanceControls.test.tsx
+++ b/apps/web/src/features/training/TrainerAdvanceControls.test.tsx
@@ -54,6 +54,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerChart.test.tsx
+++ b/apps/web/src/features/training/TrainerChart.test.tsx
@@ -60,6 +60,7 @@ function makeView(): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/TrainerChart.tsx
+++ b/apps/web/src/features/training/TrainerChart.tsx
@@ -17,7 +17,9 @@ import { remainingBarsAt } from './remainingBars';
 import { replayBands, replayDivider } from './replayBands';
 import { TrainerOverlayLayer, TrainerOverlayProvider } from './trainerOverlay';
 import { TrainerAdvanceControls } from './TrainerAdvanceControls';
+import { TrainerCoachPanel } from './TrainerCoachPanel';
 import { TrainerDrawingTools } from './TrainerDrawingTools';
+import { TrainerReview } from './TrainerReview';
 import { TrainerOrderPanel } from './TrainerOrderPanel';
 import { TrainerPeriodSwitch } from './TrainerPeriodSwitch';
 import { TrainerBandLegend, TrainerSettlement } from './TrainerSettlement';
@@ -26,6 +28,8 @@ import { useTrainerDrawings } from './useTrainerDrawings';
 import { useTrainerReviewOverlay } from './useTrainerReviewOverlay';
 
 const STORAGE_NAMESPACE = 'trainer';
+
+type TrainerTab = 'settlement' | 'review';
 
 export interface TrainerChartProps {
   view: TrainerView;
@@ -77,11 +81,15 @@ export function TrainerChart({ view, sessionId, bridge, onViewChange }: TrainerC
   const remaining = remainingBarsAt(view, advancePeriod);
 
   const settling = view.terminal && bridge != null && sessionId != null && onViewChange != null;
-  const shellMode = settling
-    ? expanded
-      ? ' trainer-shell--review'
-      : ' trainer-shell--settle'
-    : '';
+  const [tab, setTab] = useState<TrainerTab>('settlement');
+  const reviewing = settling && tab === 'review';
+  const shellMode = reviewing
+    ? ' trainer-shell--postmortem'
+    : settling
+      ? expanded
+        ? ' trainer-shell--review'
+        : ' trainer-shell--settle'
+      : '';
 
   return (
     <TrainerOverlayProvider>
@@ -99,13 +107,30 @@ export function TrainerChart({ view, sessionId, bridge, onViewChange }: TrainerC
                 ? '已收盘'
                 : `剩余 ${remaining.approximate ? '约 ' : ''}${remaining.count} 根`}
             </span>
-            <TrainerPeriodSwitch
-              ladder={view.ladder}
-              activeTf={activeTf}
-              onChange={setRequestedTf}
-            />
+            {settling ? (
+              <div className="trainer-tabs">
+                <button
+                  className={`trainer-tab${tab === 'settlement' ? ' trainer-tab--on' : ''}`}
+                  onClick={() => setTab('settlement')}
+                >
+                  本局结算
+                </button>
+                <button
+                  className={`trainer-tab${tab === 'review' ? ' trainer-tab--on' : ''}`}
+                  onClick={() => setTab('review')}
+                >
+                  复盘
+                </button>
+              </div>
+            ) : (
+              <TrainerPeriodSwitch
+                ladder={view.ladder}
+                activeTf={activeTf}
+                onChange={setRequestedTf}
+              />
+            )}
           </div>
-          <div className="trainer-body">
+          <div className="trainer-body" hidden={reviewing}>
             {settling && !expanded ? (
               <>
                 <TrainerThumbnail
@@ -135,7 +160,12 @@ export function TrainerChart({ view, sessionId, bridge, onViewChange }: TrainerC
           // key remounts these panels (and their draft state) on a new case instead of
           // syncing them with an effect.
           <>
-            {view.terminal ? (
+            {/* The review tab is a sibling of the play chart rather than a replacement for it:
+                unmounting that chart would tear down lightweight-charts and rebuild it on every
+                switch back. */}
+            {reviewing ? (
+              <TrainerReview bridge={bridge} sessionId={sessionId} />
+            ) : view.terminal ? (
               <TrainerSettlement
                 key={`settlement-${view.caseId}`}
                 view={view}
@@ -165,6 +195,12 @@ export function TrainerChart({ view, sessionId, bridge, onViewChange }: TrainerC
                   onViewChange={onViewChange}
                   drawingActive={drawings.tool !== 'off'}
                   onTakeChart={() => drawings.setTool('off')}
+                />
+                <TrainerCoachPanel
+                  key={`coach-${view.caseId}`}
+                  view={view}
+                  bridge={bridge}
+                  sessionId={sessionId}
                 />
               </>
             )}

--- a/apps/web/src/features/training/TrainerCoachCompare.test.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrainerCoachCall, TrainerCoachVerdict } from '@kansoku/pro-api';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+import { TrainerCoachCompare } from './TrainerCoachCompare';
+
+function verdict(overrides: Partial<TrainerCoachVerdict> = {}): TrainerCoachVerdict {
+  return {
+    outcome: 'win',
+    plannedRewardRisk: 2,
+    realizedR: 2,
+    directionCorrect: true,
+    agreement: 'held',
+    judgedAt: '2026-01-05T15:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function call(overrides: Partial<TrainerCoachCall> = {}): TrainerCoachCall {
+  return {
+    id: 'coach-1',
+    cursor: 7,
+    step: 8,
+    askedAt: '2026-01-05T14:35:00.000Z',
+    model: 'test/model',
+    humanBefore: { direction: 'long', entry: 101, stop: 99, target: 105 },
+    ai: {
+      direction: 'short',
+      anchor: { timeframe: 'm5', time: '2026-01-05T14:35:00.000Z', price: 103 },
+      entry_plan: { entry: 103, stop: 105, target1: 99 },
+      scenarios: [],
+      comment: '冲高未站稳前高，量能收缩',
+    },
+    verdict: verdict(),
+    annotation: null,
+    ...overrides,
+  };
+}
+
+function bridgeWith(annotate: ReturnType<typeof vi.fn>): TrainerBridge {
+  return { annotate } as unknown as TrainerBridge;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TrainerCoachCompare annotation gate', () => {
+  it('asks about the reason only when the market confirmed the direction', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call()]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('理由站得住吗？')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '站得住' })).toBeTruthy();
+  });
+
+  it('archives a refuted call without asking', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ verdict: verdict({ outcome: 'loss', directionCorrect: false, realizedR: -1 }) })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('理由站得住吗？')).toBeNull();
+    expect(screen.getByText('方向没判对，直接归档，不问理由。')).toBeTruthy();
+  });
+
+  it('shows no annotation row before the episode has been judged', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ verdict: null })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('理由站得住吗？')).toBeNull();
+    expect(screen.queryByText(/方向没判对/)).toBeNull();
+  });
+
+  it('sends the chosen verdict and hands the updated call back up', async () => {
+    const annotated = call({ annotation: { verdict: 'sound', at: '2026-01-05T15:10:00.000Z' } });
+    const annotate = vi.fn().mockResolvedValue({ ok: true, data: annotated });
+    const onAnnotated = vi.fn();
+    render(
+      <TrainerCoachCompare
+        calls={[call()]}
+        bridge={bridgeWith(annotate)}
+        sessionId="run-1"
+        onAnnotated={onAnnotated}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '结论对但理由错' }));
+
+    await waitFor(() => expect(onAnnotated).toHaveBeenCalledWith(annotated));
+    expect(annotate).toHaveBeenCalledWith({
+      sessionId: 'run-1',
+      coachId: 'coach-1',
+      verdict: 'right_call_wrong_reason',
+    });
+  });
+});
+
+describe('TrainerCoachCompare readout', () => {
+  it('names the disagreement and what came of it', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ verdict: verdict({ agreement: 'persuaded' }) })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('分歧 · 你改了 → 被说服')).toBeTruthy();
+    expect(screen.getByText(/到目标 · \+2\.00R/)).toBeTruthy();
+    expect(screen.getByText(/你当时：做多/)).toBeTruthy();
+  });
+
+  it('keeps an AI that agreed out of the comparison', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ verdict: verdict({ agreement: 'aligned' }) })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('同向 · 不进对照')).toBeTruthy();
+  });
+
+  it('seeks the timeline to the bar the question was asked on', () => {
+    const onSeek = vi.fn();
+    render(
+      <TrainerCoachCompare
+        calls={[call()]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={onSeek}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /第 1 次 · B7/ }));
+
+    expect(onSeek).toHaveBeenCalledWith('coach-1');
+  });
+
+  it('says so plainly when the trader never asked', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('本局没有问过 AI。')).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/training/TrainerCoachCompare.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import type {
+  TrainerAnnotationVerdict,
+  TrainerCoachAgreement,
+  TrainerCoachCall,
+  TrainerCoachOutcome,
+} from '@kansoku/pro-api';
+import { fmt, signed } from '@web/lib/format';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+import { coachPlanLine, DIRECTION_LABEL } from './coachStance';
+
+const OUTCOME_LABEL: Record<TrainerCoachOutcome, string> = {
+  win: '到目标',
+  loss: '被止损',
+  timeout_flat: '走完没结果',
+  no_fill: '没成交',
+  format_violation: '三价填错',
+  abstained: '它选择观望',
+};
+
+const AGREEMENT_LABEL: Record<TrainerCoachAgreement, string> = {
+  aligned: '同向 · 不进对照',
+  persuaded: '分歧 · 你改了 → 被说服',
+  held: '分歧 · 你没改 → 坚持',
+};
+
+const ANNOTATION_LABEL: Record<TrainerAnnotationVerdict, string> = {
+  sound: '站得住',
+  right_call_wrong_reason: '结论对但理由错',
+  unfounded: '不成立',
+  skipped: '跳过',
+};
+
+const ANNOTATION_ORDER: TrainerAnnotationVerdict[] = [
+  'sound',
+  'right_call_wrong_reason',
+  'unfounded',
+  'skipped',
+];
+
+export interface TrainerCoachCompareProps {
+  calls: readonly TrainerCoachCall[];
+  bridge: TrainerBridge;
+  sessionId: string;
+  onAnnotated: (call: TrainerCoachCall) => void;
+  onSeek: (coachId: string) => void;
+}
+
+/**
+ * Sits directly under the chart: each call happened at a specific bar, and the closer the
+ * comparison is to that bar the less work it takes to read the two together.
+ */
+export function TrainerCoachCompare({
+  calls,
+  bridge,
+  sessionId,
+  onAnnotated,
+  onSeek,
+}: TrainerCoachCompareProps) {
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const annotate = async (coachId: string, verdict: TrainerAnnotationVerdict): Promise<void> => {
+    setPending(coachId);
+    setError(null);
+    try {
+      const result = await bridge.annotate({ sessionId, coachId, verdict });
+      if (result.ok) onAnnotated(result.data);
+      else setError(result.error);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  if (calls.length === 0) {
+    return (
+      <div className="trainer-review-coach" data-testid="trainer-coach-compare">
+        <div className="trainer-label">AI 对照</div>
+        <p className="trainer-settle-hint">本局没有问过 AI。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="trainer-review-coach" data-testid="trainer-coach-compare">
+      <div className="trainer-label">AI 对照 · 本局召唤 {calls.length} 次</div>
+      {error && <span className="trainer-order-error">{error}</span>}
+      {calls.map((call, index) => {
+        const plan = coachPlanLine(call);
+        const verdict = call.verdict;
+        return (
+          <article className="trainer-coach-card" key={call.id}>
+            <header className="trainer-coach-head">
+              <button className="trainer-chip trainer-coach-at" onClick={() => onSeek(call.id)}>
+                第 {index + 1} 次 · B{call.cursor}
+              </button>
+              <span>
+                AI：<b>{DIRECTION_LABEL[call.ai.direction]}</b>
+                {plan.prices && <span className="num"> {plan.prices}</span>}
+              </span>
+              <span className="trainer-settle-hint">
+                你当时：{DIRECTION_LABEL[call.humanBefore.direction]}
+              </span>
+              {verdict && (
+                <>
+                  <span className={`trainer-chip trainer-chip--${verdict.agreement}`}>
+                    {AGREEMENT_LABEL[verdict.agreement]}
+                  </span>
+                  <span
+                    className={`trainer-chip trainer-chip--${verdict.directionCorrect ? 'hit' : 'miss'}`}
+                  >
+                    {OUTCOME_LABEL[verdict.outcome]}
+                    {verdict.realizedR !== null && ` · ${signed(verdict.realizedR)}R`}
+                    {verdict.plannedRewardRisk !== null &&
+                      ` · 计划 ${fmt(verdict.plannedRewardRisk)}:1`}
+                  </span>
+                </>
+              )}
+            </header>
+            <p className="trainer-coach-body">{call.ai.comment}</p>
+            {/* Only calls the market confirmed get an annotation row. Asking about a call whose
+                direction was already refuted buys nothing and trains clicking through. */}
+            {verdict?.directionCorrect ? (
+              <div className="trainer-coach-annotate">
+                <span className="trainer-settle-hint">理由站得住吗？</span>
+                {ANNOTATION_ORDER.map((option) => (
+                  <button
+                    key={option}
+                    className={`btn${call.annotation?.verdict === option ? ' btn--accent' : ''}`}
+                    disabled={pending === call.id}
+                    onClick={() => void annotate(call.id, option)}
+                  >
+                    {ANNOTATION_LABEL[option]}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              verdict && (
+                <p className="trainer-settle-hint">方向没判对，直接归档，不问理由。</p>
+              )
+            )}
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/training/TrainerCoachPanel.test.tsx
+++ b/apps/web/src/features/training/TrainerCoachPanel.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrainerCoachCall, TrainerView } from '@kansoku/pro-api';
+import type { RawBar } from '@kansoku/shared/types';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+import { TrainerCoachPanel } from './TrainerCoachPanel';
+import { TrainerOverlayLayer, TrainerOverlayProvider } from './trainerOverlay';
+
+function bar(iso: string, close: number): RawBar {
+  return { time: iso, open: close - 1, high: close + 1, low: close - 1.5, close, volume: 1000 };
+}
+
+function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
+  const base = [bar('2026-01-05T14:00:00.000Z', 100), bar('2026-01-05T14:05:00.000Z', 103)];
+  return {
+    caseId: 'case-1',
+    symbol: 'TRAIN01',
+    basePeriod: '5m',
+    ladder: ['5m', '15m', '1h'],
+    cursor: base.length - 1,
+    asOf: base.at(-1)!.time,
+    bars: { base, mid: base, top: base },
+    quote: {},
+    phase: 'flat',
+    order: null,
+    position: null,
+    trades: [],
+    netR: 0,
+    remainingBars: 20,
+    terminal: false,
+    result: null,
+    submitted: false,
+    ...overrides,
+  };
+}
+
+function makeCall(overrides: Partial<TrainerCoachCall> = {}): TrainerCoachCall {
+  return {
+    id: 'coach-1',
+    cursor: 1,
+    step: 2,
+    askedAt: '2026-01-05T14:05:00.000Z',
+    model: 'test/model',
+    humanBefore: { direction: 'long', entry: 101, stop: 99, target: 105 },
+    ai: {
+      direction: 'short',
+      anchor: { timeframe: 'm5', time: '2026-01-05T14:05:00.000Z', price: 103 },
+      entry_plan: { entry: 103, stop: 105, target1: 99 },
+      scenarios: [],
+      comment: '冲高未站稳前高，量能收缩',
+    },
+    verdict: null,
+    annotation: null,
+    ...overrides,
+  };
+}
+
+function makeBridge(coach: ReturnType<typeof vi.fn>): TrainerBridge {
+  return { coach } as unknown as TrainerBridge;
+}
+
+// The panel puts its latest answer in the chart overlay, so the portal needs a host to land in.
+function mount(view: TrainerView, bridge: TrainerBridge) {
+  return render(
+    <TrainerOverlayProvider>
+      <TrainerCoachPanel view={view} bridge={bridge} sessionId="run-1" />
+      <TrainerOverlayLayer />
+    </TrainerOverlayProvider>,
+  );
+}
+
+function askButton(name: string | RegExp): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TrainerCoachPanel lock order', () => {
+  it('keeps the button disabled until the trader has submitted', () => {
+    const coach = vi.fn();
+    mount(makeView(), makeBridge(coach));
+
+    const button = askButton('问 AI');
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(coach).not.toHaveBeenCalled();
+    expect(screen.getByText(/先提交你自己的方向与三价/)).toBeTruthy();
+  });
+
+  it('unlocks once a submission exists', () => {
+    mount(makeView({ submitted: true }), makeBridge(vi.fn()));
+
+    expect(askButton('问 AI').disabled).toBe(false);
+    expect(screen.queryByText(/先提交你自己的方向与三价/)).toBeNull();
+  });
+});
+
+describe('TrainerCoachPanel answers', () => {
+  it('shows the second opinion and flags a disagreement, with no verdict mid-episode', async () => {
+    const coach = vi.fn().mockResolvedValue({ ok: true, data: makeCall() });
+    mount(makeView({ submitted: true }), makeBridge(coach));
+
+    fireEvent.click(askButton('问 AI'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trainer-coach-comment').textContent).toBe(
+        '冲高未站稳前高，量能收缩',
+      );
+    });
+    expect(coach).toHaveBeenCalledWith({ sessionId: 'run-1' });
+    expect(screen.getByText('与你分歧')).toBeTruthy();
+    expect(screen.getByText('对错与理由的评判留到收盘后')).toBeTruthy();
+    expect(askButton(/再问一次（第 2 次）/)).toBeTruthy();
+  });
+
+  it('leaves no answer on screen when the call fails', async () => {
+    const coach = vi
+      .fn()
+      .mockResolvedValue({ ok: false, error: '模型没响应', code: 'TRAINER_PROTOCOL', status: 400 });
+    mount(makeView({ submitted: true }), makeBridge(coach));
+
+    fireEvent.click(askButton('问 AI'));
+
+    await waitFor(() => expect(screen.getByText('模型没响应')).toBeTruthy());
+    expect(screen.queryByTestId('trainer-coach-comment')).toBeNull();
+    expect(askButton('问 AI').disabled).toBe(false);
+  });
+
+  it('does not flag agreement as a disagreement', async () => {
+    const agreed = makeCall({
+      ai: { ...makeCall().ai, direction: 'long' },
+    });
+    const coach = vi.fn().mockResolvedValue({ ok: true, data: agreed });
+    mount(makeView({ submitted: true }), makeBridge(coach));
+
+    fireEvent.click(askButton('问 AI'));
+
+    await waitFor(() => expect(screen.getByTestId('trainer-coach-comment')).toBeTruthy());
+    expect(screen.queryByText('与你分歧')).toBeNull();
+  });
+});

--- a/apps/web/src/features/training/TrainerCoachPanel.tsx
+++ b/apps/web/src/features/training/TrainerCoachPanel.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import type { TrainerCoachCall, TrainerView } from '@kansoku/pro-api';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+import {
+  coachDisagrees,
+  coachLockReason,
+  coachPlanLine,
+  DIRECTION_LABEL,
+} from './coachStance';
+import { TrainerOverlayPortal } from './trainerOverlay';
+
+export interface TrainerCoachPanelProps {
+  view: TrainerView;
+  bridge: TrainerBridge;
+  sessionId: string;
+}
+
+/**
+ * The second opinion, on demand and unlimited — the trader pays for each one, so how many to spend
+ * is theirs to decide. What is not theirs is the order: the button stays locked until they have
+ * submitted (see `coachUnlocked`).
+ *
+ * Nothing here shows a verdict. Mid-episode there is no outcome to judge against, and putting a
+ * provisional one on screen would tell the trader which way the case goes.
+ */
+export function TrainerCoachPanel({ view, bridge, sessionId }: TrainerCoachPanelProps) {
+  const [calls, setCalls] = useState<TrainerCoachCall[]>([]);
+  const [asking, setAsking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const locked = coachLockReason(view);
+  const latest = calls.at(-1) ?? null;
+
+  const ask = async (): Promise<void> => {
+    setAsking(true);
+    setError(null);
+    try {
+      const result = await bridge.coach({ sessionId });
+      if (result.ok) setCalls((prev) => [...prev, result.data]);
+      else setError(result.error);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAsking(false);
+    }
+  };
+
+  return (
+    <>
+      {latest && (
+        <TrainerOverlayPortal slot="stack">
+          <div className="trainer-chip trainer-chip--coach" data-testid="trainer-coach-latest">
+            <b>AI</b>
+            <span>{DIRECTION_LABEL[latest.ai.direction]}</span>
+            {coachPlanLine(latest).prices && (
+              <span className="num">{coachPlanLine(latest).prices}</span>
+            )}
+            {coachDisagrees(latest) && <span className="trainer-coach-split">与你分歧</span>}
+          </div>
+        </TrainerOverlayPortal>
+      )}
+      <div className="trainer-coach-lane" data-testid="trainer-coach-lane">
+        <button
+          className="btn trainer-coach-ask"
+          disabled={locked !== undefined || asking}
+          title={locked}
+          onClick={() => void ask()}
+        >
+          {asking ? '正在问…' : calls.length === 0 ? '问 AI' : `再问一次（第 ${calls.length + 1} 次）`}
+        </button>
+        {locked && <span className="trainer-settle-hint">{locked}</span>}
+        {error && <span className="trainer-order-error">{error}</span>}
+        {latest && !error && (
+          <p className="trainer-coach-comment" data-testid="trainer-coach-comment">
+            {latest.ai.comment}
+          </p>
+        )}
+        {calls.length > 0 && (
+          <span className="trainer-settle-hint">对错与理由的评判留到收盘后</span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/training/TrainerOrderPanel.test.tsx
+++ b/apps/web/src/features/training/TrainerOrderPanel.test.tsx
@@ -39,6 +39,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerReview.test.tsx
+++ b/apps/web/src/features/training/TrainerReview.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrainerReviewPayload } from '@kansoku/pro-api';
+import type { RawBar } from '@kansoku/shared/types';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+
+vi.mock('../charts/intraday/useIntradayCharts', () => ({
+  EMA_COLORS: ['#fff'],
+  useIntradayCharts: vi.fn(),
+}));
+
+vi.mock('../desktop/desktopWindowsBridge', () => ({
+  getPopoutBridge: () => null,
+}));
+
+const { TrainerReview } = await import('./TrainerReview');
+
+function bar(iso: string, close: number): RawBar {
+  return { time: iso, open: close - 1, high: close + 1, low: close - 1.5, close, volume: 1000 };
+}
+
+const REPLAY = [
+  bar('2026-01-05T14:00:00.000Z', 100),
+  bar('2026-01-05T14:05:00.000Z', 101),
+  bar('2026-01-05T14:10:00.000Z', 102),
+  bar('2026-01-05T14:15:00.000Z', 103),
+];
+
+function payload(overrides: Partial<TrainerReviewPayload> = {}): TrainerReviewPayload {
+  return {
+    sessionId: 'run-1',
+    caseId: 'case-1',
+    symbol: 'TRAIN01',
+    basePeriod: '5m',
+    ladder: ['5m', '15m', '1h'],
+    provenance: {
+      outputId: 'case-1',
+      aliasSymbol: 'TRAIN01',
+      sourceId: 'src-1',
+      sourceSymbol: 'REALCANARY.US',
+      sourceCutoff: '2019-04-01T20:00:00.000Z',
+      syntheticCutoff: '2026-01-05T13:55:00.000Z',
+      dayShift: 1064,
+      priceScale: 0.1,
+      volumeScale: 7,
+    },
+    tag: 'false-breakout',
+    lookback: [bar('2026-01-05T13:55:00.000Z', 99)],
+    replay: REPLAY,
+    epilogue: [bar('2026-01-05T14:20:00.000Z', 106)],
+    playedThrough: 2,
+    trades: [],
+    result: null,
+    events: [
+      {
+        kind: 'coach',
+        at: REPLAY[1].time,
+        barIndex: 1,
+        price: 101,
+        label: '第 1 次问 AI',
+        coachId: 'coach-1',
+      },
+    ],
+    coach: [],
+    facts: {
+      stopAutopsy: {
+        tradeId: 1,
+        stop: 98,
+        overshoot: 0.6,
+        overshootPct: 0.6122,
+        reachedTargetAfter: true,
+      },
+      holdToEpilogueEndR: 3,
+      afterExitHighR: 4.5,
+      afterExitLowR: -1,
+    },
+    lesson: null,
+    ...overrides,
+  };
+}
+
+function bridgeWith(overrides: Partial<Record<string, unknown>> = {}): TrainerBridge {
+  return {
+    review: vi.fn().mockResolvedValue({ ok: true, data: payload() }),
+    annotate: vi.fn(),
+    saveLesson: vi.fn(),
+    syncLesson: vi.fn(),
+    ...overrides,
+  } as unknown as TrainerBridge;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TrainerReview', () => {
+  it('reveals the real identity and the structure tag once the episode is over', async () => {
+    render(<TrainerReview bridge={bridgeWith()} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByText('REALCANARY.US')).toBeTruthy());
+    expect(screen.getByText('2019-04-01')).toBeTruthy();
+    expect(screen.getByText('标签：假突破')).toBeTruthy();
+  });
+
+  it('shows the three numbers a live account cannot produce', async () => {
+    render(<TrainerReview bridge={bridgeWith()} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('trainer-review-facts')).toBeTruthy());
+    expect(screen.getByText(/占止损价 0\.61%，之后到过目标/)).toBeTruthy();
+    expect(screen.getByText('仅供观察，不计成绩')).toBeTruthy();
+  });
+
+  it('parks the brush at the end and lets it be dragged back', async () => {
+    render(<TrainerReview bridge={bridgeWith()} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('trainer-review-timeline')).toBeTruthy());
+    const brush = screen.getByLabelText('重放到第几根') as HTMLInputElement;
+    expect(brush.value).toBe('3');
+    expect(brush.max).toBe('3');
+
+    fireEvent.change(brush, { target: { value: '1' } });
+    expect((screen.getByLabelText('重放到第几根') as HTMLInputElement).value).toBe('1');
+  });
+
+  // Splicing post-case bars onto a rewound chart would put them straight after a mid-case bar,
+  // so the toggle is only live while the brush is parked at the end.
+  it('locks the epilogue toggle while the chart is rewound', async () => {
+    render(<TrainerReview bridge={bridgeWith()} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('trainer-review-timeline')).toBeTruthy());
+    const toggle = screen.getByLabelText(/显示收盘后走势/) as HTMLInputElement;
+    expect(toggle.disabled).toBe(false);
+
+    fireEvent.change(screen.getByLabelText('重放到第几根'), { target: { value: '1' } });
+
+    expect((screen.getByLabelText(/显示收盘后走势/) as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('reports a refusal instead of rendering an empty page', async () => {
+    const bridge = bridgeWith({
+      review: vi
+        .fn()
+        .mockResolvedValue({ ok: false, error: '这一局还没结束', code: 'TRAINER_PROTOCOL', status: 400 }),
+    });
+    render(<TrainerReview bridge={bridge} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByText('这一局还没结束')).toBeTruthy());
+    expect(screen.queryByTestId('trainer-review')).toBeNull();
+  });
+});
+
+describe('TrainerReview lesson gate', () => {
+  it('keeps the sync button locked until the sentence has been stored', async () => {
+    render(<TrainerReview bridge={bridgeWith()} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('trainer-review-lesson')).toBeTruthy());
+    const sync = screen.getByRole('button', {
+      name: '同步到 journal/lessons.md',
+    }) as HTMLButtonElement;
+    expect(sync.disabled).toBe(true);
+  });
+
+  it('unlocks the sync button once the same sentence is stored, and never syncs on its own', async () => {
+    const saveLesson = vi.fn().mockResolvedValue({
+      ok: true,
+      data: { text: '止损放结构外', writtenAt: '2026-01-05T15:00:00.000Z', syncedAt: null },
+    });
+    const syncLesson = vi.fn();
+    render(<TrainerReview bridge={bridgeWith({ saveLesson, syncLesson })} sessionId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('trainer-review-lesson')).toBeTruthy());
+    fireEvent.change(screen.getByLabelText('本局教训'), { target: { value: '止损放结构外' } });
+    fireEvent.click(screen.getByRole('button', { name: '存进训练区' }));
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('button', { name: '同步到 journal/lessons.md' }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false),
+    );
+    expect(saveLesson).toHaveBeenCalledWith({ sessionId: 'run-1', text: '止损放结构外' });
+    expect(syncLesson).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/training/TrainerReview.tsx
+++ b/apps/web/src/features/training/TrainerReview.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { TrainerCoachCall, TrainerLesson, TrainerReviewPayload } from '@kansoku/pro-api';
+import { IntradayControlsProvider } from '../charts/intraday/controlsContext';
+import { IntradayChartOnly } from '../charts/intraday/IntradayChartOnly';
+import type { DrawingChartHandle } from '../charts/intraday/useIntradayCharts';
+import { getPopoutBridge } from '../desktop/desktopWindowsBridge';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+import { TRAINER_CASE_TAG_LABEL } from './caseTagLabels';
+import {
+  buildReviewBuilt,
+  reviewBands,
+  reviewChartTf,
+  reviewMaxBrush,
+  reviewTrades,
+} from './reviewChart';
+import { TrainerCoachCompare } from './TrainerCoachCompare';
+import { TrainerReviewFacts } from './TrainerReviewFacts';
+import { TrainerReviewLesson } from './TrainerReviewLesson';
+import { TrainerReviewTimeline } from './TrainerReviewTimeline';
+import { useTrainerReviewOverlay } from './useTrainerReviewOverlay';
+
+const STORAGE_NAMESPACE = 'trainer-review';
+
+export interface TrainerReviewProps {
+  bridge: TrainerBridge;
+  sessionId: string;
+}
+
+export function TrainerReview({ bridge, sessionId }: TrainerReviewProps) {
+  const [payload, setPayload] = useState<TrainerReviewPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void bridge.review({ sessionId }).then((result) => {
+      if (!active) return;
+      if (result.ok) setPayload(result.data);
+      else setError(result.error);
+    });
+    return () => {
+      active = false;
+    };
+  }, [bridge, sessionId]);
+
+  if (error) return <div className="trainer-order-error">{error}</div>;
+  if (!payload) return <div className="trainer-order-panel--status">正在整理这一局…</div>;
+  return (
+    <ReviewBody
+      key={payload.sessionId}
+      payload={payload}
+      bridge={bridge}
+      sessionId={sessionId}
+      onPayloadChange={setPayload}
+    />
+  );
+}
+
+interface ReviewBodyProps {
+  payload: TrainerReviewPayload;
+  bridge: TrainerBridge;
+  sessionId: string;
+  onPayloadChange: (payload: TrainerReviewPayload) => void;
+}
+
+function ReviewBody({ payload, bridge, sessionId, onPayloadChange }: ReviewBodyProps) {
+  const max = reviewMaxBrush(payload);
+  // Parked at the end so the whole case is on screen at once — the played run, the stretch never
+  // reached, and the epilogue. Dragging left is what rewinds it.
+  const [brush, setBrush] = useState(max);
+  const [showEpilogue, setShowEpilogue] = useState(true);
+  const [handle, setHandle] = useState<DrawingChartHandle | null>(null);
+
+  const built = useMemo(
+    () => buildReviewBuilt(payload, brush, showEpilogue),
+    [payload, brush, showEpilogue],
+  );
+  const bands = useMemo(
+    () => reviewBands(payload, brush, showEpilogue),
+    [payload, brush, showEpilogue],
+  );
+  const trades = useMemo(() => reviewTrades(payload, brush), [payload, brush]);
+  useTrainerReviewOverlay(handle, trades, bands);
+
+  const seekToCoach = (coachId: string): void => {
+    const at = payload.coach.find((call) => call.id === coachId)?.cursor;
+    if (at !== undefined && at >= 0) setBrush(Math.min(at, max));
+  };
+
+  const replaceCall = (updated: TrainerCoachCall): void => {
+    onPayloadChange({
+      ...payload,
+      coach: payload.coach.map((call) => (call.id === updated.id ? updated : call)),
+    });
+  };
+
+  const replaceLesson = (lesson: TrainerLesson): void => {
+    onPayloadChange({ ...payload, lesson });
+  };
+
+  return (
+    <div className="trainer-review" data-testid="trainer-review">
+      <section className="trainer-review-reveal">
+        <span className="trainer-reveal-key">真身</span>
+        <span className="num trainer-reveal-sym">{payload.provenance.sourceSymbol}</span>
+        <span className="num trainer-reveal-date">
+          {payload.provenance.sourceCutoff.slice(0, 10)}
+        </span>
+        <span className="trainer-chip">
+          标签：{payload.tag ? TRAINER_CASE_TAG_LABEL[payload.tag] : '未标注'}
+        </span>
+        <OpenRealChartButton symbol={payload.provenance.sourceSymbol} />
+      </section>
+
+      <section className="trainer-review-stage">
+        <IntradayControlsProvider storageNamespace={STORAGE_NAMESPACE}>
+          <div className="trainer-review-chart">
+            <IntradayChartOnly
+              symbol={payload.symbol}
+              built={built}
+              activeTf={reviewChartTf(payload)}
+              drawings={false}
+              storageNamespace={STORAGE_NAMESPACE}
+              onChartHandle={setHandle}
+            />
+          </div>
+        </IntradayControlsProvider>
+        <TrainerReviewTimeline
+          max={max}
+          brush={brush}
+          playedThrough={payload.playedThrough}
+          events={payload.events}
+          onBrush={setBrush}
+        />
+        <div className="trainer-review-legend-row">
+          <ReviewLegend />
+          <label className="trainer-settlement-epilogue-toggle">
+            <input
+              type="checkbox"
+              checked={showEpilogue}
+              disabled={brush < max || payload.epilogue.length === 0}
+              onChange={(e) => setShowEpilogue(e.target.checked)}
+            />
+            显示收盘后走势
+            <span className="trainer-settle-hint">（尾声段，不计入成绩，只用于看结构）</span>
+          </label>
+        </div>
+      </section>
+
+      <TrainerReviewFacts facts={payload.facts} />
+
+      <TrainerCoachCompare
+        calls={payload.coach}
+        bridge={bridge}
+        sessionId={sessionId}
+        onAnnotated={replaceCall}
+        onSeek={seekToCoach}
+      />
+
+      <TrainerReviewLesson
+        lesson={payload.lesson}
+        bridge={bridge}
+        sessionId={sessionId}
+        onChange={replaceLesson}
+      />
+    </div>
+  );
+}
+
+function ReviewLegend() {
+  return (
+    <div className="trainer-band-legend">
+      <span>
+        <i className="trainer-band-swatch trainer-band-swatch--given" />
+        开局给的历史
+      </span>
+      <span>
+        <i className="trainer-band-swatch trainer-band-swatch--played" />
+        你打过的段
+      </span>
+      <span>
+        <i className="trainer-band-swatch trainer-band-swatch--fog" />
+        被雾遮住的段
+      </span>
+      <span>
+        <i className="trainer-band-swatch trainer-band-swatch--epilogue" />
+        尾声段
+      </span>
+    </div>
+  );
+}
+
+function OpenRealChartButton({ symbol }: { symbol: string }) {
+  const bridge = getPopoutBridge();
+  if (!bridge) return null;
+  return (
+    <button className="btn trainer-reveal-jump" onClick={() => void bridge.openPopout(symbol)}>
+      在行情页打开真图 →
+    </button>
+  );
+}

--- a/apps/web/src/features/training/TrainerReviewFacts.tsx
+++ b/apps/web/src/features/training/TrainerReviewFacts.tsx
@@ -1,0 +1,50 @@
+import type { TrainerReviewFacts as Facts } from '@kansoku/pro-api';
+import { fmt, signed } from '@web/lib/format';
+
+/**
+ * The three numbers a live account cannot produce, because a live account has no parallel world in
+ * which the trade was left alone.
+ *
+ * Every one of them reads through the epilogue, and none of them enters a statistic. "Holding would
+ * have paid +3.6R" is true of this board and silent about the boards where holding wipes you out;
+ * the caption says so rather than leaving the number to be read as a lesson.
+ */
+export function TrainerReviewFacts({ facts }: { facts: Facts }) {
+  const autopsy = facts.stopAutopsy;
+  return (
+    <div className="trainer-review-facts" data-testid="trainer-review-facts">
+      <div className="trainer-label">实盘做不到的三个数</div>
+      <div className="trainer-review-figs">
+        <figure className="trainer-fig">
+          <figcaption>被止损那笔超出多少</figcaption>
+          <div className={`num trainer-fig-val${autopsy ? ' down' : ''}`}>
+            {autopsy ? `-${fmt(autopsy.overshoot)}` : '—'}
+          </div>
+          <div className="trainer-fig-sub">
+            {autopsy
+              ? `占止损价 ${fmt(autopsy.overshootPct)}%，之后${autopsy.reachedTargetAfter ? '到过' : '没到过'}目标`
+              : '本局没有被止损'}
+          </div>
+        </figure>
+        <figure className="trainer-fig">
+          <figcaption>不平仓拿到尾声段末</figcaption>
+          <div className="num trainer-fig-val">
+            {facts.holdToEpilogueEndR === null ? '—' : signed(facts.holdToEpilogueEndR)}
+            <span className="trainer-fig-unit"> R</span>
+          </div>
+          <div className="trainer-fig-sub">仅供观察，不计成绩</div>
+        </figure>
+        <figure className="trainer-fig">
+          <figcaption>离场后最高 / 最低</figcaption>
+          <div className="num trainer-fig-val">
+            {facts.afterExitHighR === null ? '—' : signed(facts.afterExitHighR)}
+            {' / '}
+            {facts.afterExitLowR === null ? '—' : signed(facts.afterExitLowR)}
+            <span className="trainer-fig-unit"> R</span>
+          </div>
+          <div className="trainer-fig-sub">你走之后市场还给过什么</div>
+        </figure>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/training/TrainerReviewLesson.tsx
+++ b/apps/web/src/features/training/TrainerReviewLesson.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import type { TrainerLesson } from '@kansoku/pro-api';
+import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
+
+export interface TrainerReviewLessonProps {
+  lesson: TrainerLesson | null;
+  bridge: TrainerBridge;
+  sessionId: string;
+  onChange: (lesson: TrainerLesson) => void;
+}
+
+/**
+ * Two buttons, and the second one is the only route out of the training area.
+ *
+ * `journal/lessons.md` is read before every short-term call. A training board is synthetic — prices
+ * scaled, symbol false, no news — so part of what it teaches is about the trader's own habits and
+ * belongs there, while the rest is about the case pool and would be pollution. Nothing can tell
+ * those apart automatically, so the release stays a deliberate press.
+ */
+export function TrainerReviewLesson({
+  lesson,
+  bridge,
+  sessionId,
+  onChange,
+}: TrainerReviewLessonProps) {
+  const [text, setText] = useState(lesson?.text ?? '');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const saved = lesson !== null && lesson.text === text.trim();
+
+  const run = async (action: () => ReturnType<TrainerBridge['saveLesson']>): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await action();
+      if (result.ok) onChange(result.data);
+      else setError(result.error);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="trainer-review-lesson" data-testid="trainer-review-lesson">
+      <div className="trainer-label">教训</div>
+      <div className="trainer-review-lesson-row">
+        <input
+          className="trainer-lesson-input"
+          value={text}
+          placeholder="一句话，写你自己的毛病"
+          aria-label="本局教训"
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          className="btn"
+          disabled={busy || text.trim().length === 0}
+          onClick={() => void run(() => bridge.saveLesson({ sessionId, text }))}
+        >
+          存进训练区
+        </button>
+        <button
+          className="btn btn--accent"
+          disabled={busy || !saved || lesson?.syncedAt !== null}
+          title={saved ? undefined : '先存进训练区'}
+          onClick={() => void run(() => bridge.syncLesson({ sessionId }))}
+        >
+          {lesson?.syncedAt ? '已同步到 lessons.md' : '同步到 journal/lessons.md'}
+        </button>
+      </div>
+      {error && <span className="trainer-order-error">{error}</span>}
+      <p className="trainer-settle-hint">
+        默认只存训练区。写的是你自己的操作习惯就值得放行；写的是「这个案例池假突破特别多」就别同步 ——
+        合成盘的特征灌进实盘必读清单是污染。
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/training/TrainerReviewTimeline.tsx
+++ b/apps/web/src/features/training/TrainerReviewTimeline.tsx
@@ -1,0 +1,66 @@
+import type { TrainerReviewEvent, TrainerReviewEventKind } from '@kansoku/pro-api';
+
+const EVENT_MARK: Record<TrainerReviewEventKind, string> = {
+  entry: '▲',
+  stop: '✕',
+  target: '◎',
+  manual_exit: '●',
+  horizon_exit: '■',
+  coach: '◆',
+};
+
+export interface TrainerReviewTimelineProps {
+  max: number;
+  brush: number;
+  playedThrough: number;
+  events: readonly TrainerReviewEvent[];
+  onBrush: (bar: number) => void;
+}
+
+/**
+ * The brush is a range input rather than a canvas: it is one number, and dragging it must stay
+ * cheap enough to be smooth. Every position is already in memory, so nothing here goes over IPC.
+ */
+export function TrainerReviewTimeline({
+  max,
+  brush,
+  playedThrough,
+  events,
+  onBrush,
+}: TrainerReviewTimelineProps) {
+  const pct = (bar: number) => (max === 0 ? 0 : (bar / max) * 100);
+  return (
+    <div className="trainer-review-timeline" data-testid="trainer-review-timeline">
+      <div className="trainer-review-track">
+        <div className="trainer-review-track-fog" style={{ left: `${pct(playedThrough)}%` }} />
+        {events.map((event, index) =>
+          event.barIndex === null ? null : (
+            <button
+              key={`${event.kind}-${event.coachId ?? index}`}
+              className={`trainer-review-tick trainer-review-tick--${event.kind}`}
+              style={{ left: `${pct(event.barIndex)}%` }}
+              title={event.label}
+              onClick={() => onBrush(event.barIndex!)}
+            >
+              {EVENT_MARK[event.kind]}
+            </button>
+          ),
+        )}
+      </div>
+      <input
+        type="range"
+        className="trainer-review-brush"
+        min={0}
+        max={max}
+        value={brush}
+        aria-label="重放到第几根"
+        onChange={(e) => onBrush(Number(e.target.value))}
+      />
+      <div className="trainer-review-scale">
+        <span className="num">B0</span>
+        <span className="trainer-settle-hint">拖时间轴，图还原成当时所见</span>
+        <span className="num">B{brush}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/training/TrainerSettlement.test.tsx
+++ b/apps/web/src/features/training/TrainerSettlement.test.tsx
@@ -99,6 +99,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerSettlement.tsx
+++ b/apps/web/src/features/training/TrainerSettlement.tsx
@@ -216,8 +216,7 @@ export function TrainerSettlement({
             </span>
           )}
           <div className="trainer-ghost-slots">
-            <span>AI 对照 · M4</span>
-            <span>教训沉淀 · M5</span>
+            <span>AI 对照与教训沉淀在「复盘」页签</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/features/training/TrainerThumbnail.test.tsx
+++ b/apps/web/src/features/training/TrainerThumbnail.test.tsx
@@ -84,6 +84,7 @@ function terminalView(): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
+    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/TrainingStatsPage.test.tsx
+++ b/apps/web/src/features/training/TrainingStatsPage.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrainerStats } from '@kansoku/pro-api';
+import { TrainingStatsPage } from './TrainingStatsPage';
+
+const stats = vi.fn();
+vi.mock('@web/features/desktop/desktopTrainerBridge', () => ({
+  getTrainerBridge: () => ({ stats }),
+}));
+
+function makeStats(overrides: Partial<TrainerStats> = {}): TrainerStats {
+  return {
+    completedSessions: 3,
+    unfinishedSessions: 1,
+    sessionsByBasePeriod: { '5m': 3 } as TrainerStats['sessionsByBasePeriod'],
+    overview: {
+      samples: 3,
+      locked: true,
+      netR: 3,
+      winRate: null,
+      plannedRewardRisk: null,
+      realizedRewardRisk: null,
+      mfeGivebackRate: null,
+    },
+    byTag: [{ tag: 'false-breakout', samples: 3, locked: true, netR: 3, winRate: null }],
+    stopHealth: {
+      samples: 0,
+      locked: true,
+      reachedTargetAfterStopRate: null,
+      averageOvershootPct: null,
+    },
+    coachInfluence: {
+      samples: 2,
+      locked: true,
+      persuadedCount: 1,
+      persuadedWinRate: null,
+      heldCount: 1,
+      heldWinRate: null,
+    },
+    advanceStyle: {
+      samples: 3,
+      locked: true,
+      barByBarWinRate: null,
+      fastForwardWinRate: null,
+    },
+    coachScorecard: {
+      samples: 2,
+      locked: true,
+      settled: 1,
+      annotated: 0,
+      directionAccuracy: null,
+      soundReasonRate: null,
+      rightCallWrongReasonRate: null,
+    },
+    ...overrides,
+  };
+}
+
+function unlockedStats(): TrainerStats {
+  const base = makeStats({ completedSessions: 12, unfinishedSessions: 0 });
+  return {
+    ...base,
+    overview: {
+      samples: 12,
+      locked: false,
+      netR: 11.4,
+      winRate: 0.47,
+      plannedRewardRisk: 2.4,
+      realizedRewardRisk: 1.3,
+      mfeGivebackRate: 0.38,
+    },
+  };
+}
+
+function mount() {
+  return render(
+    <MemoryRouter>
+      <TrainingStatsPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  stats.mockReset();
+});
+
+describe('TrainingStatsPage sample guard', () => {
+  it('reports counts and refuses ratios while any block is short of samples', async () => {
+    stats.mockResolvedValue({ ok: true, data: makeStats() });
+    mount();
+
+    await waitFor(() => expect(screen.getAllByTestId('training-stats-locked').length).toBe(5));
+    expect(screen.getByText(/共 3 局打完/)).toBeTruthy();
+    expect(screen.getByText(/另有 1 局开了没打完/)).toBeTruthy();
+    expect(screen.queryByText('100%')).toBeNull();
+    expect(screen.getByText('3 局，样本不足')).toBeTruthy();
+  });
+
+  it('shows the ratios once a block clears the threshold', async () => {
+    stats.mockResolvedValue({ ok: true, data: unlockedStats() });
+    mount();
+
+    await waitFor(() => expect(screen.getByText('47%')).toBeTruthy());
+    expect(screen.getByText('2.40 → 1.30')).toBeTruthy();
+    expect(screen.getByText('+11.40')).toBeTruthy();
+    // The four blocks that are still short stay locked even though the overview opened up.
+    expect(screen.getAllByTestId('training-stats-locked').length).toBe(4);
+  });
+});

--- a/apps/web/src/features/training/TrainingStatsPage.tsx
+++ b/apps/web/src/features/training/TrainingStatsPage.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import type { TrainerStatBlock, TrainerStats } from '@kansoku/pro-api';
+import { getTrainerBridge } from '@web/features/desktop/desktopTrainerBridge';
+import { fmt, signed } from '@web/lib/format';
+import { Card, SectionTitle } from '@web/ui';
+import { TRAINER_CASE_TAG_LABEL } from './caseTagLabels';
+
+const pct = (value: number | null): string => (value === null ? '—' : `${fmt(value * 100, 0)}%`);
+
+export function TrainingStatsPage() {
+  const bridge = useMemo(() => getTrainerBridge(), []);
+  const [stats, setStats] = useState<TrainerStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!bridge) return;
+    let active = true;
+    void bridge.stats().then((result) => {
+      if (!active) return;
+      if (result.ok) setStats(result.data);
+      else setError(result.error);
+    });
+    return () => {
+      active = false;
+    };
+  }, [bridge]);
+
+  if (!bridge) return <div className="trainer-order-error">训练统计只在桌面端可用</div>;
+  if (error) return <div className="trainer-order-error">{error}</div>;
+  if (!stats) return <div className="trainer-order-panel--status">正在统计…</div>;
+
+  const periods = Object.entries(stats.sessionsByBasePeriod)
+    .map(([period, count]) => `${period} ${count}`)
+    .join(' / ');
+
+  return (
+    <div className="training-stats">
+      <SectionTitle>
+        训练统计
+        <Link className="training-stats-back" to="/">
+          ← 回首页
+        </Link>
+      </SectionTitle>
+      <p className="trainer-settle-hint">
+        共 {stats.completedSessions} 局打完{periods && ` · ${periods}`}
+        {stats.unfinishedSessions > 0 && ` · 另有 ${stats.unfinishedSessions} 局开了没打完，不计入`}
+      </p>
+
+      <Card className="training-stats-overview">
+        <Guard block={stats.overview} unit="完成的局">
+          <div className="trainer-review-figs">
+            <Figure label="累计净 R" value={signed(stats.overview.netR)} />
+            <Figure label="胜率" value={pct(stats.overview.winRate)} />
+            <Figure
+              label="计划盈亏比 → 实际拿到"
+              value={`${fmt(stats.overview.plannedRewardRisk ?? 0)} → ${fmt(stats.overview.realizedRewardRisk ?? 0)}`}
+              hint="这一栏最该先看：它分开「位置选得差」和「拿不住」"
+            />
+            <Figure label="最大浮盈回吐比例" value={pct(stats.overview.mfeGivebackRate)} />
+          </div>
+        </Guard>
+      </Card>
+
+      <div className="training-stats-grid">
+        <Card>
+          <h4>按结构标签</h4>
+          {stats.byTag.length === 0 && <p className="trainer-settle-hint">还没有打完的局。</p>}
+          {stats.byTag.map((row) => (
+            <div className="training-stats-kv" key={row.tag ?? 'untagged'}>
+              <span>{row.tag ? TRAINER_CASE_TAG_LABEL[row.tag] : '未标注'}</span>
+              <b>
+                {row.locked
+                  ? `${row.samples} 局，样本不足`
+                  : `${signed(row.netR)}R · ${pct(row.winRate)}`}
+              </b>
+            </div>
+          ))}
+        </Card>
+
+        <Card>
+          <h4>止损体检</h4>
+          <Guard block={stats.stopHealth} unit="被止损的局">
+            <div className="training-stats-kv">
+              <span>被止损后仍到过目标</span>
+              <b>{pct(stats.stopHealth.reachedTargetAfterStopRate)}</b>
+            </div>
+            <div className="training-stats-kv">
+              <span>止损被打的平均超出</span>
+              <b>{fmt(stats.stopHealth.averageOvershootPct ?? 0)}%</b>
+            </div>
+          </Guard>
+          <p className="trainer-settle-hint">
+            实盘被止损后没有平行世界，看不到这个数。
+          </p>
+        </Card>
+
+        <Card>
+          <h4>AI 陪练影响</h4>
+          <Guard block={stats.coachInfluence} unit="有分歧的召唤">
+            <div className="training-stats-kv">
+              <span>被说服改主意</span>
+              <b>
+                {pct(stats.coachInfluence.persuadedWinRate)}（{stats.coachInfluence.persuadedCount}
+                次）
+              </b>
+            </div>
+            <div className="training-stats-kv">
+              <span>坚持自己判断</span>
+              <b>
+                {pct(stats.coachInfluence.heldWinRate)}（{stats.coachInfluence.heldCount} 次）
+              </b>
+            </div>
+          </Guard>
+          <p className="trainer-settle-hint">
+            只统计有分歧的召唤，同向的不计 —— 否则「AI 附和我」会被灌水成「AI 说服我」。
+          </p>
+        </Card>
+
+        <Card>
+          <h4>推进方式影响</h4>
+          <Guard block={stats.advanceStyle} unit="成交的笔">
+            <div className="training-stats-kv">
+              <span>逐根推进期间持仓</span>
+              <b>{pct(stats.advanceStyle.barByBarWinRate)}</b>
+            </div>
+            <div className="training-stats-kv">
+              <span>大周期快进期间持仓</span>
+              <b>{pct(stats.advanceStyle.fastForwardWinRate)}</b>
+            </div>
+          </Guard>
+          <p className="trainer-settle-hint">放弃观察权的代价。</p>
+        </Card>
+
+        <Card>
+          <h4>AI 成绩单</h4>
+          <Guard block={stats.coachScorecard} unit="召唤">
+            <div className="training-stats-kv">
+              <span>方向准确率</span>
+              <b>
+                {pct(stats.coachScorecard.directionAccuracy)}（{stats.coachScorecard.settled}
+                次有结果）
+              </b>
+            </div>
+            <div className="training-stats-kv">
+              <span>其中理由站得住</span>
+              <b>{pct(stats.coachScorecard.soundReasonRate)}</b>
+            </div>
+            <div className="training-stats-kv">
+              <span>结论对但理由错</span>
+              <b>{pct(stats.coachScorecard.rightCallWrongReasonRate)}</b>
+            </div>
+          </Guard>
+          <p className="trainer-settle-hint">靠错逻辑蒙对的，下次必错。</p>
+        </Card>
+      </div>
+
+      <p className="trainer-settle-hint training-stats-guard-note">
+        任何一块样本不足 10 就只报个数，不报比率。刷了 3 局赢 3 局显示「胜率 100%」，那个数字唯一的作用是骗你。
+      </p>
+    </div>
+  );
+}
+
+/**
+ * A locked block says how many samples it has and stops. It does not render a zero, a dash in
+ * place of a ratio, or a bar at 0% — each of those reads as a measurement, and there isn't one.
+ */
+function Guard({
+  block,
+  unit,
+  children,
+}: {
+  block: TrainerStatBlock;
+  unit: string;
+  children: React.ReactNode;
+}) {
+  if (!block.locked) return <>{children}</>;
+  return (
+    <div className="training-stats-locked" data-testid="training-stats-locked">
+      只有 <b>{block.samples}</b> {unit}
+      <br />
+      样本太少，不出比率
+    </div>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <figure className="trainer-fig">
+      <figcaption>{label}</figcaption>
+      <div className="num trainer-fig-val">{value}</div>
+      {hint && <div className="trainer-fig-sub">{hint}</div>}
+    </figure>
+  );
+}

--- a/apps/web/src/features/training/caseTagLabels.ts
+++ b/apps/web/src/features/training/caseTagLabels.ts
@@ -1,0 +1,9 @@
+import type { TrainerCaseTag } from '@kansoku/pro-api';
+
+export const TRAINER_CASE_TAG_LABEL: Record<TrainerCaseTag, string> = {
+  'trend-follow': '趋势跟随',
+  'pullback-entry': '回调买点',
+  'false-breakout': '假突破',
+  'top-reversal': '顶部反转',
+  'range-bound': '区间震荡',
+};

--- a/apps/web/src/features/training/coachStance.ts
+++ b/apps/web/src/features/training/coachStance.ts
@@ -1,0 +1,43 @@
+import type { TrainerCoachCall, TrainerDirection, TrainerView } from '@kansoku/pro-api';
+
+export const DIRECTION_LABEL: Record<TrainerDirection | 'neutral', string> = {
+  long: '做多',
+  short: '做空',
+  neutral: '观望',
+};
+
+/**
+ * The AI stays sealed until the trader has committed to a direction and three prices of their own.
+ *
+ * Asking first turns the session into copying an answer, and it anchors every annotation they will
+ * later give — "the AI was right" quietly becomes "we agreed". The runtime refuses the same call
+ * for the same reason; this only keeps the button from lying about being available.
+ */
+export function coachUnlocked(view: TrainerView): boolean {
+  return view.submitted;
+}
+
+export function coachLockReason(view: TrainerView): string | undefined {
+  return coachUnlocked(view) ? undefined : '先提交你自己的方向与三价，AI 的看法才解锁';
+}
+
+export interface CoachPlanLine {
+  direction: TrainerDirection | 'neutral';
+  prices: string | null;
+}
+
+export function coachPlanLine(call: TrainerCoachCall): CoachPlanLine {
+  const plan = call.ai.entry_plan;
+  return {
+    direction: call.ai.direction,
+    prices: plan ? `${plan.entry} / ${plan.stop} / ${plan.target1 ?? '—'}` : null,
+  };
+}
+
+/**
+ * Whether the two sides actually disagreed. Only a disagreement can go on to be counted as
+ * influence — an AI that agreed moved nobody, and folding those in would drown the contrast.
+ */
+export function coachDisagrees(call: TrainerCoachCall): boolean {
+  return call.ai.direction !== call.humanBefore.direction;
+}

--- a/apps/web/src/features/training/episodeReturns.test.ts
+++ b/apps/web/src/features/training/episodeReturns.test.ts
@@ -27,6 +27,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/orderDraft.test.ts
+++ b/apps/web/src/features/training/orderDraft.test.ts
@@ -45,6 +45,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/payloadToIntradayBuilt.test.ts
+++ b/apps/web/src/features/training/payloadToIntradayBuilt.test.ts
@@ -71,6 +71,7 @@ function makeView(overrides?: Partial<TrainerView>): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/payloadToIntradayBuilt.ts
+++ b/apps/web/src/features/training/payloadToIntradayBuilt.ts
@@ -221,7 +221,7 @@ function episodeMarkers(
   return placed.map((entry) => entry.marker);
 }
 
-function rawBarsToTfData(
+export function rawBarsToTfData(
   bars: RawBar[],
   trades: readonly TrainerClosedTrade[],
   position: TrainerPosition | null,
@@ -269,7 +269,7 @@ function rawBarsToTfData(
   };
 }
 
-function emptyTfSummary(): IntradayTfSummary {
+export function emptyTfSummary(): IntradayTfSummary {
   return {
     last_dif: null,
     last_dea: null,

--- a/apps/web/src/features/training/quickEntry.test.ts
+++ b/apps/web/src/features/training/quickEntry.test.ts
@@ -62,6 +62,7 @@ function makeView(bars: { base: RawBar[]; mid?: RawBar[]; top?: RawBar[] }): Tra
     remainingBars: 10,
     terminal: false,
     result: null,
+    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/remainingBars.test.ts
+++ b/apps/web/src/features/training/remainingBars.test.ts
@@ -30,6 +30,7 @@ function makeView(base: RawBar[], remainingBars: number): TrainerView {
     remainingBars,
     terminal: false,
     result: null,
+    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/replayBands.test.ts
+++ b/apps/web/src/features/training/replayBands.test.ts
@@ -33,6 +33,7 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
+    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/reviewChart.test.ts
+++ b/apps/web/src/features/training/reviewChart.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { TrainerClosedTrade, TrainerReviewPayload } from '@kansoku/pro-api';
+import type { RawBar } from '@kansoku/shared/types';
+import { reviewBands, reviewSeries, reviewTrades } from './reviewChart';
+
+function bar(iso: string, close: number): RawBar {
+  return { time: iso, open: close - 1, high: close + 1, low: close - 1.5, close, volume: 1000 };
+}
+
+const LOOKBACK = [bar('2026-01-05T13:50:00.000Z', 98), bar('2026-01-05T13:55:00.000Z', 99)];
+const REPLAY = [
+  bar('2026-01-05T14:00:00.000Z', 100),
+  bar('2026-01-05T14:05:00.000Z', 101),
+  bar('2026-01-05T14:10:00.000Z', 102),
+  bar('2026-01-05T14:15:00.000Z', 103),
+  bar('2026-01-05T14:20:00.000Z', 104),
+];
+const EPILOGUE = [bar('2026-01-05T14:25:00.000Z', 106), bar('2026-01-05T14:30:00.000Z', 108)];
+
+function trade(entryTime: string, exitTime: string, tradeId = 1): TrainerClosedTrade {
+  return {
+    tradeId,
+    direction: 'long',
+    decisionBar: 0,
+    decisionTime: entryTime,
+    entry: { time: entryTime, price: 100 },
+    exit: { time: exitTime, price: 103 },
+    exitReason: 'target',
+    initialStop: 98,
+    finalStop: 98,
+    target: 103,
+    initialRisk: 2,
+    grossR: 1.5,
+    frictionR: 0,
+    netR: 1.5,
+    mfeR: 1.5,
+    maeR: 0,
+    holdingBars: 3,
+  };
+}
+
+function payload(overrides: Partial<TrainerReviewPayload> = {}): TrainerReviewPayload {
+  return {
+    sessionId: 'run-1',
+    caseId: 'case-1',
+    symbol: 'TRAIN01',
+    basePeriod: '5m',
+    ladder: ['5m', '15m', '1h'],
+    provenance: {
+      outputId: 'case-1',
+      aliasSymbol: 'TRAIN01',
+      sourceId: 'src-1',
+      sourceSymbol: 'REALCANARY.US',
+      sourceCutoff: '2019-04-01T20:00:00.000Z',
+      syntheticCutoff: '2026-01-05T13:55:00.000Z',
+      dayShift: 1064,
+      priceScale: 0.1,
+      volumeScale: 7,
+    },
+    tag: 'false-breakout',
+    lookback: LOOKBACK,
+    replay: REPLAY,
+    epilogue: EPILOGUE,
+    playedThrough: 2,
+    trades: [trade('2026-01-05T14:00:00.000Z', '2026-01-05T14:10:00.000Z')],
+    result: null,
+    events: [],
+    coach: [],
+    facts: {
+      stopAutopsy: null,
+      holdToEpilogueEndR: null,
+      afterExitHighR: null,
+      afterExitLowR: null,
+    },
+    lesson: null,
+    ...overrides,
+  };
+}
+
+describe('reviewSeries', () => {
+  it('stops at the brush so the chart comes back to what was on screen then', () => {
+    const bars = reviewSeries(payload(), 1, true);
+
+    expect(bars.map((b) => b.time)).toEqual([
+      LOOKBACK[0].time,
+      LOOKBACK[1].time,
+      REPLAY[0].time,
+      REPLAY[1].time,
+    ]);
+  });
+
+  it('joins the epilogue only when the brush is parked at the end', () => {
+    expect(reviewSeries(payload(), 4, true).at(-1)!.time).toBe(EPILOGUE[1].time);
+    expect(reviewSeries(payload(), 3, true).at(-1)!.time).toBe(REPLAY[3].time);
+  });
+
+  it('leaves the epilogue off when the toggle is off', () => {
+    expect(reviewSeries(payload(), 4, false).at(-1)!.time).toBe(REPLAY[4].time);
+  });
+});
+
+describe('reviewTrades', () => {
+  it('hides a trade that had not been entered yet at the brush position', () => {
+    expect(reviewTrades(payload(), 0)).toHaveLength(1);
+    expect(
+      reviewTrades(
+        payload({ trades: [trade('2026-01-05T14:15:00.000Z', '2026-01-05T14:20:00.000Z')] }),
+        1,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('reviewBands', () => {
+  it('separates what was handed over, what was played, and what was never reached', () => {
+    const kinds = reviewBands(payload(), 4, false).map((band) => band.kind);
+
+    expect(kinds).toEqual(['given', 'played', 'fog']);
+  });
+
+  it('drops the fog band once the brush is back inside the played run', () => {
+    expect(reviewBands(payload(), 2, false).map((band) => band.kind)).toEqual(['given', 'played']);
+  });
+
+  it('adds the epilogue band only with the brush at the end and the toggle on', () => {
+    expect(reviewBands(payload(), 4, true).map((band) => band.kind)).toContain('epilogue');
+    expect(reviewBands(payload(), 3, true).map((band) => band.kind)).not.toContain('epilogue');
+  });
+
+  it('leaves the given band left-unbounded so older history is covered too', () => {
+    const given = reviewBands(payload(), 4, false)[0];
+
+    expect(given.startTime).toBe(0);
+    expect(given.endTime).toBe(Math.floor(Date.parse(LOOKBACK[1].time) / 1000));
+  });
+});

--- a/apps/web/src/features/training/reviewChart.ts
+++ b/apps/web/src/features/training/reviewChart.ts
@@ -1,0 +1,133 @@
+import type { TrainerClosedTrade, TrainerReviewPayload } from '@kansoku/pro-api';
+import type { IntradayBuilt, IntradayTfData, RawBar } from '@kansoku/shared/types';
+import type { ChartTf } from '../charts/intraday/timeframes';
+import type { ReplayBand } from '../charts/intraday/replayBandPrimitive';
+import {
+  emptyTfSummary,
+  rawBarsToTfData,
+  TRAINER_PERIOD_TO_CHART_TF,
+} from './payloadToIntradayBuilt';
+
+const sec = (iso: string): number => Math.floor(Date.parse(iso) / 1000);
+
+export function reviewChartTf(payload: TrainerReviewPayload): ChartTf {
+  return TRAINER_PERIOD_TO_CHART_TF[payload.basePeriod];
+}
+
+/** The last playable bar, where the brush rests until the trader drags it. */
+export function reviewMaxBrush(payload: TrainerReviewPayload): number {
+  return Math.max(0, payload.replay.length - 1);
+}
+
+function atEnd(payload: TrainerReviewPayload, brush: number): boolean {
+  return brush >= reviewMaxBrush(payload);
+}
+
+/**
+ * Bars up to the brush, and no further. Dragging it left is the whole point of the page: the chart
+ * has to come back to what was on screen at that bar, which means the bars after it stop existing
+ * rather than merely dimming.
+ *
+ * The epilogue only joins when the brush is parked at the end. Splicing it onto a rewound chart
+ * would put post-case prices immediately after a mid-case bar.
+ */
+export function reviewSeries(
+  payload: TrainerReviewPayload,
+  brush: number,
+  showEpilogue: boolean,
+): RawBar[] {
+  const played = payload.replay.slice(0, Math.max(0, brush) + 1);
+  const tail = showEpilogue && atEnd(payload, brush) ? payload.epilogue : [];
+  return [...payload.lookback, ...played, ...tail];
+}
+
+/**
+ * A trade the trader had not made yet at the brush position is not drawn. Rewinding the chart and
+ * leaving the marks on would show them an entry they had not taken, which is the one thing this
+ * page exists to reconstruct honestly.
+ */
+export function reviewTrades(
+  payload: TrainerReviewPayload,
+  brush: number,
+): TrainerClosedTrade[] {
+  const cutoff = payload.replay[Math.max(0, brush)];
+  if (!cutoff) return [];
+  const cutoffMs = Date.parse(cutoff.time);
+  return payload.trades.filter((trade) => Date.parse(trade.entry.time) <= cutoffMs);
+}
+
+/**
+ * Three visibility classes plus the epilogue: what the case handed over, what the trader stepped
+ * through, and the stretch they never reached because they closed out first.
+ */
+export function reviewBands(
+  payload: TrainerReviewPayload,
+  brush: number,
+  showEpilogue: boolean,
+): ReplayBand[] {
+  const bands: ReplayBand[] = [];
+  const lastGiven = payload.lookback.at(-1);
+  // Left-unbounded rather than anchored to the first bar: everything before the cutoff was equally
+  // handed over, including history older than the array happens to carry.
+  if (lastGiven) bands.push({ kind: 'given', startTime: 0, endTime: sec(lastGiven.time) });
+
+  const shown = Math.min(Math.max(0, brush), reviewMaxBrush(payload));
+  const playedTo = Math.min(shown, payload.playedThrough);
+  if (payload.replay.length > 0 && playedTo >= 0) {
+    bands.push({
+      kind: 'played',
+      startTime: sec(payload.replay[0].time),
+      endTime: sec(payload.replay[playedTo].time),
+    });
+  }
+  if (shown > payload.playedThrough) {
+    bands.push({
+      kind: 'fog',
+      startTime: sec(payload.replay[payload.playedThrough + 1].time),
+      endTime: sec(payload.replay[shown].time),
+    });
+  }
+  if (showEpilogue && atEnd(payload, brush) && payload.epilogue.length > 0) {
+    bands.push({
+      kind: 'epilogue',
+      startTime: sec(payload.epilogue[0].time),
+      endTime: sec(payload.epilogue.at(-1)!.time),
+    });
+  }
+  return bands;
+}
+
+export function buildReviewBuilt(
+  payload: TrainerReviewPayload,
+  brush: number,
+  showEpilogue: boolean,
+): IntradayBuilt {
+  const tf = reviewChartTf(payload);
+  const bars = reviewSeries(payload, brush, showEpilogue);
+  const timeframes: Record<string, IntradayTfData> = {
+    [tf]: rawBarsToTfData(bars, reviewTrades(payload, brush), null),
+  };
+  return {
+    kind: 'intraday',
+    // `defaultTf` is only consulted when no `activeTf` is passed, and the review chart always
+    // passes one — the base period, which may be a tier this union does not name.
+    defaultTf: 'm5',
+    timeframes: timeframes as IntradayBuilt['timeframes'],
+    entryPlan: null,
+    sidebar: {
+      symbol: payload.symbol,
+      name: payload.symbol,
+      asOf: bars.at(-1)?.time ?? '',
+      last: Number(bars.at(-1)?.close ?? 0),
+      prediction: null,
+      entryPlan: null,
+      position: null,
+      technicals: { m5: emptyTfSummary(), m15: emptyTfSummary(), h1: emptyTfSummary() },
+      dayContext: null,
+      optionsLevels: null,
+      eventRisk: null,
+      news: [],
+      context: null,
+    },
+  };
+}

--- a/apps/web/src/features/training/settlementStats.ts
+++ b/apps/web/src/features/training/settlementStats.ts
@@ -1,8 +1,10 @@
-import type {
-  TrainerClosedTrade,
-  TrainerResult,
-  TrainerTradeExit,
-  TrainerTradeLot,
+import {
+  trainerMfeGivebackR,
+  trainerPlannedRewardRisk,
+  type TrainerClosedTrade,
+  type TrainerResult,
+  type TrainerTradeExit,
+  type TrainerTradeLot,
 } from '@kansoku/pro-api';
 import { FULL_POSITION } from './orderDraft';
 
@@ -37,17 +39,9 @@ export interface SettlementSummary {
   lossCount: number;
 }
 
-// Judged at the first fill, never at the average of the lots: `initialRisk` is the risk unit the
-// engine locked against that same first price, so pairing it with a post-add average would produce
-// a ratio measured with two different rulers.
-export function plannedRewardRisk(trade: TrainerClosedTrade): number | null {
-  if (trade.initialRisk <= 0) return null;
-  return Math.abs(trade.target - tradeEntryFills(trade)[0].price) / trade.initialRisk;
-}
+export const plannedRewardRisk = trainerPlannedRewardRisk;
 
-export function mfeGivebackR(trade: TrainerClosedTrade): number {
-  return Math.max(0, trade.mfeR - trade.netR);
-}
+export const mfeGivebackR = trainerMfeGivebackR;
 
 export function settlementTradeRows(trades: readonly TrainerClosedTrade[]): SettlementTradeRow[] {
   return trades.map((trade) => ({

--- a/apps/web/src/generated-routes.ts
+++ b/apps/web/src/generated-routes.ts
@@ -18,7 +18,8 @@ import * as SyncComponent8 from "./pages/research/index.sync"
 import * as SyncComponent9 from "./pages/settings.sync"
 import * as SyncComponent10 from "./pages/symbol/[sym].sync"
 import * as SyncComponent11 from "./pages/symbol/sepa/[sym].sync"
-import * as SyncComponent12 from "./pages/index.sync"
+import * as SyncComponent12 from "./pages/training/stats.sync"
+import * as SyncComponent13 from "./pages/index.sync"
 
 // Generated route configuration
 export const routes: RouteObject[] = [
@@ -125,10 +126,21 @@ export const routes: RouteObject[] = [
     ]
   },
   {
+    "path": "training",
+    "children": [
+      {
+        "path": "stats",
+        "Component": SyncComponent12.Component,
+        "loader": SyncComponent12.loader,
+        "handle": SyncComponent12.handle
+      }
+    ]
+  },
+  {
     "path": "",
-    "Component": SyncComponent12.Component,
-    "loader": SyncComponent12.loader,
-    "handle": SyncComponent12.handle
+    "Component": SyncComponent13.Component,
+    "loader": SyncComponent13.loader,
+    "handle": SyncComponent13.handle
   }
 ]
 

--- a/apps/web/src/pages/training/stats.sync.tsx
+++ b/apps/web/src/pages/training/stats.sync.tsx
@@ -1,0 +1,5 @@
+import { TrainingStatsPage } from '@web/features/training/TrainingStatsPage';
+
+export function Component() {
+  return <TrainingStatsPage />;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9240,3 +9240,290 @@ a.zone-item:hover {
 .settings-about-link a:hover {
   color: var(--text-primary);
 }
+
+/* Blind-replay trainer — AI sparring, review tab and cross-session statistics (M4 / M5). */
+
+.trainer-tabs {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+  -webkit-app-region: no-drag;
+}
+.trainer-tab {
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+}
+.trainer-tab--on {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.trainer-coach-lane {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 16px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+}
+.trainer-coach-comment {
+  margin: 0;
+  flex: 1 1 240px;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+}
+.trainer-chip--coach {
+  border-left: 2px solid var(--accent);
+}
+.trainer-coach-split {
+  color: var(--accent);
+}
+
+/* The review tab scrolls as one document: the chart is a fixed slab at the top and everything
+   below it is prose the trader reads once, not a pane that has to keep its own scroll position. */
+.trainer-shell--postmortem {
+  overflow-y: auto;
+}
+.trainer-shell--postmortem .trainer-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.trainer-review {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 16px;
+}
+.trainer-review-reveal {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.trainer-review-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.trainer-review-chart {
+  height: 320px;
+  border: 1px solid var(--border);
+}
+.trainer-review-legend-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+}
+.trainer-band-swatch--fog {
+  background: #202020;
+}
+
+.trainer-review-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.trainer-review-track {
+  position: relative;
+  height: 18px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+}
+.trainer-review-track-fog {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: rgb(232 232 232 / 0.05);
+}
+.trainer-review-tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  padding: 0 2px;
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 16px;
+  cursor: pointer;
+}
+.trainer-review-tick--entry {
+  color: var(--up);
+}
+.trainer-review-tick--stop {
+  color: var(--down);
+}
+.trainer-review-tick--target {
+  color: var(--up);
+}
+.trainer-review-tick--coach {
+  color: var(--accent);
+}
+.trainer-review-brush {
+  width: 100%;
+  accent-color: var(--accent);
+}
+.trainer-review-scale {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.trainer-label {
+  font-size: var(--fs-sm);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.trainer-review-facts,
+.trainer-review-coach,
+.trainer-review-lesson {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.trainer-review-figs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
+}
+
+.trainer-coach-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.trainer-coach-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: var(--fs-sm);
+}
+.trainer-coach-at {
+  cursor: pointer;
+  font: inherit;
+}
+.trainer-coach-body {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+}
+.trainer-coach-annotate {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+}
+.trainer-chip--persuaded {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.trainer-chip--hit {
+  border-color: var(--up);
+  color: var(--up);
+}
+.trainer-chip--miss {
+  border-color: var(--down);
+  color: var(--down);
+}
+
+.trainer-review-lesson-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.trainer-lesson-input {
+  flex: 1 1 260px;
+  min-width: 0;
+  height: var(--control-h);
+  box-sizing: border-box;
+  padding: 0 10px;
+  background: var(--bg-element);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.training-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+.training-stats-back {
+  margin-left: 10px;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+.training-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+.training-stats-kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 3px 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+}
+.training-stats-kv b {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+/* Hatched rather than merely greyed: a locked card must not read as a card whose numbers happen
+   to be small. */
+.training-stats-locked {
+  background: repeating-linear-gradient(
+    135deg,
+    transparent,
+    transparent 5px,
+    rgb(255 255 255 / 0.028) 5px,
+    rgb(255 255 255 / 0.028) 10px
+  );
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  padding: 12px 10px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+}
+.training-stats-guard-note {
+  border-left: 2px solid var(--accent);
+  padding-left: 10px;
+}
+.trainer-card-stats {
+  align-self: center;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}

--- a/docs/superpowers/specs/2026-07-28-blind-replay-trainer-m4-m5-design.md
+++ b/docs/superpowers/specs/2026-07-28-blind-replay-trainer-m4-m5-design.md
@@ -1,7 +1,7 @@
 # 盲盘训练 M4 + M5：AI 陪练、复盘与统计
 
 日期：2026-07-28
-状态：设计已确认，待实现
+状态：已实现（2026-07-29），实现时的偏离见 §10
 上游：[2026-07-25-blind-replay-training-design.md](./2026-07-25-blind-replay-training-design.md)（母设计，本文是它 §7 §8 的落地方案）
 
 ## 1. 范围
@@ -23,13 +23,13 @@
 
 **这件事在 M2 做 bench mock 时已经顺手完成了。** 现状：
 
-| 现成件 | 位置 | 作用 |
-| --- | --- | --- |
-| `AnalystDeps` | `packages/core/src/ai/personas/analyst/types.ts:12` | `fetchKline` / `fetchNews` / `buildReassessPack` / `now` 全部可注入 |
-| `createMockDeps` | `apps/pro/src/bench/mock/index.ts:113` | 把 analyst 整个接到 `Question` fixtures 上 |
-| `composeCellSession` | `apps/pro/src/bench/runner/session.ts:39` | 给定 `RunnerQuestion` → 跑出一个 `Submission` |
-| `buildEpisodeQuestionViewAtCursor` | `packages/bench/src/episode/view.ts:104` | 给定 case + 游标 → 截断到那一刻的 `RunnerQuestion` |
-| `replayDirectional` | `packages/bench/src/score/replay.ts:43` | 给定三价 + 之后的 bars → win / loss / timeout_flat / no_fill + 实际 R |
+| 现成件                             | 位置                                                | 作用                                                                  |
+| ---------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
+| `AnalystDeps`                      | `packages/core/src/ai/personas/analyst/types.ts:12` | `fetchKline` / `fetchNews` / `buildReassessPack` / `now` 全部可注入   |
+| `createMockDeps`                   | `apps/pro/src/bench/mock/index.ts:113`              | 把 analyst 整个接到 `Question` fixtures 上                            |
+| `composeCellSession`               | `apps/pro/src/bench/runner/session.ts:39`           | 给定 `RunnerQuestion` → 跑出一个 `Submission`                         |
+| `buildEpisodeQuestionViewAtCursor` | `packages/bench/src/episode/view.ts:104`            | 给定 case + 游标 → 截断到那一刻的 `RunnerQuestion`                    |
+| `replayDirectional`                | `packages/bench/src/score/replay.ts:43`             | 给定三价 + 之后的 bars → win / loss / timeout_flat / no_fill + 实际 R |
 
 最后两个是同一个接口的两头，**只是从没被接上过**。`session.ts` 已经在用 `buildEpisodeQuestionViewAtCursor` 给人渲染图表；M4 要做的就是把同一个函数的输出再喂给 AI 一次。
 
@@ -75,12 +75,12 @@ session 文件从 `version: 1` 升到 `2`，加一个 `coach: TrainerCoachCall[]
 ```ts
 interface TrainerCoachCall {
   id: string;
-  cursor: number;                     // 召唤时游标
+  cursor: number; // 召唤时游标
   askedAt: string;
-  humanBefore: TrainerSubmission;     // 召唤那一刻人的判断快照
-  ai: TrainerSubmission;              // AI 的判断
-  verdict: TrainerCoachVerdict | null;    // 局终才填
-  annotation: TrainerAnnotation | null;   // 人工标注
+  humanBefore: TrainerSubmission; // 召唤那一刻人的判断快照
+  ai: TrainerSubmission; // AI 的判断
+  verdict: TrainerCoachVerdict | null; // 局终才填
+  annotation: TrainerAnnotation | null; // 人工标注
 }
 ```
 
@@ -94,11 +94,11 @@ interface TrainerCoachCall {
 
 三档判定：
 
-| 情形 | 记为 |
-| --- | --- |
-| AI 与 `humanBefore` **同向** | 不进对照 |
-| **分歧**，且人在归属窗口内按 AI 方向重新 submit | 被说服 |
-| **分歧**，归属窗口内人没改方向 | 坚持 |
+| 情形                                            | 记为     |
+| ----------------------------------------------- | -------- |
+| AI 与 `humanBefore` **同向**                    | 不进对照 |
+| **分歧**，且人在归属窗口内按 AI 方向重新 submit | 被说服   |
+| **分歧**，归属窗口内人没改方向                  | 坚持     |
 
 **归属窗口 = 这次召唤之后、到下一次召唤或局终为止。** 不写死这个窗口的话，一局里召唤三次，人在最后改了方向，三次召唤会同时被记成「说服了他」，一次操作被算三遍。窗口内发生的第一次方向变更归给窗口所属的那次召唤。
 
@@ -272,3 +272,18 @@ bench 是 CLI 跑的，`repoRoot` 现成；训练器跑在 Electron 里，打包
 **实现计划的第一个任务就是探这个，不是写功能。** 探不通就整期停下来重新设计，不带着一个「本地能跑、打包就废」的方案往下滚。
 
 次要风险：session 文件扫全量做统计，局数多了会慢。先不优化——几百局的规模无所谓，真慢了再加索引。
+
+## 10. 实现时的偏离（2026-07-29）
+
+§9 的唯一真风险先探了：**scaffold 在 Electron 里拿得到，不需要重新设计。** app 侧的 analyst 本来就在跑同一条链路（`loadSkillIndex(skillSearchDirs(repoRoot))` + 读 `intraday-signal` SKILL.md + 读 trading-discipline），打包后 `stageSkills.mjs` 把整个 `.claude/skills` 解引用拷进 `Resources/skills`，`boot/env.ts` 软链到数据目录并把 `TRADE_PROJECT_ROOT` 指过去。实测 `loadAnalystScaffold()` 在开发态返回 32 个 skill、21979 字节 skill 正文、12731 字节纪律正文（含 `episode-execution` 章节）；`dist-skills` 里 `intraday-signal/SKILL.md` 与 `trading-discipline/references/episode-execution.md` 都在。
+
+以下几处与前文写法不同，**现状以本节为准**：
+
+- **`humanBefore` 不是完整的 `TrainerSubmission`，是一份精简的方向快照**（`TrainerCoachStance`：方向 + 三价）。它由 pro 侧从引擎状态现读——挂单期读 `order`，持仓期读 `position`，都没有就回落到最后一条 `submit` 动作记录——而不是由前端传上来。整个对照实验的支点是「他当时真的这么想」，这件事不能让调用方事后重述。
+- **`TrainerCoachCall` 多了一个 `step` 字段**，是引擎自己的单调动作计数。§3.4 的归属窗口只能挂在它上面：submit 和 cancel 都不推进游标，光靠 `cursor` 的话同一根上的两次召唤会抢同一次改主意。
+- **`TrainerView` 多了一个 `submitted` 字段**（首次提交后永久为真）。前端的锁与运行时的锁必须是同一个条件——观望提交会立判据成立却不产生挂单/持仓/成交，光看那三样会让按钮比服务端更严。
+- **复盘页的图只画基础周期。** 时间轴刷子直接切基础 K 线；把梯队的上层周期在渲染端重新聚合，等于把「一根上层周期等于几根基础 K 线」这条规则抄第二份到前端，与它真正结算用的那份自由漂移。
+- **不揭晓难度。** 母设计 §8 写了「AI 打的标签与难度」，但 M2 落地的 `CasePick` 只有 `worthy` / `tag` / `reason`，没有难度这个字段。揭晓页只报标签。
+- **`plannedRewardRisk` / `mfeGivebackR` 搬进了 `packages/pro-api`**（`trainerTrade.ts`）。结算面板在 `apps/web`、统计在 `apps/pro`，开源边界不允许 web 反向引 pro，两边各留一份必然漂移，所以这两个纯函数跟着契约走。
+- **`TrainerCoachScorecard` 多报一个 `settled`。** 护栏的样本单位按 §4.3 是总召唤次数，但方向准确率的分母只能是市场真的结算过的那几次（win / loss / timeout_flat）。两个数都报出来，「21 次召唤 52%」才不会盖住「其中只有 4 次跑出了结果」。
+- **`no_fill` / `format_violation` / `abstained` 一律不进方向准确率**，只进样本计数。这三种都不是市场判过对错的方向，算进任何一边都会挪动那个数字而不测量任何东西。

--- a/docs/superpowers/specs/2026-07-28-blind-replay-trainer-m4-m5-design.md
+++ b/docs/superpowers/specs/2026-07-28-blind-replay-trainer-m4-m5-design.md
@@ -1,0 +1,274 @@
+# 盲盘训练 M4 + M5：AI 陪练、复盘与统计
+
+日期：2026-07-28
+状态：设计已确认，待实现
+上游：[2026-07-25-blind-replay-training-design.md](./2026-07-25-blind-replay-training-design.md)（母设计，本文是它 §7 §8 的落地方案）
+
+## 1. 范围
+
+一次做完母设计里的两期：
+
+- **M4 — AI 陪练与标注**：局中手动召唤 AI 给第二意见，局终自动判定它的对错，对判对的那些请求人工标注「理由站不站得住」。
+- **M5 — 复盘与统计**：复盘页重放整局，跨局统计面板，教训沉淀通道。
+
+**回流导出（评测集与偏差报告）砍出本期**，理由见 §8。
+
+全部功能属于 Pro。
+
+## 2. 关键发现：工程量比母设计的预估小得多
+
+母设计 §7 把「pipeline 数据注入改造」列为**本设计最大的单项工程**：
+
+> 现有 pipeline 面向实时市场编写，自行拉取长桥、新闻、宏观。必须将数据获取抽成可注入接口。
+
+**这件事在 M2 做 bench mock 时已经顺手完成了。** 现状：
+
+| 现成件 | 位置 | 作用 |
+| --- | --- | --- |
+| `AnalystDeps` | `packages/core/src/ai/personas/analyst/types.ts:12` | `fetchKline` / `fetchNews` / `buildReassessPack` / `now` 全部可注入 |
+| `createMockDeps` | `apps/pro/src/bench/mock/index.ts:113` | 把 analyst 整个接到 `Question` fixtures 上 |
+| `composeCellSession` | `apps/pro/src/bench/runner/session.ts:39` | 给定 `RunnerQuestion` → 跑出一个 `Submission` |
+| `buildEpisodeQuestionViewAtCursor` | `packages/bench/src/episode/view.ts:104` | 给定 case + 游标 → 截断到那一刻的 `RunnerQuestion` |
+| `replayDirectional` | `packages/bench/src/score/replay.ts:43` | 给定三价 + 之后的 bars → win / loss / timeout_flat / no_fill + 实际 R |
+
+最后两个是同一个接口的两头，**只是从没被接上过**。`session.ts` 已经在用 `buildEpisodeQuestionViewAtCursor` 给人渲染图表；M4 要做的就是把同一个函数的输出再喂给 AI 一次。
+
+所以 M4 的真实工作量在别处：锁定顺序、召唤记录的存储结构、判定时机、结算页的对照与标注 UI。
+
+## 3. M4 — AI 陪练
+
+### 3.1 召唤链路
+
+```
+点「问 AI」（人已提交方向+三价才解锁）
+  → trainerRuntime.coach({ sessionId })
+  → buildEpisodeQuestionViewAtCursor(case, state.cursor)   // → RunnerQuestion
+  → composeCellSession({ question, mode: 'blind', model, scaffold })
+  → 跑出一个 Submission
+  → 追加一条 coach 记录到 session 文件
+```
+
+**锁定顺序不可妥协**（母设计 §7）：没提交自己的判断之前，「问 AI」是 disabled。开局即可问 AI 的话，训练退化成抄答案，标注也被锚定污染。
+
+解锁后手动触发、不限次数，token 成本由用户自己掌握。
+
+### 3.2 防泄漏
+
+这是本期最需要下功夫的地方，因为**泄漏是静默的**：AI 偷看了未来，表现出来只是「它怎么这么准」，没有任何一环会报错。错误数据会一路流进标注、统计，最后流进「改 prompt」的决策。
+
+三层防御：
+
+**第一层，类型。** `Question` 有 `replay` 字段（未来的可交易段），`RunnerQuestion` **没有这个字段**。coach 链路全程只碰 `RunnerQuestion`，未来在类型上就不存在。
+
+这一层顺带堵死了最危险的一处：`buildRunCodeTool`（`apps/pro/src/bench/mock/index.ts:92`）把 `question.fixtures.kline` **整个塞进沙箱 globals**，绕开工具直接给数据。如果拿到的是原始 `Question`，AI 一行代码就能读到未来。
+
+**第二层，blind 档。** `MockMode = 'blind' | 'live'` 已存在。blind 档下 `buildMockDataPack` 不下发 news / fundamentals / calendar，`fetchNews` 返回空数组。训练器一律 blind——盘面已匿名化，AI 拿不到基本面也是公平的（母设计 §7）。
+
+**第三层，运行时断言 + canary。** 见 §7。
+
+### 3.3 存储
+
+session 文件从 `version: 1` 升到 `2`，加一个 `coach: TrainerCoachCall[]`。读旧文件时缺字段补空数组，已有的局照常能开。
+
+**不另起目录。** 一局的所有东西在一个文件里，M5 扫统计时一次读完，不用 join 两个目录。
+
+```ts
+interface TrainerCoachCall {
+  id: string;
+  cursor: number;                     // 召唤时游标
+  askedAt: string;
+  humanBefore: TrainerSubmission;     // 召唤那一刻人的判断快照
+  ai: TrainerSubmission;              // AI 的判断
+  verdict: TrainerCoachVerdict | null;    // 局终才填
+  annotation: TrainerAnnotation | null;   // 人工标注
+}
+```
+
+`humanBefore` 是整个对照实验的支点。没有这个快照，局终时只看得到最终结果，分不清那是人本来的想法还是被 AI 掰过来的。
+
+### 3.4 「改主意」怎么度量
+
+母设计 §8 要「被 AI 说服改主意的胜率 vs 坚持自己判断的胜率」。
+
+引擎允许这个度量成立：`submitEpisode` 只在 `flat` 时有效（`engine.ts:367`），而 `cancel` 和平仓都会把 phase 打回 `flat`（`engine.ts:716,828,842`）——所以一局里可以 submit → cancel → 换方向重新 submit，「改主意」有真实的动作痕迹。
+
+三档判定：
+
+| 情形 | 记为 |
+| --- | --- |
+| AI 与 `humanBefore` **同向** | 不进对照 |
+| **分歧**，且人在归属窗口内按 AI 方向重新 submit | 被说服 |
+| **分歧**，归属窗口内人没改方向 | 坚持 |
+
+**归属窗口 = 这次召唤之后、到下一次召唤或局终为止。** 不写死这个窗口的话，一局里召唤三次，人在最后改了方向，三次召唤会同时被记成「说服了他」，一次操作被算三遍。窗口内发生的第一次方向变更归给窗口所属的那次召唤。
+
+同向必须排除。否则「AI 附和我」会被灌水成「AI 说服我」，这个对照实验就废了。
+
+### 3.5 自动判定
+
+**局终一次性批量算**，局中不算——结局还没发生，算了也是错的。
+
+对每条 coach 记录跑 `replayDirectional`：
+
+- 输入：AI 的 `entry_plan` 三价 + **召唤那根之后到 replay 段末**的 bars
+- 输出：win / loss / timeout_flat / no_fill / format_violation + 实际 R
+
+**判定窗口不含尾声段**，守住母设计「尾声段不进任何统计口径」。人提前收工也不缩短窗口——那是评 AI，不是评人。
+
+**AI 调用失败不落记录**（母设计 §12），训练照常继续，UI 给一句失败提示。这样统计里不会混进「召唤了但没结果」的空洞。
+
+### 3.6 人工标注
+
+**只在自动判定为「方向对」时才请求标注**（母设计 §7）。方向已经错的直接归档不问——把点击花在信息量最高处。
+
+选项四个：站得住 / 结论对但理由错 / 不成立 / 跳过。跳过本身也记录，用来区分「未标」与「标了没问题」。
+
+**标注入口在复盘页，不在结算页。** 判断「理由站不站得住」必须看图——它说「回踩 20 周期均线获支撑」，你得看到价格到底碰没碰那条线。结算页是成绩单（每笔明细、净 R），没有那个上下文。结算页与复盘页是同一个训练窗口的两个页签，切过去即可。
+
+## 4. M5 — 复盘与统计
+
+### 4.1 复盘页
+
+接在结算页后面，同一个训练窗口，顶部切页签（本局结算 / 复盘）。
+
+局已结束，不再有泄漏风险，所以数据一次性全给：pro 侧新增 `review({ sessionId })` 返回完整可交易段 + 尾声段 + 事件时间轴。**拖时间轴在本地切片，不走 IPC**——每拖一格发一次请求会卡得没法用。
+
+- **揭晓真身**：真实代号、真实日期、AI 打的标签与难度，一键跳 symbol 页看真图（provenance 提供）
+- **三段底色**：你打过的段 / 训练时被雾遮住的段（你提前收工没走到的）/ 尾声段。后两段的 K 线压暗
+- **时间轴刷子**拉到任意一根，图还原成当时所见，右半边重新变回雾
+- **事件标注**（图上 + 时间轴上）：进场、止损、目标达成、AI 召唤、收盘
+- **「显示收盘后走势」开关**揭尾声段（复用现有 `EpilogueToggle`）
+- **实盘做不到的三个数**：强平后的最高/最低、不平仓拿到尾声段末的结果、被止损那笔超出多少以及之后到没到过目标
+- **AI 对照**：放在图的正下方（召唤发生在图上某根，对照离那根越近越好读），每次召唤一条，含判定结果与标注入口
+- **教训输入**
+
+### 4.2 统计面板
+
+主窗口，`TrainerCard` 点进去的二级页。数据源是扫 `sessionsDir` 的 session 文件，join case 文件拿结构标签。
+
+**只统计跑到 `terminal` 的局。** `sessionsDir` 里躺着的还有开了没打完的（开局看两眼就关掉的、中途去干别的的）。把这些算进胜率就是拿「我不喜欢的开局」冲淡分母。未完成的局在面板上单独报个数就够。
+
+全部做成**纯函数**：输入 session 列表 + case 元数据，输出统计对象。统计口径能被单测钉死，不用起 UI 验。
+
+六块（照母设计 §8）：
+
+1. **总览**：累计 R、胜率、计划盈亏比 vs 实际拿到、最大浮盈回吐比例
+2. **按结构标签**的净 R 与胜率
+3. **止损体检**：被止损后价格最终仍达目标的比例、止损被打的平均超出幅度
+4. **AI 陪练影响**：被说服 vs 坚持的胜率（只统计有分歧的召唤）
+5. **推进方式影响**：逐根推进期间持仓的胜率 vs 大周期快进期间的胜率
+6. **AI 成绩单**：方向准确率、其中「理由站得住」与「结论对但理由错」的占比
+
+第 1 块里「计划 2.4:1 → 实际 1.3:1」这一栏最该先看：它区分「选位置的毛病」和「拿不住的毛病」，这是两种完全不同的病。
+
+**不做**：卡片折叠、「近 N 局 / 全部」时间窗切换。样本本来就少，再切一刀只会让护栏更容易触发，反而看不到东西。
+
+### 4.3 样本量护栏
+
+母设计没写，本期加。
+
+**任何一块统计在样本不足 10 时，只报个数，不报比率。**
+
+阈值按**每块自己的样本单位**算，不是全局按局数算：总览和止损体检按完成局数，按标签那块按该标签下的局数，AI 陪练影响按**有分歧的召唤次数**，AI 成绩单按总召唤次数。刷了 40 局但只召唤过 5 次 AI，AI 那两块照样该锁住。
+
+刷了 3 局赢 3 局，面板显示「胜率 100%」——这个数字唯一的作用是骗你。统计面板的价值全在样本够大之后，在那之前它应该拒绝回答。这是 TD-NOISE-01 在 UI 上的落实：在噪声里找规律等于训练自己亏钱。
+
+### 4.4 教训沉淀
+
+结算页写一句话 → 存进 session 文件 → 旁边一个**「同步到 `journal/lessons.md`」按钮**，人手动挑。
+
+默认不流出去。理由：训练局是匿名合成盘，价格被缩放过、代号是假的、没有新闻和基本面。在这种环境里学到的东西，一部分是关于**你自己的操作习惯**（止损贴太近、拿不住、追高），这些该进 lessons 影响实盘；另一部分是关于**这个训练环境**的（「这个案例池里假突破特别多」），流进实盘 AI 的必读清单是污染。
+
+`journal/lessons.md` 在本仓库有明确身份：CLAUDE.md 写着它是「复盘教训清单，一行一条带日期；短线预测每次运行前必读」。写进去的东西会真的影响实盘判断，所以闸门交给人。
+
+母设计 §8「结构化训练数据不写入 `journal/`」仍然成立——那句话管的是结构化数据，不是人写的一句话。
+
+## 5. 落点
+
+```
+apps/pro/src/modules/training/
+  coachRun.ts        # 召唤一次：拼装 view → cell session → Submission
+  coachVerdict.ts    # 纯函数：coach 记录 + replay bars → 自动判定 + 改主意三档
+  reviewPayload.ts   # 复盘页的全量数据组装
+  trainingStats.ts   # 纯函数：session 列表 + case 元数据 → 统计对象（含样本护栏）
+  sessionStore.ts    # 升 version 2，向后兼容读
+  trainerRuntime.ts  # 加 coach / annotate / review / stats / lesson 方法
+
+packages/pro-api/src/trainerTypes.ts
+  TrainerCoachCall / TrainerCoachVerdict / TrainerAnnotation
+  TrainerReviewPayload / TrainerStats / TrainerLesson
+  TrainerApi 加对应方法
+
+apps/web/src/features/training/
+  TrainerCoachPanel.tsx    # 局中「问 AI」+ AI 意见展示
+  TrainerReview.tsx        # 复盘页外壳
+  TrainerReviewTimeline.tsx / TrainerReviewFacts.tsx / TrainerCoachCompare.tsx
+apps/web/src/features/home/
+  TrainingStatsPage.tsx    # 统计面板
+```
+
+训练 UI 落在公开仓 `apps/web`（**不是** 母设计 §2 写的 overlay 投影——实现时改了，现状以此为准），通过 capabilities 在免费版隐藏。
+
+文件大小按仓库规矩：单文件 500 行、组件 300 行。复盘页必须拆——图、时间轴、三个数的面板、AI 对照各自独立。
+
+## 6. 数据流总览
+
+```
+局中：
+  提交方向+三价 → 解锁问 AI
+    → 点「问 AI」→ 截断视图 → analyst(blind) → Submission
+    → 存 coach 记录（含 humanBefore 快照）
+
+局终：
+  对每条 coach 记录 → replayDirectional(游标+1 .. replay 段末) → verdict
+    → 方向对的 → 复盘页请求人工标注 → 写回 session 文件
+
+复盘：
+  review(sessionId) → 全量 bars + 尾声段 + 事件轴 → 本地切片重放
+
+统计：
+  扫全部 session 文件 + join case 标签 → 纯函数聚合 → 样本护栏 → 面板
+```
+
+## 7. 测试
+
+**泄漏测试（最重要）**
+
+- coach 拿到的 question 里，**任何周期的任何一根** bar 时间 ≤ 游标那根
+- `run_code` 沙箱 globals 里的 kline 同样截断（最容易漏的一处，它绕开工具直接给数据）
+- blind 档下 news / fundamentals / calendar 不出现在下发给模型的文本里
+- **canary**：故意造一个含未来 bar 的 case 喂进去，断言链路把它挡掉
+
+canary 是必须的。没有它，将来某次重构把截断逻辑改坏了，上面三条断言可能一起变成永远通过的空断言。
+
+**纯函数单测**
+
+- 「改主意」三档判定
+- 自动判定边界：`no_fill`（三根内没摸到入场价）、`format_violation`（止损方向填反）
+- 统计聚合，重点测样本护栏：9 局返回「样本不足」，10 局才出比率
+- 尾声段被排除在所有统计口径外
+
+**组件测试**（沿用现有 vitest + jsdom 模式）
+
+- 锁定顺序：未提交时「问 AI」disabled
+- 标注区只在方向判对时出现
+- 样本不足时卡片显示个数不显示比率
+
+**不测**：AI 输出的质量好坏（那是 bench 的职责）；不做 E2E。
+
+## 8. 明确不做
+
+- **回流导出（评测集 + 偏差报告）**。训练 case 本来就是 `Question` 格式，跟 bench 数据集同构，真需要时写个短脚本挪文件即可；而「系统性偏差」要大样本才显现，现在样本是 0，做出来第一个月看到的全是噪声，反而会误导去改 prompt——正好撞上 TD-NOISE-01。数据结构上留好口子，等统计面板真看出某类 case 有偏差了再单开一期。
+- **AI 影子局**（让 AI 把整局从头跑到尾做全程对照）。那不是母设计 §7 描述的「手动召唤看第二意见」，是另一个功能，且一局要烧几十次模型调用。有意思，但不混进本期。
+- 训练器专用的 AI persona。必须和 bench 用同一个 analyst、同一套 `loadBenchDiscipline`，两边喂给模型的规则文本逐字相同——否则训练器量出来的 AI 成绩推不出 bench 的结论，回流价值归零。
+- AI 看到人的判断。看到就不是独立第二意见了。
+
+## 9. 风险与探路
+
+**唯一的真风险：`composeCellSession` 需要 `scaffold`（`skillText` + `disciplineText`，从仓库里读 SKILL.md）。**
+
+bench 是 CLI 跑的，`repoRoot` 现成；训练器跑在 Electron 里，打包后能不能读到仓库里的 markdown 是未知的。
+
+**实现计划的第一个任务就是探这个，不是写功能。** 探不通就整期停下来重新设计，不带着一个「本地能跑、打包就废」的方案往下滚。
+
+次要风险：session 文件扫全量做统计，局数多了会慢。先不优化——几百局的规模无所谓，真慢了再加索引。

--- a/packages/pro-api/src/index.ts
+++ b/packages/pro-api/src/index.ts
@@ -5,6 +5,7 @@ export * from './aiTypes.js';
 export * from './licenseTypes.js';
 export * from './detectors.js';
 export * from './trainerTypes.js';
+export * from './trainerTrade.js';
 
 // Shared contract between core's registration seam (packages/core/src/pro/hooks.ts)
 // and the pro composition that supplies the real implementation at start() —

--- a/packages/pro-api/src/trainerTrade.ts
+++ b/packages/pro-api/src/trainerTrade.ts
@@ -1,0 +1,28 @@
+import type { TrainerClosedTrade } from './trainerTypes.js';
+
+/**
+ * The per-trade arithmetic the settlement panel and the cross-session statistics both quote.
+ *
+ * It sits in the contract package because both readers live on opposite sides of the open-core
+ * boundary — `apps/web` may not import `apps/pro` — and a second copy of "what the plan was worth"
+ * would drift from the first the moment either side is touched.
+ */
+
+/**
+ * Judged at the first fill, never at the average of the lots: `initialRisk` is the risk unit the
+ * engine locked against that same first price, so pairing it with a post-add average would produce
+ * a ratio measured with two different rulers.
+ */
+export function trainerFirstFillPrice(trade: TrainerClosedTrade): number {
+  return trade.lots?.[0]?.price ?? trade.entry.price;
+}
+
+export function trainerPlannedRewardRisk(trade: TrainerClosedTrade): number | null {
+  if (trade.initialRisk <= 0) return null;
+  return Math.abs(trade.target - trainerFirstFillPrice(trade)) / trade.initialRisk;
+}
+
+/** Profit that showed up on the screen and was handed back. Never negative. */
+export function trainerMfeGivebackR(trade: TrainerClosedTrade): number {
+  return Math.max(0, trade.mfeR - trade.netR);
+}

--- a/packages/pro-api/src/trainerTypes.ts
+++ b/packages/pro-api/src/trainerTypes.ts
@@ -185,6 +185,11 @@ export interface TrainerView {
   remainingBars: number;
   terminal: boolean;
   result: TrainerResult | null;
+  // Whether the trader has ever committed to a direction, which is what unlocks the AI. Sticky:
+  // cancelling an order does not re-seal it. Carried rather than inferred from `order` / `position`
+  // / `trades`, because an abstention commits a view without producing any of the three, and the
+  // renderer's lock must match the one the runtime enforces.
+  submitted: boolean;
 }
 
 export interface TrainerStepEvent {
@@ -294,6 +299,206 @@ export interface TrainerSubmission {
   comment: string;
 }
 
+export const TRAINER_CASE_TAGS = [
+  'trend-follow',
+  'pullback-entry',
+  'false-breakout',
+  'top-reversal',
+  'range-bound',
+] as const;
+
+export type TrainerCaseTag = (typeof TRAINER_CASE_TAGS)[number];
+
+// The trainer's own outcomes on top of the replay scorer's five: `abstained` is an AI that
+// declined to take a side, which is neither a right nor a wrong direction and must not land in
+// either half of the accuracy ratio.
+export type TrainerCoachOutcome =
+  'win' | 'loss' | 'timeout_flat' | 'no_fill' | 'format_violation' | 'abstained';
+
+// What the trader's own book said at the moment they asked. Derived from engine state rather
+// than sent by the renderer: the whole comparison rests on this snapshot being the judgement
+// they actually held, so it must not be something a caller can restate after the fact.
+export interface TrainerCoachStance {
+  direction: TrainerDirection | 'neutral';
+  entry: number | null;
+  stop: number | null;
+  target: number | null;
+}
+
+// `aligned` is excluded from the persuaded/held comparison on purpose: counting an AI that
+// agreed with the trader as an AI that moved them would water the contrast down to nothing.
+export type TrainerCoachAgreement = 'aligned' | 'persuaded' | 'held';
+
+export interface TrainerCoachVerdict {
+  outcome: TrainerCoachOutcome;
+  /** The plan's own reward-to-risk, before the market had a say. */
+  plannedRewardRisk: number | null;
+  /** What the plan actually collected, in R. */
+  realizedR: number | null;
+  directionCorrect: boolean;
+  agreement: TrainerCoachAgreement;
+  judgedAt: string;
+}
+
+// `skipped` is stored rather than left absent so "looked at it, nothing wrong" stays
+// distinguishable from "never looked".
+export type TrainerAnnotationVerdict =
+  'sound' | 'right_call_wrong_reason' | 'unfounded' | 'skipped';
+
+export interface TrainerAnnotation {
+  verdict: TrainerAnnotationVerdict;
+  at: string;
+}
+
+// `step` is the engine's own monotonic action counter, captured when the question was asked.
+// The attribution window for "did this change their mind" runs from this step to the next
+// call's — `cursor` cannot carry it, because submitting and cancelling leave the cursor where
+// it was, so two calls on the same bar would claim the same change.
+export interface TrainerCoachCall {
+  id: string;
+  cursor: number;
+  step: number;
+  askedAt: string;
+  model: string;
+  humanBefore: TrainerCoachStance;
+  ai: TrainerSubmission;
+  verdict: TrainerCoachVerdict | null;
+  annotation: TrainerAnnotation | null;
+}
+
+// `syncedAt` is null while the lesson lives only in the training area. Nothing writes
+// `journal/lessons.md` without the trader pressing the button — a synthetic, price-scaled,
+// news-free board teaches two different kinds of thing, and only one of them belongs in the
+// list that gates real trades.
+export interface TrainerLesson {
+  text: string;
+  writtenAt: string;
+  syncedAt: string | null;
+}
+
+export type TrainerReviewEventKind =
+  'entry' | 'stop' | 'target' | 'manual_exit' | 'horizon_exit' | 'coach';
+
+export interface TrainerReviewEvent {
+  kind: TrainerReviewEventKind;
+  at: string;
+  /** Index into `replay`, or null when the moment falls outside the playable segment. */
+  barIndex: number | null;
+  price: number | null;
+  label: string;
+  coachId?: string;
+}
+
+// The stop-out's overshoot is measured against the stop the trade was carrying when it was hit,
+// and `reachedTargetAfter` scans the remaining playable bars only — the epilogue is barred from
+// every counted number, here as everywhere else.
+export interface TrainerStopAutopsy {
+  tradeId: number;
+  stop: number;
+  overshoot: number;
+  overshootPct: number;
+  reachedTargetAfter: boolean;
+}
+
+export interface TrainerReviewFacts {
+  stopAutopsy: TrainerStopAutopsy | null;
+  /** Where the last trade would have stood at the end of the epilogue. Observation only. */
+  holdToEpilogueEndR: number | null;
+  /** Best and worst the epilogue reached after the trader was out, in R. Observation only. */
+  afterExitHighR: number | null;
+  afterExitLowR: number | null;
+}
+
+export interface TrainerReviewPayload {
+  sessionId: string;
+  caseId: string;
+  symbol: string;
+  basePeriod: TrainerBasePeriod;
+  ladder: readonly [TrainerViewPeriod, TrainerViewPeriod, TrainerViewPeriod];
+  provenance: TrainerProvenance;
+  tag: TrainerCaseTag | null;
+  /**
+   * Base-period bars handed over before the first playable one — the chart's left half. The
+   * review chart is base-period only: the brush slices these bars directly, and re-deriving the
+   * ladder's upper tiers on the renderer would put a second copy of the aggregation rule there,
+   * free to drift from the one the episode was actually settled on.
+   */
+  lookback: RawBar[];
+  /** The whole playable segment, fog included. */
+  replay: RawBar[];
+  epilogue: RawBar[];
+  /** Cursor the trader stopped at; bars past it were never seen during the session. */
+  playedThrough: number;
+  trades: TrainerClosedTrade[];
+  result: TrainerResult | null;
+  events: TrainerReviewEvent[];
+  coach: TrainerCoachCall[];
+  facts: TrainerReviewFacts;
+  lesson: TrainerLesson | null;
+}
+
+// Every block reports `samples` whether or not it is locked, so a locked card can still say how
+// far off it is. When `locked` is true the ratios are null rather than zero — a missing number
+// and a measured zero are different answers.
+export interface TrainerStatBlock {
+  samples: number;
+  locked: boolean;
+}
+
+export interface TrainerOverviewStats extends TrainerStatBlock {
+  netR: number;
+  winRate: number | null;
+  plannedRewardRisk: number | null;
+  realizedRewardRisk: number | null;
+  mfeGivebackRate: number | null;
+}
+
+export interface TrainerTagStats extends TrainerStatBlock {
+  tag: TrainerCaseTag | null;
+  netR: number;
+  winRate: number | null;
+}
+
+export interface TrainerStopHealthStats extends TrainerStatBlock {
+  reachedTargetAfterStopRate: number | null;
+  averageOvershootPct: number | null;
+}
+
+export interface TrainerCoachInfluenceStats extends TrainerStatBlock {
+  persuadedCount: number;
+  persuadedWinRate: number | null;
+  heldCount: number;
+  heldWinRate: number | null;
+}
+
+export interface TrainerAdvanceStyleStats extends TrainerStatBlock {
+  barByBarWinRate: number | null;
+  fastForwardWinRate: number | null;
+}
+
+// `samples` counts every call, which is the guard's unit; `settled` counts the ones the market
+// actually resolved, which is the accuracy ratio's denominator. Reporting only the first would
+// let "52% over 21 calls" hide the fact that 21 calls produced four scored plans.
+export interface TrainerCoachScorecard extends TrainerStatBlock {
+  settled: number;
+  annotated: number;
+  directionAccuracy: number | null;
+  soundReasonRate: number | null;
+  rightCallWrongReasonRate: number | null;
+}
+
+export interface TrainerStats {
+  completedSessions: number;
+  unfinishedSessions: number;
+  sessionsByBasePeriod: Record<TrainerBasePeriod, number>;
+  overview: TrainerOverviewStats;
+  byTag: TrainerTagStats[];
+  stopHealth: TrainerStopHealthStats;
+  coachInfluence: TrainerCoachInfluenceStats;
+  advanceStyle: TrainerAdvanceStyleStats;
+  coachScorecard: TrainerCoachScorecard;
+}
+
 // A refused amendment is the answer, not a transport failure, so this rides home on `ok: true`.
 // The envelope's `ok: false` stays reserved for the caller getting the question itself wrong —
 // an unknown session, an unreadable case — which is not something the trader can act on.
@@ -342,6 +547,16 @@ export interface TrainerApi {
   add(input: { sessionId: string; size: number; reason: TrainerReason }): TrainerStepResult;
   reduce(input: { sessionId: string; size?: number; reason: TrainerReason }): TrainerStepResult;
   reveal(input: { sessionId: string }): TrainerReveal;
+  coach(input: { sessionId: string }): TrainerCoachCall;
+  annotate(input: {
+    sessionId: string;
+    coachId: string;
+    verdict: TrainerAnnotationVerdict;
+  }): TrainerCoachCall;
+  review(input: { sessionId: string }): TrainerReviewPayload;
+  stats(): TrainerStats;
+  saveLesson(input: { sessionId: string; text: string }): TrainerLesson;
+  syncLesson(input: { sessionId: string }): TrainerLesson;
 }
 
 // TRAINER_GUARDRAIL is a legal move the risk boundary refused — a stop that gives back a booked


### PR DESCRIPTION
盲盘训练 M4/M5 的公开仓侧：契约类型 + 局中问 AI 面板 + 复盘页签 + 统计面板。设计文档在本 PR 里（`docs/superpowers/specs/2026-07-28-blind-replay-trainer-m4-m5-design.md`，含新加的 §10 实现偏离）。

pro 侧配套：kansoku-trade/kansoku-pro#26。

## 先说探路结论：spec §9 那个风险不成立

spec 把「scaffold 在 Electron 打包后拿不拿得到」列为整期唯一的真风险，规定探不通就整期停下。探通了 —— app 侧 analyst 本来就在跑同一条链路，`stageSkills.mjs` 把整个 `.claude/skills` 解引用拷进 `Resources/skills`，`boot/env.ts` 软链到数据目录并把 `TRADE_PROJECT_ROOT` 指过去。开发态和打包态都实测过，细节写在 spec §10。

## 改了什么

**契约**（`packages/pro-api`）：`TrainerCoachCall` / `TrainerCoachVerdict` / `TrainerAnnotation` / `TrainerReviewPayload` / `TrainerStats` / `TrainerLesson`，`TrainerApi` 加 coach / annotate / review / stats / saveLesson / syncLesson。

**局中**（`TrainerCoachPanel`）：问 AI 按钮 + 第二意见展示。

**复盘页签**（`TrainerReview` + timeline / facts / coach-compare / lesson 四个子组件）：真身揭晓、时间轴刷子、图上事件、显示收盘后走势开关、实盘做不到的三个数、AI 对照带标注入口、教训输入。

**统计面板**（`TrainingStatsPage`，`/training/stats`）：六块 + 样本护栏，从 `TrainerCard` 点进去。

## 几个关键决定

**锁定顺序不可妥协。** 没提交自己的方向与三价之前，问 AI 是 disabled。开局即可问的话训练退化成抄答案，标注也被锚定污染 ——「AI 说得对」会悄悄变成「我俩想得一样」。

为此 `TrainerView` 新增 `submitted` 字段，而不是让前端从 order/position/trades 推断：**观望提交会确立判断但不产生这三样中的任何一个**，光看那三样会让按钮比服务端更严。前端的锁和运行时的锁必须是同一个条件。

**局中不显示任何判定。** 结局还没发生，摆一个临时结论上去等于告诉用户这局往哪走。

**复盘页的图只画基础周期。** 在渲染端重新聚合梯队上层，等于把「一根上层周期等于几根基础 K 线」抄第二份到前端，和真正结算用的那份自由漂移。

**拖刷子是截断 bars，不是压暗。** 顺带把当时还没进的仓也藏掉 —— 复盘要还原当时所见，不是给当时没发生的事加装饰。尾声段只在刷子停在末尾时才接上，否则会把收盘后的价格直接拼在一根局中 K 线后面。

**标注区只在方向判对时出现。** 方向已经被市场否掉的直接归档不问 —— 把点击花在那儿买不到信息，只会训练出敷衍点击的习惯。

**`plannedRewardRisk` / `mfeGivebackR` 搬进 `pro-api`。** 结算面板在 `apps/web`、统计在 `apps/pro`，开源边界不允许 web 反向引 pro；两边各留一份，任何一边一动就漂移。

**护栏锁住的卡片画的是斜纹底 + 个数，不是 0 也不是破折号** —— 那两个都会被读成「测量结果」，而这里根本没有测量。

## 顺带

- `ReplayBandKind` 加了 `fog`（复盘页专用：他没走到的那段）
- `TrainerSettlement` 里的 `AI 对照 · M4` / `教训沉淀 · M5` 占位换成指向复盘页签
- 一批训练测试 fixture 补 `submitted` 字段；`TrainerCard` 测试补 `MemoryRouter`（卡片现在带一条到统计页的链接）

## 验证

- `vitest run` 1120 全绿（新增 TrainerCoachPanel / TrainerCoachCompare / TrainerReview / TrainingStatsPage / reviewChart 五个测试文件）
- `tsc --noEmit` 六个包全过
- `vite build --configLoader runner` 通过，`proLeakGuard` 无告警；路由文件已重新生成
- 改动文件 eslint + prettier 干净
