### PR TITLE
fix(training): name a question asked at the open 开局, not B-1

### DIFF
--- a/apps/web/src/features/training/TrainerCoachCompare.test.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.test.tsx
@@ -134,6 +134,23 @@ describe('TrainerCoachCompare readout', () => {
     expect(screen.getByText(/你当时：做多/)).toBeTruthy();
   });
 
+  // Asking at the open lands on cursor -1, so the raw index would name a bar the timeline
+  // (B0..Bn) does not have.
+  it('labels a question asked at the open as 开局, not as a negative bar', () => {
+    render(
+      <TrainerCoachCompare
+        calls={[call({ cursor: -1, humanBefore: null, verdict: verdict({ agreement: null }) })]}
+        bridge={bridgeWith(vi.fn())}
+        sessionId="run-1"
+        onAnnotated={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /第 1 次 · 开局/ })).toBeTruthy();
+    expect(screen.queryByText(/B-1/)).toBeNull();
+  });
+
   it('says the trader had no side yet, and drops the agreement chip with it', () => {
     render(
       <TrainerCoachCompare

--- a/apps/web/src/features/training/TrainerCoachCompare.tsx
+++ b/apps/web/src/features/training/TrainerCoachCompare.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@kansoku/pro-api';
 import { fmt, signed } from '@web/lib/format';
 import type { TrainerBridge } from '../desktop/desktopTrainerBridge';
-import { coachPlanLine, DIRECTION_LABEL } from './coachStance';
+import { coachBarLabel, coachPlanLine, DIRECTION_LABEL } from './coachStance';
 
 const OUTCOME_LABEL: Record<TrainerCoachOutcome, string> = {
   win: '到目标',
@@ -92,7 +92,7 @@ export function TrainerCoachCompare({
           <article className="trainer-coach-card" key={call.id}>
             <header className="trainer-coach-head">
               <button className="trainer-chip trainer-coach-at" onClick={() => onSeek(call.id)}>
-                第 {index + 1} 次 · B{call.cursor}
+                第 {index + 1} 次 · {coachBarLabel(call.cursor)}
               </button>
               <span>
                 AI：<b>{DIRECTION_LABEL[call.ai.direction]}</b>

--- a/apps/web/src/features/training/coachStance.test.ts
+++ b/apps/web/src/features/training/coachStance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { TrainerCoachCall } from '@kansoku/pro-api';
+import { coachBarLabel, coachDisagrees, coachPlanLine } from './coachStance';
+
+function call(overrides: Partial<TrainerCoachCall> = {}): TrainerCoachCall {
+  return {
+    id: 'coach-1',
+    cursor: 7,
+    step: 8,
+    askedAt: '2026-01-05T14:35:00.000Z',
+    model: 'test/model',
+    humanBefore: { direction: 'long', entry: 101, stop: 99, target: 105 },
+    ai: {
+      direction: 'short',
+      anchor: { timeframe: 'm5', time: '2026-01-05T14:35:00.000Z', price: 103 },
+      entry_plan: { entry: 103, stop: 105, target1: 99 },
+      scenarios: [],
+      comment: '冲高未站稳前高',
+    },
+    verdict: null,
+    annotation: null,
+    ...overrides,
+  };
+}
+
+describe('coachBarLabel', () => {
+  it('names the bar the question was asked on', () => {
+    expect(coachBarLabel(0)).toBe('B0');
+    expect(coachBarLabel(37)).toBe('B37');
+  });
+
+  // The engine sits at -1 until the first bar is stepped into, and the AI is reachable from the
+  // open — so this index is reachable and must not print as a bar the timeline does not have.
+  it('says 开局 rather than pointing at a bar that does not exist', () => {
+    expect(coachBarLabel(-1)).toBe('开局');
+  });
+});
+
+describe('coachDisagrees', () => {
+  it('is true only when both sides took a side and they differ', () => {
+    expect(coachDisagrees(call())).toBe(true);
+  });
+
+  it('is false when they agreed', () => {
+    expect(coachDisagrees(call({ ai: { ...call().ai, direction: 'long' } }))).toBe(false);
+  });
+
+  it('is false when the trader had taken no side to disagree with', () => {
+    expect(coachDisagrees(call({ humanBefore: null }))).toBe(false);
+  });
+});
+
+describe('coachPlanLine', () => {
+  it('lays the three prices out in entry / stop / target order', () => {
+    expect(coachPlanLine(call()).prices).toBe('103 / 105 / 99');
+  });
+
+  it('withholds the prices when the AI filed no plan', () => {
+    expect(coachPlanLine(call({ ai: { ...call().ai, entry_plan: undefined } })).prices).toBeNull();
+  });
+});

--- a/apps/web/src/features/training/coachStance.ts
+++ b/apps/web/src/features/training/coachStance.ts
@@ -6,6 +6,15 @@ export const DIRECTION_LABEL: Record<TrainerDirection | 'neutral', string> = {
   neutral: '观望',
 };
 
+/**
+ * The engine's cursor is -1 until the first bar is stepped into, and the AI is reachable from the
+ * open, so a call can legitimately carry a bar index that no bar has. The review timeline runs
+ * B0..Bn, so rendering it raw would point at a candle that does not exist.
+ */
+export function coachBarLabel(cursor: number): string {
+  return cursor < 0 ? '开局' : `B${cursor}`;
+}
+
 export interface CoachPlanLine {
   direction: TrainerDirection | 'neutral';
   prices: string | null;


### PR DESCRIPTION
复盘页的 AI 对照把「开局就问的那次召唤」渲染成了 **`第 1 次 · B-1`**，而同一页的时间轴标的是 B0…B155——指着一根不存在的 K 线。

## 为什么现在才出现

引擎的游标在推进第一根之前是 `-1`。拆锁之前这个值到不了 coach 记录：召唤必须先有一张已提交的单，而那不可能发生在第一根之前。所以 `TrainerCoachCompare` 直接渲染 `B{call.cursor}` 一直是对的。`#115` 让开局即可召唤之后，同一个表达式就开始打印 `B-1`。

## 影响面

纯显示。游标为负时 `buildEpisodeQuestionViewAtCursor` 的行为是正确的（不 reveal 任何 bar、cutoff 回落到题目自身），判定和统计都不读这个标签。

## 改动

`coachBarLabel(cursor)` 收在 `coachStance.ts`（coach 相关纯函数都在那），`cursor < 0` 时给「开局」。

`coachStance.ts` 原先没有直接单测，顺手补上：`coachBarLabel`、`coachDisagrees`（含 `humanBefore` 为空的分支）、`coachPlanLine`。

## 验证

- `@kansoku/web` typecheck 干净，改动文件 eslint 干净
- 165 个测试文件 / 1195 个测试全过（新增 8 个）
- 这条缺陷本身是桌面端实跑时肉眼看到的——jsdom 没有布局也没有真实链路，单元测试看不见它，所以这次连断言一起补上了