### PR TITLE
feat(web): support custom Base URL during onboarding

### DIFF
--- a/apps/web/src/features/onboarding/StepAi.test.tsx
+++ b/apps/web/src/features/onboarding/StepAi.test.tsx
@@ -72,6 +72,7 @@ describe('StepAi', () => {
 
     renderWithClient(<StepAi onNext={onNext} />);
     await openApiKeyForm();
+    expect(document.querySelectorAll('.onboarding-apikey-row')).toHaveLength(2);
     enterApiKey();
     fireEvent.change(screen.getByLabelText('Base URL（可选）'), {
       target: { value: 'https://gateway.example.com/v1' },

--- a/apps/web/src/features/onboarding/StepAi.test.tsx
+++ b/apps/web/src/features/onboarding/StepAi.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Catalog } from '../settings/types';
+
+const getCatalog = vi.fn();
+const putCredential = vi.fn();
+const putProviderBaseUrl = vi.fn();
+const putRole = vi.fn();
+
+vi.mock('@web/lib/client', () => ({
+  client: {
+    settings: {
+      getCatalog: (...args: unknown[]) => getCatalog(...args),
+      putCredential: (...args: unknown[]) => putCredential(...args),
+      putProviderBaseUrl: (...args: unknown[]) => putProviderBaseUrl(...args),
+      putRole: (...args: unknown[]) => putRole(...args),
+    },
+  },
+}));
+
+const { StepAi } = await import('./StepAi');
+
+const catalog: Catalog = {
+  providers: [
+    {
+      id: 'openai',
+      name: 'OpenAI',
+      auth: { kind: 'api_key', status: 'missing' },
+      models: [{ id: 'gpt-test', name: 'GPT Test', thinkingLevels: [] }],
+    },
+  ],
+};
+
+function renderWithClient(children: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+}
+
+async function openApiKeyForm() {
+  fireEvent.click(await screen.findByRole('button', { name: '填入' }));
+}
+
+function enterApiKey(value = 'sk-test') {
+  fireEvent.change(screen.getByPlaceholderText('API key'), { target: { value } });
+}
+
+describe('StepAi', () => {
+  afterEach(() => {
+    cleanup();
+    for (const mock of [getCatalog, putCredential, putProviderBaseUrl, putRole]) {
+      mock.mockReset();
+    }
+  });
+
+  it('saves a custom Base URL before refreshing the catalog and assigning the primary model', async () => {
+    getCatalog.mockResolvedValue(catalog);
+    putCredential.mockResolvedValue({ provider: 'openai', masked: '••••test' });
+    putProviderBaseUrl.mockResolvedValue({
+      provider: 'openai',
+      baseUrl: 'https://gateway.example.com/v1',
+    });
+    putRole.mockResolvedValue({
+      mode: 'custom',
+      provider: 'openai',
+      modelId: 'gpt-test',
+      thinkingLevel: 'off',
+    });
+    const onNext = vi.fn();
+
+    renderWithClient(<StepAi onNext={onNext} />);
+    await openApiKeyForm();
+    enterApiKey();
+    fireEvent.change(screen.getByLabelText('Base URL（可选）'), {
+      target: { value: 'https://gateway.example.com/v1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存并使用' }));
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledTimes(1));
+    expect(putCredential).toHaveBeenCalledWith({ provider: 'openai', key: 'sk-test' });
+    expect(putProviderBaseUrl).toHaveBeenCalledWith({
+      provider: 'openai',
+      baseUrl: 'https://gateway.example.com/v1',
+    });
+    expect(putRole).toHaveBeenCalledWith({
+      role: 'primary',
+      mode: 'custom',
+      provider: 'openai',
+      modelId: 'gpt-test',
+      thinkingLevel: 'off',
+    });
+    expect(putCredential.mock.invocationCallOrder[0]).toBeLessThan(
+      putProviderBaseUrl.mock.invocationCallOrder[0],
+    );
+    expect(putProviderBaseUrl.mock.invocationCallOrder[0]).toBeLessThan(
+      getCatalog.mock.invocationCallOrder[1],
+    );
+    expect(getCatalog.mock.invocationCallOrder[1]).toBeLessThan(
+      putRole.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps the official endpoint when Base URL is left blank', async () => {
+    getCatalog.mockResolvedValue(catalog);
+    putCredential.mockResolvedValue({ provider: 'openai', masked: '••••test' });
+    putProviderBaseUrl.mockResolvedValue({ provider: 'openai', baseUrl: null });
+    putRole.mockResolvedValue({
+      mode: 'custom',
+      provider: 'openai',
+      modelId: 'gpt-test',
+      thinkingLevel: 'off',
+    });
+    const onNext = vi.fn();
+
+    renderWithClient(<StepAi onNext={onNext} />);
+    await openApiKeyForm();
+    enterApiKey();
+    fireEvent.click(screen.getByRole('button', { name: '保存并使用' }));
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledTimes(1));
+    expect(putProviderBaseUrl).toHaveBeenCalledWith({ provider: 'openai', baseUrl: '' });
+  });
+
+  it('shows Base URL validation errors and does not finish onboarding', async () => {
+    getCatalog.mockResolvedValue(catalog);
+    putCredential.mockResolvedValue({ provider: 'openai', masked: '••••test' });
+    putProviderBaseUrl.mockRejectedValue(
+      new Error('invalid baseUrl: gateway.example.com — expected a full http(s) URL'),
+    );
+    const onNext = vi.fn();
+
+    renderWithClient(<StepAi onNext={onNext} />);
+    await openApiKeyForm();
+    enterApiKey();
+    fireEvent.change(screen.getByLabelText('Base URL（可选）'), {
+      target: { value: 'gateway.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存并使用' }));
+
+    expect(
+      await screen.findByText('invalid baseUrl: gateway.example.com — expected a full http(s) URL'),
+    ).toBeTruthy();
+    expect(onNext).not.toHaveBeenCalled();
+    expect(putRole).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/onboarding/StepAi.tsx
+++ b/apps/web/src/features/onboarding/StepAi.tsx
@@ -213,33 +213,38 @@ export function StepAi({ onNext }: { onNext: () => void }) {
 
       {showApiKey && apiProviders.length > 0 ? (
         <div className="onboarding-apikey">
-          <Select
-            value={effectiveApiProvider}
-            options={apiProviders.map((p) => ({ value: p.id, label: p.name }))}
-            onChange={setApiProvider}
-          />
-          <Input
-            autoComplete="off"
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            placeholder="API key"
-          />
-          <Input
-            aria-label="Base URL（可选）"
-            autoComplete="off"
-            type="url"
-            value={apiBaseUrl}
-            onChange={(event) => setApiBaseUrl(event.target.value)}
-            placeholder="默认官方地址，可填中转站地址（可选）"
-          />
-          <Button
-            accent
-            disabled={busy !== null || !effectiveApiProvider || !apiKey}
-            onClick={saveApiKey}
-          >
-            {busy === 'apikey' ? '保存中…' : '保存并使用'}
-          </Button>
+          <div className="onboarding-apikey-row onboarding-apikey-row--endpoint">
+            <Input
+              aria-label="Base URL（可选）"
+              autoComplete="off"
+              type="url"
+              value={apiBaseUrl}
+              onChange={(event) => setApiBaseUrl(event.target.value)}
+              placeholder="默认官方地址，可填中转站地址（可选）"
+            />
+          </div>
+          <div className="onboarding-apikey-row onboarding-apikey-row--credentials">
+            <Select
+              ariaLabel="AI Provider"
+              value={effectiveApiProvider}
+              options={apiProviders.map((p) => ({ value: p.id, label: p.name }))}
+              onChange={setApiProvider}
+            />
+            <Input
+              autoComplete="off"
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              placeholder="API key"
+            />
+            <Button
+              accent
+              disabled={busy !== null || !effectiveApiProvider || !apiKey}
+              onClick={saveApiKey}
+            >
+              {busy === 'apikey' ? '保存中…' : '保存并使用'}
+            </Button>
+          </div>
         </div>
       ) : null}
 

--- a/apps/web/src/features/onboarding/StepAi.tsx
+++ b/apps/web/src/features/onboarding/StepAi.tsx
@@ -46,6 +46,7 @@ export function StepAi({ onNext }: { onNext: () => void }) {
   const [showApiKey, setShowApiKey] = useState(false);
   const [apiProvider, setApiProvider] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [apiBaseUrl, setApiBaseUrl] = useState('');
 
   if (loading || !catalog) {
     return (
@@ -79,6 +80,10 @@ export function StepAi({ onNext }: { onNext: () => void }) {
   const saveApiKey = () =>
     finish('apikey', async () => {
       await client.settings.putCredential({ provider: effectiveApiProvider, key: apiKey });
+      await client.settings.putProviderBaseUrl({
+        provider: effectiveApiProvider,
+        baseUrl: apiBaseUrl,
+      });
       await connectPrimary(await fetchCatalog(), effectiveApiProvider);
     });
 
@@ -219,6 +224,14 @@ export function StepAi({ onNext }: { onNext: () => void }) {
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
             placeholder="API key"
+          />
+          <Input
+            aria-label="Base URL（可选）"
+            autoComplete="off"
+            type="url"
+            value={apiBaseUrl}
+            onChange={(event) => setApiBaseUrl(event.target.value)}
+            placeholder="默认官方地址，可填中转站地址（可选）"
           />
           <Button
             accent

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8482,10 +8482,28 @@ a.zone-item:hover {
   margin-top: 12px;
 }
 .onboarding-apikey {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 8px;
   margin-top: 12px;
+}
+.onboarding-apikey-row {
+  display: grid;
+  gap: 8px;
+}
+.onboarding-apikey-row--endpoint {
+  grid-template-columns: minmax(0, 1fr);
+}
+.onboarding-apikey-row--credentials {
+  grid-template-columns: minmax(108px, 0.65fr) minmax(0, 1.35fr) auto;
+}
+.onboarding-apikey .input,
+.onboarding-apikey .ui-select-trigger {
+  width: 100%;
+  min-width: 0;
+}
+.onboarding-apikey-row--credentials .btn {
+  min-width: 112px;
+  justify-content: center;
 }
 .onboarding-skip-link {
   background: none;


### PR DESCRIPTION
## 背景

首次“配置 AI”页面只能填写 Provider 和 API Key，使用第三方中转站的用户无法同时配置 Base URL，只能进入应用后再去设置页补填。

## 改动

- 在首次引导的 API Key 表单加入可选 Base URL 输入框；
- 留空时沿用官方默认地址，填写时复用现有 `putProviderBaseUrl` 保存与校验逻辑；
- 在刷新模型目录、设置主模型之前保存 Base URL，确保后续请求立即使用自定义地址；
- 非法地址保留在当前引导步骤并显示错误；
- 新增组件测试，覆盖自定义地址、留空使用官方地址、非法地址三种流程。

## 验证

- `pnpm --filter @kansoku/web typecheck`
- `pnpm --filter @kansoku/web test`（161 个测试文件、1124 条用例通过）
- `pnpm --filter @kansoku/web build`

Closes #111
