### PR TITLE
fix(ci): point --prepackaged at the .app, not its parent directory

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -265,12 +265,18 @@ jobs:
       # both from the stapled bundle. --prepackaged skips the pack/sign phase
       # entirely (doPack returns immediately), so this only re-runs dmg/zip
       # target packaging against the already-notarized app.
+      #
+      # --prepackaged takes the .app itself, not the directory holding it:
+      # macPackager passes the value straight through as `appPath` to
+      # packageInDistributableFormat. Given the parent directory it archives
+      # that directory instead, and the zip comes out with no .app at its top
+      # level — which the verify step below then fails to find.
       - name: repackage dmg + zip from the stapled app
         if: steps.signing.outputs.enabled == 'true' && vars.NOTARY_SUBMIT_ONLY != 'true'
         working-directory: apps/desktop
         run: |
           rm -f release/*.dmg release/*.zip
-          pnpm exec electron-builder --prepackaged release/mac-arm64 --mac dmg zip --arm64 --publish never
+          pnpm exec electron-builder --prepackaged release/mac-arm64/Kansoku.app --mac dmg zip --arm64 --publish never
 
       - name: verify signature (dmg + zip both embed the already-signed app)
         working-directory: apps/desktop


### PR DESCRIPTION
`desktop-v0.32.0` 的发布跑挂在 **verify signature**：解开重打包出来的 zip 后，`"$ZIP_EXTRACT_DIR"/*.app` 一个都没匹配到。

## 为什么现在才炸

「repackage dmg + zip from the stapled app」这一步被 `NOTARY_SUBMIT_ONLY != 'true'` 挡着，而那个仓变量从 7/29（显式公证路径落地那天）一直是 `true`，今天才删掉。**也就是说这一步从写下来到今天，第一次真正执行——然后就挂了。**在此之前每次发版都走 submit-only：不等、不 staple、不重打包，所以这条路径一直没被验证过。

## 根因

`macPackager.js:269`：

```js
const appPath = prepackaged == null
  ? path.join(this.computeAppOutDir(outDir, arch), `${productFilename}.app`)
  : prepackaged;
```

这个值原样传给 `packageInDistributableFormat`，所以 `--prepackaged` 要的是 **`.app` 本身**，不是装着它的目录。传 `release/mac-arm64` 之后归档目标打的是那个目录，`Kansoku.app` 就比所有下游消费者预期的位置深了一层。

上一步的 notarize 传的本来就是 `.app` 路径（`apps/desktop/release/mac-arm64/Kansoku.app`），现在两处一致了。

## 影响面

只影响已签名 + 要 staple 的发布路径。ad-hoc 构建和 submit-only 构建都不走这一步。

## 验证

改的是只有真发版才会执行的步骤，本地无法预演——验证方式就是这次 0.32.0 的重发。合并后我会把 tag 重指到含本修复的提交，由 tag push 触发发布，跑通即为验证；再挂就带着新日志继续查。