### PR TITLE
feat(training): move 问 AI onto the order lane and unlock it

### DIFF
--- a/apps/web/src/features/training/TrainerAdvanceControls.test.tsx
+++ b/apps/web/src/features/training/TrainerAdvanceControls.test.tsx
@@ -54,7 +54,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerChart.test.tsx
+++ b/apps/web/src/features/training/TrainerChart.test.tsx
@@ -60,7 +60,6 @@ function makeView(): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
   };
 }
 
@@ -128,6 +127,22 @@ describe('TrainerChart', () => {
     );
     expect(screen.getByRole('button', { name: '做多' })).toBeTruthy();
     expect(screen.getByRole('button', { name: '做空' })).toBeTruthy();
+  });
+
+  // The coach button rides on the order lane rather than owning a row, so an answer arriving can
+  // never change the chart's height. Asserting the shared row keeps that from regressing into a
+  // second lane the next time the panel is touched.
+  it('puts the coach button on the same row as the order lane, askable from the open', () => {
+    const bridge = { submit: vi.fn() } as unknown as Parameters<typeof TrainerChart>[0]['bridge'];
+    render(
+      <TrainerChart view={makeView()} bridge={bridge} sessionId="run-1" onViewChange={() => {}} />,
+    );
+
+    const ask = screen.getByRole('button', { name: '问 AI' }) as HTMLButtonElement;
+    expect(ask.disabled).toBe(false);
+    const row = ask.closest('.trainer-lane-row');
+    expect(row).not.toBeNull();
+    expect(row!.querySelector('.trainer-lane')).not.toBeNull();
   });
 
   it('advances by the ladder tier currently selected in the period switch', () => {

--- a/apps/web/src/features/training/TrainerChart.tsx
+++ b/apps/web/src/features/training/TrainerChart.tsx
@@ -186,22 +186,27 @@ export function TrainerChart({ view, sessionId, bridge, onViewChange }: TrainerC
                   sessionId={sessionId}
                   onViewChange={onViewChange}
                 />
-                <TrainerOrderPanel
-                  key={`order-${view.caseId}`}
-                  view={view}
-                  handle={chartHandle}
-                  bridge={bridge}
-                  sessionId={sessionId}
-                  onViewChange={onViewChange}
-                  drawingActive={drawings.tool !== 'off'}
-                  onTakeChart={() => drawings.setTool('off')}
-                />
-                <TrainerCoachPanel
-                  key={`coach-${view.caseId}`}
-                  view={view}
-                  bridge={bridge}
-                  sessionId={sessionId}
-                />
+                {/* One row, not two. The order panel renders exactly one inline element per
+                    state — every other thing it draws goes through the overlay — so wrapping it
+                    here puts the coach button on the end of whichever lane is showing without
+                    each of those states having to remember to carry it. */}
+                <div className="trainer-lane-row">
+                  <TrainerOrderPanel
+                    key={`order-${view.caseId}`}
+                    view={view}
+                    handle={chartHandle}
+                    bridge={bridge}
+                    sessionId={sessionId}
+                    onViewChange={onViewChange}
+                    drawingActive={drawings.tool !== 'off'}
+                    onTakeChart={() => drawings.setTool('off')}
+                  />
+                  <TrainerCoachPanel
+                    key={`coach-${view.caseId}`}
+                    bridge={bridge}
+                    sessionId={sessionId}
+                  />
+                </div>
               </>
             )}
           </>

--- a/apps/web/src/features/training/TrainerCoachCompare.test.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.test.tsx
@@ -134,6 +134,22 @@ describe('TrainerCoachCompare readout', () => {
     expect(screen.getByText(/你当时：做多/)).toBeTruthy();
   });
 
+  it('says the trader had no side yet, and drops the agreement chip with it', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ humanBefore: null, verdict: verdict({ agreement: null }) })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('你当时还没表态')).toBeTruthy();
+    expect(screen.queryByText(/分歧|同向/)).toBeNull();
+    expect(screen.getByText(/到目标 · \+2\.00R/)).toBeTruthy();
+  });
+
   it('keeps an AI that agreed out of the comparison', () => {
     render(
       <TrainerCoachCompare

--- a/apps/web/src/features/training/TrainerCoachCompare.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.tsx
@@ -99,13 +99,17 @@ export function TrainerCoachCompare({
                 {plan.prices && <span className="num"> {plan.prices}</span>}
               </span>
               <span className="trainer-settle-hint">
-                你当时：{DIRECTION_LABEL[call.humanBefore.direction]}
+                {call.humanBefore
+                  ? `你当时：${DIRECTION_LABEL[call.humanBefore.direction]}`
+                  : '你当时还没表态'}
               </span>
               {verdict && (
                 <>
-                  <span className={`trainer-chip trainer-chip--${verdict.agreement}`}>
-                    {AGREEMENT_LABEL[verdict.agreement]}
-                  </span>
+                  {verdict.agreement && (
+                    <span className={`trainer-chip trainer-chip--${verdict.agreement}`}>
+                      {AGREEMENT_LABEL[verdict.agreement]}
+                    </span>
+                  )}
                   <span
                     className={`trainer-chip trainer-chip--${verdict.directionCorrect ? 'hit' : 'miss'}`}
                   >

--- a/apps/web/src/features/training/TrainerCoachPanel.test.tsx
+++ b/apps/web/src/features/training/TrainerCoachPanel.test.tsx
@@ -1,39 +1,10 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { TrainerCoachCall, TrainerView } from '@kansoku/pro-api';
-import type { RawBar } from '@kansoku/shared/types';
+import type { TrainerCoachCall } from '@kansoku/pro-api';
 import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
 import { TrainerCoachPanel } from './TrainerCoachPanel';
 import { TrainerOverlayLayer, TrainerOverlayProvider } from './trainerOverlay';
-
-function bar(iso: string, close: number): RawBar {
-  return { time: iso, open: close - 1, high: close + 1, low: close - 1.5, close, volume: 1000 };
-}
-
-function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
-  const base = [bar('2026-01-05T14:00:00.000Z', 100), bar('2026-01-05T14:05:00.000Z', 103)];
-  return {
-    caseId: 'case-1',
-    symbol: 'TRAIN01',
-    basePeriod: '5m',
-    ladder: ['5m', '15m', '1h'],
-    cursor: base.length - 1,
-    asOf: base.at(-1)!.time,
-    bars: { base, mid: base, top: base },
-    quote: {},
-    phase: 'flat',
-    order: null,
-    position: null,
-    trades: [],
-    netR: 0,
-    remainingBars: 20,
-    terminal: false,
-    result: null,
-    submitted: false,
-    ...overrides,
-  };
-}
 
 function makeCall(overrides: Partial<TrainerCoachCall> = {}): TrainerCoachCall {
   return {
@@ -61,10 +32,10 @@ function makeBridge(coach: ReturnType<typeof vi.fn>): TrainerBridge {
 }
 
 // The panel puts its latest answer in the chart overlay, so the portal needs a host to land in.
-function mount(view: TrainerView, bridge: TrainerBridge) {
+function mount(bridge: TrainerBridge) {
   return render(
     <TrainerOverlayProvider>
-      <TrainerCoachPanel view={view} bridge={bridge} sessionId="run-1" />
+      <TrainerCoachPanel bridge={bridge} sessionId="run-1" />
       <TrainerOverlayLayer />
     </TrainerOverlayProvider>,
   );
@@ -78,67 +49,79 @@ afterEach(() => {
   cleanup();
 });
 
-describe('TrainerCoachPanel lock order', () => {
-  it('keeps the button disabled until the trader has submitted', () => {
-    const coach = vi.fn();
-    mount(makeView(), makeBridge(coach));
+describe('TrainerCoachPanel availability', () => {
+  it('is askable with nothing submitted and no position open', async () => {
+    const coach = vi.fn().mockResolvedValue({ ok: true, data: makeCall() });
+    mount(makeBridge(coach));
 
     const button = askButton('问 AI');
-    expect(button.disabled).toBe(true);
+    expect(button.disabled).toBe(false);
     fireEvent.click(button);
-    expect(coach).not.toHaveBeenCalled();
-    expect(screen.getByText(/先提交你自己的方向与三价/)).toBeTruthy();
+
+    await waitFor(() => expect(coach).toHaveBeenCalledWith({ sessionId: 'run-1' }));
   });
 
-  it('unlocks once a submission exists', () => {
-    mount(makeView({ submitted: true }), makeBridge(vi.fn()));
+  it('counts the calls made so far on the button', async () => {
+    const coach = vi.fn().mockResolvedValue({ ok: true, data: makeCall() });
+    mount(makeBridge(coach));
 
-    expect(askButton('问 AI').disabled).toBe(false);
-    expect(screen.queryByText(/先提交你自己的方向与三价/)).toBeNull();
+    fireEvent.click(askButton('问 AI'));
+
+    await waitFor(() => expect(askButton('问 AI · 1')).toBeTruthy());
   });
 });
 
 describe('TrainerCoachPanel answers', () => {
-  it('shows the second opinion and flags a disagreement, with no verdict mid-episode', async () => {
+  it('shows the stance collapsed and the reasoning only once expanded', async () => {
     const coach = vi.fn().mockResolvedValue({ ok: true, data: makeCall() });
-    mount(makeView({ submitted: true }), makeBridge(coach));
+    mount(makeBridge(coach));
 
     fireEvent.click(askButton('问 AI'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('trainer-coach-comment').textContent).toBe(
-        '冲高未站稳前高，量能收缩',
-      );
-    });
-    expect(coach).toHaveBeenCalledWith({ sessionId: 'run-1' });
+    const chip = await screen.findByTestId('trainer-coach-latest');
+    expect(chip.textContent).toContain('做空');
+    expect(chip.textContent).toContain('103 / 105 / 99');
     expect(screen.getByText('与你分歧')).toBeTruthy();
-    expect(screen.getByText('对错与理由的评判留到收盘后')).toBeTruthy();
-    expect(askButton(/再问一次（第 2 次）/)).toBeTruthy();
+    expect(screen.queryByTestId('trainer-coach-comment')).toBeNull();
+
+    fireEvent.click(chip);
+
+    const comment = screen.getByTestId('trainer-coach-comment');
+    expect(comment.textContent).toContain('冲高未站稳前高，量能收缩');
+    expect(comment.textContent).toContain('对错与理由的评判留到收盘后');
   });
 
   it('leaves no answer on screen when the call fails', async () => {
     const coach = vi
       .fn()
       .mockResolvedValue({ ok: false, error: '模型没响应', code: 'TRAINER_PROTOCOL', status: 400 });
-    mount(makeView({ submitted: true }), makeBridge(coach));
+    mount(makeBridge(coach));
 
     fireEvent.click(askButton('问 AI'));
 
     await waitFor(() => expect(screen.getByText('模型没响应')).toBeTruthy());
-    expect(screen.queryByTestId('trainer-coach-comment')).toBeNull();
+    expect(screen.queryByTestId('trainer-coach-latest')).toBeNull();
     expect(askButton('问 AI').disabled).toBe(false);
   });
 
   it('does not flag agreement as a disagreement', async () => {
-    const agreed = makeCall({
-      ai: { ...makeCall().ai, direction: 'long' },
-    });
+    const agreed = makeCall({ ai: { ...makeCall().ai, direction: 'long' } });
     const coach = vi.fn().mockResolvedValue({ ok: true, data: agreed });
-    mount(makeView({ submitted: true }), makeBridge(coach));
+    mount(makeBridge(coach));
 
     fireEvent.click(askButton('问 AI'));
 
-    await waitFor(() => expect(screen.getByTestId('trainer-coach-comment')).toBeTruthy());
+    await screen.findByTestId('trainer-coach-latest');
+    expect(screen.queryByText('与你分歧')).toBeNull();
+  });
+
+  it('flags no disagreement when the trader had taken no side to disagree with', async () => {
+    const coach = vi.fn().mockResolvedValue({ ok: true, data: makeCall({ humanBefore: null }) });
+    mount(makeBridge(coach));
+
+    fireEvent.click(askButton('问 AI'));
+
+    await screen.findByTestId('trainer-coach-latest');
     expect(screen.queryByText('与你分歧')).toBeNull();
   });
 });

--- a/apps/web/src/features/training/TrainerCoachPanel.tsx
+++ b/apps/web/src/features/training/TrainerCoachPanel.tsx
@@ -1,33 +1,29 @@
 import { useState } from 'react';
-import type { TrainerCoachCall, TrainerView } from '@kansoku/pro-api';
+import type { TrainerCoachCall } from '@kansoku/pro-api';
 import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
-import {
-  coachDisagrees,
-  coachLockReason,
-  coachPlanLine,
-  DIRECTION_LABEL,
-} from './coachStance';
+import { coachDisagrees, coachPlanLine, DIRECTION_LABEL } from './coachStance';
 import { TrainerOverlayPortal } from './trainerOverlay';
 
 export interface TrainerCoachPanelProps {
-  view: TrainerView;
   bridge: TrainerBridge;
   sessionId: string;
 }
 
 /**
- * The second opinion, on demand and unlimited — the trader pays for each one, so how many to spend
- * is theirs to decide. What is not theirs is the order: the button stays locked until they have
- * submitted (see `coachUnlocked`).
+ * The second opinion, on demand, unlimited, and reachable from the first bar — the trader pays for
+ * each one, so when and how often to spend is theirs to decide.
+ *
+ * Everything this renders lives either in the order lane or in the absolutely positioned overlay,
+ * never in a row of its own: an answer arriving must not resize the chart the trader is reading.
  *
  * Nothing here shows a verdict. Mid-episode there is no outcome to judge against, and putting a
  * provisional one on screen would tell the trader which way the case goes.
  */
-export function TrainerCoachPanel({ view, bridge, sessionId }: TrainerCoachPanelProps) {
+export function TrainerCoachPanel({ bridge, sessionId }: TrainerCoachPanelProps) {
   const [calls, setCalls] = useState<TrainerCoachCall[]>([]);
   const [asking, setAsking] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const locked = coachLockReason(view);
+  const [open, setOpen] = useState(false);
   const latest = calls.at(-1) ?? null;
 
   const ask = async (): Promise<void> => {
@@ -35,8 +31,10 @@ export function TrainerCoachPanel({ view, bridge, sessionId }: TrainerCoachPanel
     setError(null);
     try {
       const result = await bridge.coach({ sessionId });
-      if (result.ok) setCalls((prev) => [...prev, result.data]);
-      else setError(result.error);
+      if (result.ok) {
+        setCalls((prev) => [...prev, result.data]);
+        setOpen(false);
+      } else setError(result.error);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -44,39 +42,43 @@ export function TrainerCoachPanel({ view, bridge, sessionId }: TrainerCoachPanel
     }
   };
 
+  const plan = latest ? coachPlanLine(latest) : null;
+
   return (
     <>
-      {latest && (
-        <TrainerOverlayPortal slot="stack">
-          <div className="trainer-chip trainer-chip--coach" data-testid="trainer-coach-latest">
-            <b>AI</b>
-            <span>{DIRECTION_LABEL[latest.ai.direction]}</span>
-            {coachPlanLine(latest).prices && (
-              <span className="num">{coachPlanLine(latest).prices}</span>
+      <TrainerOverlayPortal slot="stack">
+        {error && <div className="trainer-chip trainer-chip--error">{error}</div>}
+        {latest && (
+          // Collapsed by default: the side and the three prices are what gets read at a glance,
+          // the reasoning is what gets read on purpose. Expanding by default would drop a
+          // paragraph over the newest candles, which is where the trader is looking.
+          <button
+            type="button"
+            className={`trainer-chip trainer-chip--coach${open ? ' is-open' : ''}`}
+            data-testid="trainer-coach-latest"
+            aria-expanded={open}
+            onClick={() => setOpen((prev) => !prev)}
+          >
+            <span className="trainer-coach-stance">
+              <b>AI</b>
+              <span>{DIRECTION_LABEL[latest.ai.direction]}</span>
+              {plan?.prices && <span className="num">{plan.prices}</span>}
+              {coachDisagrees(latest) && <span className="trainer-coach-split">与你分歧</span>}
+              <span className="trainer-coach-caret">{open ? '⌃' : '⌄'}</span>
+            </span>
+            {open && (
+              <span className="trainer-coach-comment" data-testid="trainer-coach-comment">
+                {latest.ai.comment}
+                <span className="trainer-coach-defer">对错与理由的评判留到收盘后</span>
+              </span>
             )}
-            {coachDisagrees(latest) && <span className="trainer-coach-split">与你分歧</span>}
-          </div>
-        </TrainerOverlayPortal>
-      )}
-      <div className="trainer-coach-lane" data-testid="trainer-coach-lane">
-        <button
-          className="btn trainer-coach-ask"
-          disabled={locked !== undefined || asking}
-          title={locked}
-          onClick={() => void ask()}
-        >
-          {asking ? '正在问…' : calls.length === 0 ? '问 AI' : `再问一次（第 ${calls.length + 1} 次）`}
+          </button>
+        )}
+      </TrainerOverlayPortal>
+      <div className="trainer-coach-slot">
+        <button className="btn trainer-coach-ask" disabled={asking} onClick={() => void ask()}>
+          {asking ? '问 AI…' : calls.length === 0 ? '问 AI' : `问 AI · ${calls.length}`}
         </button>
-        {locked && <span className="trainer-settle-hint">{locked}</span>}
-        {error && <span className="trainer-order-error">{error}</span>}
-        {latest && !error && (
-          <p className="trainer-coach-comment" data-testid="trainer-coach-comment">
-            {latest.ai.comment}
-          </p>
-        )}
-        {calls.length > 0 && (
-          <span className="trainer-settle-hint">对错与理由的评判留到收盘后</span>
-        )}
       </div>
     </>
   );

--- a/apps/web/src/features/training/TrainerOrderPanel.test.tsx
+++ b/apps/web/src/features/training/TrainerOrderPanel.test.tsx
@@ -41,7 +41,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerSettlement.test.tsx
+++ b/apps/web/src/features/training/TrainerSettlement.test.tsx
@@ -99,7 +99,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/TrainerThumbnail.test.tsx
+++ b/apps/web/src/features/training/TrainerThumbnail.test.tsx
@@ -84,7 +84,6 @@ function terminalView(): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
-    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/coachStance.ts
+++ b/apps/web/src/features/training/coachStance.ts
@@ -1,25 +1,10 @@
-import type { TrainerCoachCall, TrainerDirection, TrainerView } from '@kansoku/pro-api';
+import type { TrainerCoachCall, TrainerDirection } from '@kansoku/pro-api';
 
 export const DIRECTION_LABEL: Record<TrainerDirection | 'neutral', string> = {
   long: '做多',
   short: '做空',
   neutral: '观望',
 };
-
-/**
- * The AI stays sealed until the trader has committed to a direction and three prices of their own.
- *
- * Asking first turns the session into copying an answer, and it anchors every annotation they will
- * later give — "the AI was right" quietly becomes "we agreed". The runtime refuses the same call
- * for the same reason; this only keeps the button from lying about being available.
- */
-export function coachUnlocked(view: TrainerView): boolean {
-  return view.submitted;
-}
-
-export function coachLockReason(view: TrainerView): string | undefined {
-  return coachUnlocked(view) ? undefined : '先提交你自己的方向与三价，AI 的看法才解锁';
-}
 
 export interface CoachPlanLine {
   direction: TrainerDirection | 'neutral';
@@ -37,7 +22,9 @@ export function coachPlanLine(call: TrainerCoachCall): CoachPlanLine {
 /**
  * Whether the two sides actually disagreed. Only a disagreement can go on to be counted as
  * influence — an AI that agreed moved nobody, and folding those in would drown the contrast.
+ *
+ * A call made before the trader took any side disagrees with nothing.
  */
 export function coachDisagrees(call: TrainerCoachCall): boolean {
-  return call.ai.direction !== call.humanBefore.direction;
+  return call.humanBefore !== null && call.ai.direction !== call.humanBefore.direction;
 }

--- a/apps/web/src/features/training/episodeReturns.test.ts
+++ b/apps/web/src/features/training/episodeReturns.test.ts
@@ -27,7 +27,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/orderDraft.test.ts
+++ b/apps/web/src/features/training/orderDraft.test.ts
@@ -45,7 +45,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/payloadToIntradayBuilt.test.ts
+++ b/apps/web/src/features/training/payloadToIntradayBuilt.test.ts
@@ -71,7 +71,6 @@ function makeView(overrides?: Partial<TrainerView>): TrainerView {
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/features/training/quickEntry.test.ts
+++ b/apps/web/src/features/training/quickEntry.test.ts
@@ -62,7 +62,6 @@ function makeView(bars: { base: RawBar[]; mid?: RawBar[]; top?: RawBar[] }): Tra
     remainingBars: 10,
     terminal: false,
     result: null,
-    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/remainingBars.test.ts
+++ b/apps/web/src/features/training/remainingBars.test.ts
@@ -30,7 +30,6 @@ function makeView(base: RawBar[], remainingBars: number): TrainerView {
     remainingBars,
     terminal: false,
     result: null,
-    submitted: false,
   };
 }
 

--- a/apps/web/src/features/training/replayBands.test.ts
+++ b/apps/web/src/features/training/replayBands.test.ts
@@ -33,7 +33,6 @@ function makeView(overrides: Partial<TrainerView> = {}): TrainerView {
     remainingBars: 0,
     terminal: true,
     result: null,
-    submitted: false,
     ...overrides,
   };
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1226,6 +1226,24 @@ body.trainer-dragging-level * {
   overflow-x: clip;
   overflow-y: visible;
 }
+/* A lane that shares its row with something anchored to the right. The row owns the rule and the
+   height so the lane keeps clipping its own overflow without also clipping its neighbour. */
+.trainer-lane-row {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: stretch;
+  height: 38px;
+  border-top: 1px solid var(--border);
+}
+.trainer-lane-row > .trainer-lane {
+  flex: 1 1 auto;
+  min-width: 0;
+  /* The row already owns the 38px, and it is border-box — so its content box is 37px. A lane
+     keeping its own `height: 38px` overhangs the row by exactly the border, which knocks the
+     button off centre by a pixel. Let the row's stretch size it instead. */
+  height: auto;
+  border-top: none;
+}
 .trainer-lane-group {
   display: flex;
   align-items: center;
@@ -9587,26 +9605,44 @@ a.zone-item:hover {
   border-color: var(--accent);
 }
 
-.trainer-coach-lane {
+.trainer-coach-slot {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 8px 16px;
-  background: var(--bg-surface);
-  border-top: 1px solid var(--border);
-}
-.trainer-coach-comment {
-  margin: 0;
-  flex: 1 1 240px;
-  min-width: 0;
-  color: var(--text-secondary);
-  font-size: var(--fs-sm);
-  line-height: 1.6;
+  padding: 0 12px 0 4px;
 }
 .trainer-chip--coach {
   border-left: 2px solid var(--accent);
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  max-width: 320px;
+  font: inherit;
+  font-size: var(--fs-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.trainer-coach-stance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.trainer-coach-caret {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+.trainer-coach-comment {
+  display: block;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  border-top: 1px solid var(--border);
+  padding-top: 6px;
+}
+.trainer-coach-defer {
+  display: block;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 .trainer-coach-split {
   color: var(--accent);

--- a/docs/superpowers/specs/2026-08-02-trainer-coach-unlock-design.md
+++ b/docs/superpowers/specs/2026-08-02-trainer-coach-unlock-design.md
@@ -1,0 +1,155 @@
+# 盲盘训练「问 AI」：拆锁 + 挪位 —— 设计
+
+> 2026-08-02 · 盲盘训练 M4 修订
+>
+> 上游设计：`2026-07-28-blind-replay-trainer-m4-m5-design.md`（M4 陪练链路）、`2026-07-25-blind-replay-training-design.md` §7
+>
+> 现状代码：web 侧已随 kansoku #107 合入 main；pro 侧已随 kansoku-pro #26（5d118ba）合入 main。本文改的是**已发布**的行为，不是待合分支。
+
+## 1. 背景
+
+M4 落地的「局中问 AI」现在有两个毛病，一个在 UI，一个在门槛。
+
+### 1.1 UI：它是唯一会在局中改变图表高度的东西
+
+`TrainerCoachPanel` 渲染成 `.trainer-coach-lane`（`apps/web/src/styles.css:9590`），是训练窗口底部第三条独立横带，排在推进条、下单条下面。
+
+这条横带违反了这块布局唯一一条明写的纪律。`styles.css:896` 那段注释说得很直接：图表下面的控件曾经「每个状态长一行」——状态、播放事件、校验、错误——每长一行就在局中改一次图表高度，所以后来全部改成绝对定位的浮层。而 `.trainer-coach-lane` 用了 `flex-wrap: wrap`，里面装着 `.trainer-coach-comment { flex: 1 1 240px; line-height: 1.6 }`：AI 一回答就换行长高，正是当初被赶走的那个行为。长高的时机还偏偏是你盯着图看结果的那一刻。
+
+另外两条毛病同源：
+
+- **视觉权重和使用频率反着。** 推进条、下单条都是 `.trainer-lane`，`height: 38px` 封死（`styles.css:1214`）；问 AI 一局最多点几次，占的高度反而不封顶。三条里只有它有 `background: var(--bg-surface)`，比每根都要用的那两条还抢眼。
+- **信息重了一份。** AI 的方向、三价、「与你分歧」已经在图右上角的 chip 里（`TrainerCoachPanel.tsx:50`），lane 里再放一段 comment——同一件事，两个形态两个位置。
+
+### 1.2 门槛：解锁要先把这一笔做完
+
+母设计把「先提交自己的判断」定为不可妥协的锁定顺序，理由是开局即可问 AI 等于抄答案。落地时这把锁的实际形态是：`coachUnlocked(view) => view.submitted`，而 `submitted` 来自一次完整的 `submit` —— 方向、入场、止损、目标四样齐全，还要过 1.5 盈亏比下限（`meetsRewardRiskFloor`）。
+
+也就是说，想在放线之前问一句「这段结构你怎么看」，门都没有。要问，先把整笔交易做完。这不是「先表个态」，是「先做完」。
+
+契约层面本来留了一条更便宜的路——`submitted` 也接受弃权（观望本身就是一次提交，不产出单也不产出仓）——但 **web 侧压根没有「观望」按钮**：`TrainerEntryLane` 只有做多、做空、市价做多、市价做空。开场白第一条写着「看不准就观望——观望也算一次决定」（`TrainerLauncher.tsx:14`），而这个决定在 UI 上没有任何落点。所以实践中解锁只有一条路：一张过了 1.5 盈亏比下限的完整单。
+
+结果就是这条最占地方的横带，绝大多数时间是灰的，旁边还常驻一句「先提交你自己的方向与三价，AI 的看法才解锁」——**它最占地方的时候正是它最没用的时候。**
+
+## 2. 已定决策与理由
+
+### 2.1 「问 AI」并进下单条右端，跟「备注」同级
+
+删掉 `.trainer-coach-lane`，底部从三条回到两条。按钮跟下单条同一行，靠右。
+
+理由：这个动作的使用频率和「备注」是一个量级，视觉权重就该是一个量级。塞进固定 38px 的行里，等于让它永远不能再改变图表高度——1.1 的纪律自动被遵守，而不是靠下一个人记得。
+
+**不选**的落点及理由：
+
+| 落点 | 不选的理由 |
+| --- | --- |
+| 左侧画线工具栏（`.trainer-overlay-rail`） | 那条栏的语义是「在图上画东西」，塞 AI 进去语义混 |
+| 顶部 header 右侧 | 离图和手都远；header 是拖窗区，要额外处理 no-drag |
+| 不给常驻入口，提交时浮出卡片 | 与 2.3 的「随时能点」直接冲突 |
+
+### 2.2 AI 的话全部收进图右上角的 chip，默认收起
+
+`trainer-overlay-stack` 是绝对定位的浮层，长多长都不碰图表高度。chip 默认一行：方向 + 三价 + 分歧标记；comment 折在里面，点 chip 展开（`max-width: 320px`），再点收起。原先常驻在横带上的那句「对错与理由的评判留到收盘后」跟着 comment 走进展开区 —— 它是读理由时才需要的提醒，不该占一行常驻。
+
+默认收起而不是常显：方向和三价是抬眼就要看的，理由是想了才看的。常显会把 chip 撑到盖住最新几根 K 线——那正是你在看的地方。
+
+多次召唤时 stack 里仍只放最新一条，历史留给结算页的「AI 对照」。这跟现在的行为一致，不新增概念。
+
+### 2.3 解锁门槛全部拆掉，抬手就问
+
+按钮永远可点，没有任何前置条件。开局第一根就能问。
+
+这等于把 AI 在这里的身份从「被对照的第二意见」换成「随叫随到的教练」，是明确的产品取舍：母设计怕的是抄答案，但代价是把 AI 关在一道贵得离谱的门后面，而训练最需要它的时刻——你还没想清楚的时候——恰好在门外。
+
+**代价照实记下：** 改完之后，开局第一根就能拿到一个完整的方向加三价。这条不做任何技术阻拦。
+
+**开局那一下走的是 `cursor = -1`。** 推进之前引擎的游标是 `-1`，旧锁让这个值永远到不了 coach 链路。`buildEpisodeQuestionViewAtCursor` 显式判 `cursor >= 0`，负数时 revealed 为空、cutoff 回落到题目自己的 `question.cutoff` —— 也就是 AI 看到的正是交易者开局看到的那一屏，没有多一根。`assertNoFutureBars` 校验的也是同一个 cutoff，所以泄漏防线在这条新路径上照常成立。
+
+**但记录必须诚实。** 不加新字段——`TrainerCoachCall` 已经有 `cursor` 和 `humanBefore`，结算页显示「B0 · 你当时还没表态」就足以让你事后分辨这一局是判出来的还是抄出来的。
+
+**不加二次确认弹窗。** 门槛拆了又换个形式装回去等于没拆。误点的代价是一次真实模型调用（`COACH_TIMEOUT_MS = 180_000`），按钮在 `asking` 期间 disabled 已经够了。
+
+### 2.4 统计口径不变，只算「你当时有方向」的那些召唤
+
+`humanBefore` 变成可空。为空的召唤不进「AI 陪练影响」（被说服 vs 坚持），但照常进「AI 成绩单」。
+
+理由：这两块量的是不同的东西。「陪练影响」量的是**你**有没有被改变——没有表态就没有可被改变的东西，这个问题不适用，不是「值为零」。「成绩单」量的是**AI**准不准，跟你有没有表态无关，所以一次都不能漏。
+
+样本会变稀。现有那条「不足 10 不出比率」的护栏自己会处理，不额外加东西——那正是它存在的理由。
+
+## 3. 改动清单
+
+### 3.1 契约（`packages/pro-api/src/trainerTypes.ts`）
+
+| 改动 | 说明 |
+| --- | --- |
+| `TrainerCoachCall.humanBefore` → `TrainerCoachStance \| null` | 放宽 |
+| `TrainerCoachVerdict.agreement` → `TrainerCoachAgreement \| null` | 放宽。**不**往三值枚举里加第四个「没表态」——那不是一种一致性，是这个问题不适用 |
+| `TrainerView.submitted` | **删除**（`trainerTypes.ts:192` 及其注释） |
+| `TrainerErrorCode` | 不动 |
+
+`submitted` 删得掉，是因为全 web 只有 `coachStance.ts:17` 一处在读它。锁一去它就是死字段，留着比删掉更容易误导后来人。
+
+### 3.2 pro 侧（`apps/pro/src/modules/training/`）
+
+- `trainerRuntime.ts:562`：删 `if (state.initialSubmission === null) throw new TrainerCoachLockedError()`，连同上面那句「a disabled button is a courtesy and this rule is not」的注释。
+- `trainerRuntime.ts:216-235` `humanStance`：返回类型改 `TrainerCoachStance | null`；`:228` 的 `throw` 改成 `return null`。**前两条分支一个字不动**——手上有挂单或持仓时方向本来就确定，这正是 2.4 口径的落实处。
+- `trainerRuntime.ts:156` `TrainerCoachLockedError` 类整个删；`:186` `failure()` 里对应的那一支一并删（它原本归到 `TRAINER_GUARDRAIL` / 409，删掉后不影响枚举，只是少一条分支）。
+- `session.ts:194`：不再产出 `submitted`。
+- `coachVerdict.ts:94` `coachAgreement`：`humanBefore` 为空时直接 `return null`，不进 `firstDirectionChange`。
+- `trainingStats.ts:130` `coachInfluenceStats`：`:137` 的筛选条件从 `verdict.agreement !== 'aligned'` 改成 `verdict.agreement !== null && verdict.agreement !== 'aligned'`。分母语义从「有分歧的召唤」变成「你当时有方向、且和 AI 有分歧的召唤」。
+- `trainingStats.ts:196` `coachScorecard`：**不动**，所有召唤照常计入。
+
+### 3.3 web 侧（`apps/web/src/features/training/`）
+
+- `coachStance.ts`：删 `coachUnlocked`、`coachLockReason`；`coachDisagrees` 在 `humanBefore` 为空时返回 `false`（没表态就没有分歧）。
+- `TrainerCoachPanel.tsx`：不再渲染 `.trainer-coach-lane`。拆成两块——按钮（进下单条那一行）和 chip（进 `trainer-overlay-stack`，带展开态）。`disabled` 只剩 `asking` 一个条件。按钮文案：`问 AI` / 问过之后 `问 AI · 3` / 请求中 `问 AI…`。错误提示改用 stack 里的 `trainer-chip--error`，跟推进条、下单条的报错走同一条路。
+- `TrainerChart.tsx:189-204`：把 `<TrainerOrderPanel>` 和 coach 按钮包进 `.trainer-lane-row`。
+- `TrainerCoachCompare.tsx:99-101`：`humanBefore` 为空时「你当时：做多」换成「你当时还没表态」；`verdict.agreement` 为空时不渲染 agreement chip。标注入口不受影响（只看 `verdict.directionCorrect`）。
+
+### 3.4 CSS（`apps/web/src/styles.css`）
+
+- 删 `.trainer-coach-lane`、`.trainer-coach-comment`。
+- `.trainer-lane` 的 `border-top` 上移到新增的 `.trainer-lane-row`；`.trainer-lane` 在行内 `flex: 1 1 auto`。
+- 新增 `.trainer-lane-row { display: flex; flex: 0 0 auto; height: 38px; border-top: 1px solid var(--border) }`。
+- 行内的 lane 还要 `height: auto`。这条是实跑量出来的：全局 `box-sizing: border-box` 之下，行的 38px 含那 1px 边框，内容盒只有 37px；lane 若继续扛着自己的 `height: 38px` 就会往下探出 1px，把「问 AI」按钮的上下间距顶成 6/4。交给行的 `align-items: stretch` 去定高即可。
+- `.trainer-chip--coach` 加展开态：收起时 comment 不渲染，展开时 `max-width: 320px`。
+
+包一层而不是让 `TrainerOrderPanel` 自己挂按钮，是因为它有五种形态——选方向、已画草稿、挂单中、持仓中，外加一条非平仓却既无单又无仓时的兜底「本局已结束」（`TrainerOrderPanel.tsx:272`）——每种都是一条独立的 `.trainer-lane`。按钮包在外面自动全覆盖，不会出现某个形态忘了挂。`.trainer-lane` 那句 `overflow-x: clip` 只管它自己，按钮在它外面，不会被裁掉。
+
+## 4. 存量兼容
+
+不需要迁移，`sessionStore` 的 `version` 不动。
+
+`humanBefore` 和 `agreement` 都是**放宽**不是收紧：已经落盘的记录全是非空，读回来照样合法。新记录才可能带空值。
+
+已完成的旧局重新打开统计时，`agreement` 全是三值之一，`coachInfluenceStats` 新加的 `!== null` 判断对它们恒真，口径与改动前完全一致。
+
+## 5. 测试
+
+**删：**
+
+- pro：未提交时调 `coach` 抛 `TrainerCoachLockedError` 的用例
+- web：`TrainerCoachPanel.test.tsx` 里按钮 disabled + 锁定提示的用例
+
+**改：**
+
+- `TrainerCoachPanel.test.tsx` 里 `askButton('问 AI')` 的文案断言（改成计数形态）
+
+**加：**
+
+- pro 端到端：开局第一根直接调 `coach` → 落一条 `humanBefore: null` 的记录 → 收盘后 `verdict` 照常有、`verdict.agreement` 为 `null`
+- pro 统计：一局里既有「有方向的召唤」也有「没表态的召唤」→ `coachInfluence` 只数前者，`coachScorecard` 两者都数
+- web：下单条各形态（选方向 / 已画草稿 / 挂单中 / 持仓中）下按钮都在且可点
+- web：chip 展开收起
+
+**不动：**
+
+- `assertNoFutureBars` 那套泄漏测试。它防的是 AI 看到游标右边的 K 线，跟解不解锁无关。
+
+## 6. 本期不做
+
+- **AI 影子局**（AI 从头到尾自己打完整局做全程对照）。M4/M5 设计已经 defer 过一次，理由不变：一局要烧几十次模型调用，且是另一个功能。
+- **单局召唤次数上限**。母设计定的是「自己付钱自己决定」，本期不改这条。
+- **按题型选盘**。与盲盘前提冲突，见 `2026-07-28-blind-case-ai-pick-design.md` §3.3。
+- **补上「观望」按钮**。§1.2 暴露的这个缺口是真的，但它属于下单条的入口设计，不属于本期。本期改完之后，它至少不再挡着 AI —— 解锁路径已经整条拆掉了。

--- a/packages/pro-api/src/trainerTypes.ts
+++ b/packages/pro-api/src/trainerTypes.ts
@@ -185,11 +185,6 @@ export interface TrainerView {
   remainingBars: number;
   terminal: boolean;
   result: TrainerResult | null;
-  // Whether the trader has ever committed to a direction, which is what unlocks the AI. Sticky:
-  // cancelling an order does not re-seal it. Carried rather than inferred from `order` / `position`
-  // / `trades`, because an abstention commits a view without producing any of the three, and the
-  // renderer's lock must match the one the runtime enforces.
-  submitted: boolean;
 }
 
 export interface TrainerStepEvent {
@@ -336,7 +331,8 @@ export interface TrainerCoachVerdict {
   /** What the plan actually collected, in R. */
   realizedR: number | null;
   directionCorrect: boolean;
-  agreement: TrainerCoachAgreement;
+  /** Null where the trader had taken no side to compare against — see `humanBefore`. */
+  agreement: TrainerCoachAgreement | null;
   judgedAt: string;
 }
 
@@ -360,7 +356,12 @@ export interface TrainerCoachCall {
   step: number;
   askedAt: string;
   model: string;
-  humanBefore: TrainerCoachStance;
+  /**
+   * Null when they asked before taking any side. The AI is reachable from the first bar, so a
+   * call may legitimately predate any view of their own; the persuaded/held comparison then has
+   * no second term and is skipped rather than filled in with a default.
+   */
+  humanBefore: TrainerCoachStance | null;
   ai: TrainerSubmission;
   verdict: TrainerCoachVerdict | null;
   annotation: TrainerAnnotation | null;


### PR DESCRIPTION
盲盘训练「问 AI」的挪位 + 拆锁。设计见 `docs/superpowers/specs/2026-08-02-trainer-coach-unlock-design.md`（本 PR 一并加入）。

配套的 pro 侧改动已合入 `kansoku-pro#27`（`a7236ac`）。本 PR 提供它依赖的契约放宽。

## UI：为什么要挪

`.trainer-coach-lane` 是图表下面**唯一还能改变图表高度**的东西：它 `flex-wrap: wrap`，里面装着 `flex: 1 1 240px` 的 AI 理由，所以答案一到就换行长高、把图挤矮——恰好在你盯着看结果的那一刻。`.trainer-overlay` 上面那段注释解释了这一区其他控件为什么全都绝对定位，这条是漏网的。

权重也是反的：推进和下单每根都用、各占 38px；问 AI 一局最多点几次，却拿到一条不封顶的行，还是三条里唯一有 `--bg-surface` 的。

改法：删掉这条横带，按钮挂到当前显示的那条下单 lane 末端，外面包一层 `.trainer-lane-row` 持有边框和高度。下单面板每种状态只产出一个行内元素（其余全走浮层），所以包在外面就覆盖了全部五种形态，不用每种自己记得挂。答案进浮层 chip，默认只显示方向和三价，理由点开才出——默认展开会把一段话糊在最新几根 K 线上。

## 一个实跑量出来的 1px

行内的 lane 需要 `height: auto`。border-box 之下行的 38px 含那 1px 边框，内容盒只剩 37px，lane 若继续扛着自己的 `height: 38px` 就正好探出那一个像素，够把按钮顶得上下不对称。jsdom 没有布局引擎，这条只有真跑起来才看得见。

## 拆锁

`submitted` 只为那把锁存在，随锁一起从契约删除；`humanBefore` 与 `verdict.agreement` 放宽为可空（对应「问的时候还没表态」）；`coachDisagrees` 把「没有立场」读成「没有分歧」而不是「有差异」。

## 验证

- `pnpm --filter @kansoku/web typecheck` / `@kansoku/pro-api typecheck`：干净
- `apps/web` 全量测试：164 个文件 1187 个测试全过（新增 coach 面板 5 例、对照页 1 例、chart 同行 1 例）
- 桌面端实跑（Electron + CDP）：按钮与同行的做多/做空/市价做多同一条基线（t=828 b=856 h=28）；`.trainer-coach-lane` 在 DOM 中为 0；开局未提交时按钮可点；chip 收起 221×23、展开 320×164，右溢出 −64、下溢出 −569；**收起与展开态 `chartBottom` 均为 784——答案到达没有改变图表高度一个像素**