### PR TITLE
feat(analytics): report to kansoku-analytics from the app

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -21,6 +21,12 @@ concurrency:
 
 env:
   REPO_SLUG: 'Innei/kansoku'
+  # Baked into the bundle at build time, so it has to be present for *every* web build in the
+  # job — and there are two: the explicit build step, and the one `pnpm package` re-runs through
+  # apps/desktop's prepackage hook. Setting it per-step would let the second build quietly strip
+  # it back out and ship an app that reports nothing. Unset (no repo variable) leaves the whole
+  # analytics module inert, which is what a fork or a local build gets.
+  VITE_ANALYTICS_ENDPOINT: ${{ vars.VITE_ANALYTICS_ENDPOINT }}
 
 jobs:
   release:

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from './features/palette/CommandPalette';
 import { RestrictedBanner } from './features/edition/RestrictedBanner';
 import { isDesktopRealtime } from './lib/portTransport';
 import { getBrowserRouter, matchPopoutSymbolRoute, navigate, routePathname, useRoute } from './lib/router';
+import { useOnboardingAnalytics, useScreenAnalytics } from './lib/useScreenAnalytics';
 import { ContextMenuHost, ModalHost } from './ui';
 import { RoutedGlobalNotifications } from './features/notifications/GlobalNotifications';
 
@@ -18,6 +19,8 @@ export function App() {
   const gate = useCredentialsGate();
   const route = useRoute();
   const isPopout = matchPopoutSymbolRoute(routePathname(route)) !== null;
+  useScreenAnalytics();
+  useOnboardingAnalytics(gate.status === 'onboarding');
 
   useEffect(() => {
     const bridge = getDesktopDeepLinkBridge();

--- a/apps/web/src/features/charts/drawings/drawingVariant.ts
+++ b/apps/web/src/features/charts/drawings/drawingVariant.ts
@@ -1,0 +1,14 @@
+import type { AnalyticsVariant } from '@web/lib/analytics';
+import type { DrawingTool } from './drawingsMachine';
+
+const VARIANT_TOOLS = new Set<string>(['hline', 'trendline', 'rect', 'fib', 'polyline']);
+
+/**
+ * `measure` is a drawing tool the ingest schema has no variant for, so it reports the feature
+ * with no breakdown rather than being dropped or smuggled in under a neighbouring name — the
+ * Worker rejects the whole event on an unknown variant, and a silent 400 would lose the use
+ * entirely.
+ */
+export function drawingVariantOf(tool: DrawingTool): AnalyticsVariant | undefined {
+  return VARIANT_TOOLS.has(tool) ? (tool as AnalyticsVariant) : undefined;
+}

--- a/apps/web/src/features/charts/drawings/useDrawings.ts
+++ b/apps/web/src/features/charts/drawings/useDrawings.ts
@@ -15,7 +15,9 @@ import type {
   MeasureShape,
   PreviewShape,
 } from './drawingsPrimitive';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { type DrawingTool, type MultiPointTool } from './drawingsMachine';
+import { drawingVariantOf } from './drawingVariant';
 import { useDrawingsInteraction } from './useDrawingsInteraction';
 
 export function decodeAnnotationsFrame(payload: unknown, ownClientId: string): Annotation[] | null {
@@ -265,7 +267,18 @@ export function useDrawings(
     [pushState, updateScrollLock],
   );
 
-  const setActiveTool = useCallback((t: DrawingTool) => applyTool(t, false), [applyTool]);
+  const setActiveTool = useCallback(
+    (t: DrawingTool) => {
+      // Picking a tool is the intent; whether a shape ends up on the chart is a separate
+      // question this column is not asking. `off` and `cursor` leave drawing rather than enter
+      // it, and `measure` has no variant in the ingest enum, so it counts without one.
+      if (t !== 'off' && t !== 'cursor') {
+        trackFeatureUsed('chart_drawing', { variant: drawingVariantOf(t) });
+      }
+      applyTool(t, false);
+    },
+    [applyTool],
+  );
 
   const clearAll = useCallback(() => {
     setSelected(null);

--- a/apps/web/src/features/cockpit/chat/useChatSession.ts
+++ b/apps/web/src/features/cockpit/chat/useChatSession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { errorMessage } from '@web/lib/api';
 import { client } from '@web/lib/client';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { subscribeChannel } from '@web/lib/ws/wsHub';
 import { useSmoothStream } from './useSmoothStream.js';
 
@@ -296,6 +297,9 @@ function useConversationSession(
       const trimmed = text.trim();
       if (!trimmed) return { ok: false, error: '内容不能为空' };
       const optimisticId = `optimistic-${Date.now()}`;
+      // Counted on intent, not on delivery: a message the backend then refuses is still the
+      // trader having reached for the assistant, which is what the feature column measures.
+      trackFeatureUsed('ai_chat', { surface: kind });
       sendPendingRef.current = true;
       setHint(null);
       setBusy(true);
@@ -329,7 +333,7 @@ function useConversationSession(
         return { ok: false, error: message };
       }
     },
-    [adapter, id],
+    [adapter, id, kind],
   );
 
   const abort = useCallback(async (): Promise<void> => {

--- a/apps/web/src/features/cockpit/useDeepDive.ts
+++ b/apps/web/src/features/cockpit/useDeepDive.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { ApiError, errorMessage } from '@web/lib/api';
 import { client } from '@web/lib/client';
 
@@ -69,6 +70,9 @@ export function useDeepDive(symbol: string, onNoteReady: () => void) {
         setRunning(false);
         setRunningSymbol(null);
         setStartedAt(null);
+        // Paired with the `started` above, so the two counts together show how many deep runs
+        // are abandoned or die mid-flight rather than reaching a report.
+        trackFeatureUsed('deep_research', { stage: 'completed' });
         const result = status.lastResult;
         if (
           result &&
@@ -101,6 +105,7 @@ export function useDeepDive(symbol: string, onNoteReady: () => void) {
     setPending(true);
     try {
       await client.symbols.deepDive({ sym: symbol });
+      trackFeatureUsed('deep_research', { stage: 'started' });
       setRunning(true);
       setRunningSymbol(symbol);
       setStartedAt(new Date().toISOString());

--- a/apps/web/src/features/cockpit/useReassessSymbol.ts
+++ b/apps/web/src/features/cockpit/useReassessSymbol.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { errorMessage } from '@web/lib/api';
 import { client } from '@web/lib/client';
 
@@ -47,6 +48,7 @@ export function useReassessSymbol(symbol: string): {
     setError(null);
 
     try {
+      trackFeatureUsed('market_analysis');
       const data = await client.symbols.reassess({ sym: symbol });
       const superseded = tokenRef.current !== token;
       if (superseded) return { ok: false, error: '请求已取消', aborted: true };

--- a/apps/web/src/features/home/SymbolActions.tsx
+++ b/apps/web/src/features/home/SymbolActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Check, Lock, RadioTower } from 'lucide-react';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { errorMessage } from '@web/lib/api';
 import { client } from '@web/lib/client';
 import { Button, Switch } from '@web/ui';
@@ -82,6 +83,7 @@ export function ReassessButton({ symbol }: { symbol: string }) {
     if (state === 'running') return;
     setState('running');
     try {
+      trackFeatureUsed('market_analysis');
       const res = await client.symbols.reassess({ sym: symbol });
       setState(res.started ? 'done' : 'failed');
     } catch (err) {

--- a/apps/web/src/features/onboarding/useCredentialsGate.ts
+++ b/apps/web/src/features/onboarding/useCredentialsGate.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+import { trackFeatureUsed } from '../../lib/analytics';
 import { useQuery } from '../../lib/apiHooks';
 import { client } from '../../lib/client';
 import {
@@ -54,6 +55,7 @@ export function useCredentialsGate(): {
 
   const completeOnboarding = useCallback(async () => {
     if (onboardingBridge) await onboardingBridge.complete();
+    trackFeatureUsed('onboarding', { stage: 'completed' });
     reloadOnboarding();
   }, [onboardingBridge, reloadOnboarding]);
 

--- a/apps/web/src/features/research/CreateResearchDialog.tsx
+++ b/apps/web/src/features/research/CreateResearchDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ResearchCreateResult, ResearchKind } from '@kansoku/core/contract/index';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { errorMessage } from '@web/lib/api';
 import { client } from '@web/lib/client';
 import { easternToday } from '@web/lib/easternDate';
@@ -47,6 +48,7 @@ export function CreateResearchDialog({
           ? { kind: 'stock', symbol: trimmedSymbol }
           : { kind: 'journal', title: trimmedTitle, date },
       );
+      trackFeatureUsed('research_create', { variant: kind });
       navigate(researchRoute(viewForKind(result.document.kind), result.document.path));
       onCreated(result);
       close();

--- a/apps/web/src/features/training/TrainerLauncher.tsx
+++ b/apps/web/src/features/training/TrainerLauncher.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { TrainerErrorCode, TrainerFillPhase, TrainerFillTask, TrainerView } from '@kansoku/pro-api';
+import { trackFeatureUsed } from '@web/lib/analytics';
 import { errorMessage } from '@web/lib/api';
 import { Button } from '@web/ui';
 import { getTrainerBridge } from '../desktop/desktopTrainerBridge';
@@ -174,8 +175,10 @@ export function TrainerLauncher() {
       .open({ basePeriod: BASE_PERIOD })
       .then((result) => {
         if (!active) return;
-        if (result.ok) setSession({ sessionId: result.data.sessionId, view: result.data.view });
-        else setFailure({ code: result.code, message: result.error });
+        if (result.ok) {
+          trackFeatureUsed('training_session', { stage: 'started' });
+          setSession({ sessionId: result.data.sessionId, view: result.data.view });
+        } else setFailure({ code: result.code, message: result.error });
       })
       .catch((error: unknown) => {
         if (active) setFailure({ code: null, message: errorMessage(error) });

--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ANONYMOUS_ID_STORAGE_KEY,
+  configureAnalytics,
+  readAnonymousId,
+  randomUuid,
+  track,
+  trackFeatureUsed,
+  type AnalyticsTransportInput,
+} from './analytics';
+import { analyticsScreenOf } from './analyticsScreen';
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key: string) => map.get(key) ?? null,
+    key: (index: number) => [...map.keys()][index] ?? null,
+    removeItem: (key: string) => map.delete(key),
+    setItem: (key: string, value: string) => map.set(key, value),
+  } as Storage;
+}
+
+function collect(): { sent: AnalyticsTransportInput[]; bodies: () => Record<string, unknown>[] } {
+  const sent: AnalyticsTransportInput[] = [];
+  configureAnalytics({
+    endpoint: 'https://e.example.test/api/events',
+    runtime: 'desktop',
+    appVersion: '0.32.0',
+    anonymousId: '11111111-1111-4111-8111-111111111111',
+    eventId: () => '22222222-2222-4222-8222-222222222222',
+    transport: (input) => sent.push(input),
+  });
+  return {
+    sent,
+    bodies: () => sent.map((input) => JSON.parse(input.body) as Record<string, unknown>),
+  };
+}
+
+afterEach(() => {
+  configureAnalytics({});
+});
+
+describe('track', () => {
+  it('sends the five required fields the Worker validates', () => {
+    const { bodies } = collect();
+
+    track('app_opened', { entry: 'main' });
+
+    expect(bodies()[0]).toEqual({
+      id: '22222222-2222-4222-8222-222222222222',
+      anonymous_id: '11111111-1111-4111-8111-111111111111',
+      event_name: 'app_opened',
+      app_version: '0.32.0',
+      runtime: 'desktop',
+      entry: 'main',
+    });
+  });
+
+  it('omits dimensions that were not supplied rather than sending nulls', () => {
+    const { bodies } = collect();
+
+    trackFeatureUsed('ai_chat', { surface: 'chart' });
+
+    const body = bodies()[0];
+    expect(body.feature).toBe('ai_chat');
+    expect(body.surface).toBe('chart');
+    expect('stage' in body).toBe(false);
+    expect('variant' in body).toBe(false);
+  });
+
+  // The Worker rejects any key outside its allowlist, so an extra field would fail the whole
+  // event rather than being ignored.
+  it('sends no key the ingest allowlist does not carry', () => {
+    const allowed = new Set([
+      'id',
+      'anonymous_id',
+      'event_name',
+      'app_version',
+      'runtime',
+      'entry',
+      'screen',
+      'feature',
+      'stage',
+      'surface',
+      'variant',
+    ]);
+    const { bodies } = collect();
+
+    track('feature_used', {
+      feature: 'chart_drawing',
+      variant: 'fib',
+      stage: 'completed',
+      surface: 'chart',
+      screen: 'chart',
+      entry: 'main',
+    });
+
+    for (const key of Object.keys(bodies()[0])) expect(allowed.has(key)).toBe(true);
+  });
+
+  it('is inert when no endpoint is configured', () => {
+    const sent: AnalyticsTransportInput[] = [];
+    configureAnalytics({ endpoint: '', transport: (input) => sent.push(input) });
+
+    track('app_opened', { entry: 'main' });
+
+    expect(sent).toEqual([]);
+  });
+
+  it('never throws when the transport does', () => {
+    configureAnalytics({
+      endpoint: 'https://e.example.test/api/events',
+      appVersion: '0.32.0',
+      runtime: 'web',
+      anonymousId: '11111111-1111-4111-8111-111111111111',
+      transport: () => {
+        throw new Error('network is down');
+      },
+    });
+
+    expect(() => track('app_opened', { entry: 'main' })).not.toThrow();
+  });
+});
+
+describe('readAnonymousId', () => {
+  it('mints one on first read and reuses it afterwards', () => {
+    const storage = memoryStorage();
+
+    const first = readAnonymousId(storage);
+
+    expect(first).toMatch(/^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i);
+    expect(storage.getItem(ANONYMOUS_ID_STORAGE_KEY)).toBe(first);
+    expect(readAnonymousId(storage)).toBe(first);
+  });
+
+  it('still yields an id when storage is unavailable', () => {
+    expect(readAnonymousId(null)).toMatch(/^[\da-f-]{36}$/i);
+  });
+
+  it('does not fail when storage throws', () => {
+    const hostile = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: vi.fn(),
+    } as unknown as Storage;
+
+    expect(() => readAnonymousId(hostile)).not.toThrow();
+  });
+});
+
+describe('randomUuid', () => {
+  const V4 = /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i;
+
+  it('produces a v4 the Worker pattern accepts', () => {
+    expect(randomUuid()).toMatch(V4);
+  });
+
+  // The ingest regex is strict about the version and variant nibbles, so the fallback path has to
+  // set them itself rather than hand back 16 raw random bytes.
+  it('still produces a valid v4 without crypto.randomUUID', () => {
+    const original = crypto.randomUUID;
+    Reflect.deleteProperty(crypto, 'randomUUID');
+    try {
+      const ids = Array.from({ length: 20 }, () => randomUuid());
+      for (const id of ids) expect(id).toMatch(V4);
+      expect(new Set(ids).size).toBe(ids.length);
+    } finally {
+      Object.defineProperty(crypto, 'randomUUID', { value: original, configurable: true });
+    }
+  });
+});
+
+describe('analyticsScreenOf', () => {
+  it.each([
+    ['/', 'home'],
+    ['/overview', 'overview'],
+    ['/charts', 'charts'],
+    ['/charts/abc123', 'chart'],
+    ['/symbol/NVDA', 'symbol'],
+    ['/symbol/sepa/NVDA', 'sepa_symbol'],
+    ['/popout/symbol/NVDA', 'symbol'],
+    ['/research', 'research'],
+    ['/chat', 'assistant'],
+    ['/training/stats', 'training_stats'],
+    ['/settings', 'settings'],
+    ['/about', 'about'],
+    ['/logs', 'logs'],
+  ])('maps %s to %s', (path, screen) => {
+    expect(analyticsScreenOf(path)).toBe(screen);
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(analyticsScreenOf('/overview/')).toBe('overview');
+  });
+
+  it('falls back to other for anything unrouted', () => {
+    expect(analyticsScreenOf('/nope')).toBe('other');
+  });
+});

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,187 @@
+import { getShellRpc } from '@web/features/desktop/shellRpc';
+
+/**
+ * Mirrors the ingest contract of the kansoku-analytics Worker (`src/event.ts` there). Every field
+ * is an enum it validates against and rejects the whole event on mismatch, so these unions are the
+ * contract, not a convenience — widening one here without widening it there produces a 400 that
+ * nothing surfaces, because delivery is deliberately silent.
+ */
+export type AnalyticsEventName = 'app_opened' | 'screen_viewed' | 'feature_used';
+export type AnalyticsRuntime = 'desktop' | 'web';
+export type AnalyticsEntry = 'main' | 'trainer';
+
+export type AnalyticsScreen =
+  | 'home'
+  | 'overview'
+  | 'charts'
+  | 'chart'
+  | 'symbol'
+  | 'sepa_symbol'
+  | 'research'
+  | 'assistant'
+  | 'training_stats'
+  | 'settings'
+  | 'about'
+  | 'logs'
+  | 'other';
+
+export type AnalyticsFeature =
+  | 'onboarding'
+  | 'market_analysis'
+  | 'deep_research'
+  | 'ai_chat'
+  | 'research_create'
+  | 'chart_drawing'
+  | 'training_session';
+
+export type AnalyticsStage = 'started' | 'completed';
+export type AnalyticsSurface = 'chart' | 'research' | 'assistant';
+export type AnalyticsVariant =
+  | 'stock'
+  | 'journal'
+  | 'hline'
+  | 'trendline'
+  | 'rect'
+  | 'fib'
+  | 'polyline';
+
+interface AnalyticsDimensions {
+  entry?: AnalyticsEntry;
+  screen?: AnalyticsScreen;
+  feature?: AnalyticsFeature;
+  stage?: AnalyticsStage;
+  surface?: AnalyticsSurface;
+  variant?: AnalyticsVariant;
+}
+
+export const ANONYMOUS_ID_STORAGE_KEY = 'trade.analytics.anonymous-id';
+
+/**
+ * `crypto.randomUUID` needs a secure context. The desktop app has one — `app://` is registered
+ * privileged with `secure: true` — but the whole module is fire-and-forget, so a context that
+ * lacks it would report nothing and say nothing. The fallback keeps that from being a silent
+ * outage; the Worker validates the shape, so it has to be a real v4.
+ */
+export function randomUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  bytes[8] = (bytes[8] & 0x3F) | 0x80;
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The device identity, and the only thing about the sender that is stored. It is a random UUID
+ * minted on first send and never derived from anything on the machine, so it identifies a browser
+ * profile and nothing else — clearing site data makes a new device, which is the intended contract.
+ */
+export function readAnonymousId(storage: Storage | null = browserStorage()): string {
+  const fresh = randomUuid();
+  if (!storage) return fresh;
+  try {
+    const stored = storage.getItem(ANONYMOUS_ID_STORAGE_KEY);
+    if (stored) return stored;
+    storage.setItem(ANONYMOUS_ID_STORAGE_KEY, fresh);
+    return fresh;
+  } catch {
+    return fresh;
+  }
+}
+
+export interface AnalyticsTransportInput {
+  endpoint: string;
+  body: string;
+}
+
+function post({ endpoint, body }: AnalyticsTransportInput): void {
+  // keepalive so an event fired as the window closes still leaves; the response is never read,
+  // and a rejection is swallowed by design — see `track`.
+  void fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
+export interface AnalyticsDeps {
+  endpoint?: string;
+  runtime?: AnalyticsRuntime;
+  appVersion?: string;
+  anonymousId?: string;
+  eventId?: () => string;
+  transport?: (input: AnalyticsTransportInput) => void;
+}
+
+let deps: AnalyticsDeps = {};
+
+export function configureAnalytics(next: AnalyticsDeps): void {
+  deps = next;
+}
+
+function endpointOf(): string | null {
+  if (deps.endpoint !== undefined) return deps.endpoint || null;
+  const configured = import.meta.env.VITE_ANALYTICS_ENDPOINT;
+  return typeof configured === 'string' && configured.length > 0 ? configured : null;
+}
+
+function runtimeOf(): AnalyticsRuntime {
+  return deps.runtime ?? (getShellRpc() !== null ? 'desktop' : 'web');
+}
+
+/**
+ * Fire-and-forget by design: analytics must never fail a user action, so nothing here throws,
+ * awaits, or reports. With no endpoint configured the whole module is inert, which is what a
+ * development build and a self-hosted build both get.
+ */
+export function track(name: AnalyticsEventName, dimensions: AnalyticsDimensions = {}): void {
+  const endpoint = endpointOf();
+  if (!endpoint) return;
+  try {
+    const body = JSON.stringify({
+      id: (deps.eventId ?? randomUuid)(),
+      anonymous_id: deps.anonymousId ?? readAnonymousId(),
+      event_name: name,
+      app_version: deps.appVersion ?? __APP_VERSION__,
+      runtime: runtimeOf(),
+      ...dimensions,
+    });
+    (deps.transport ?? post)({ endpoint, body });
+  } catch {
+    // A failure to even assemble the event is still not the user's problem.
+  }
+}
+
+export function trackAppOpened(entry: AnalyticsEntry): void {
+  track('app_opened', { entry });
+}
+
+export function trackScreenViewed(screen: AnalyticsScreen): void {
+  track('screen_viewed', { screen });
+}
+
+export function trackFeatureUsed(
+  feature: AnalyticsFeature,
+  dimensions: Omit<AnalyticsDimensions, 'feature' | 'entry' | 'screen'> = {},
+): void {
+  track('feature_used', { feature, ...dimensions });
+}

--- a/apps/web/src/lib/analyticsScreen.ts
+++ b/apps/web/src/lib/analyticsScreen.ts
@@ -1,0 +1,35 @@
+import type { AnalyticsScreen } from './analytics';
+
+/**
+ * Longest-prefix-first: `/symbol/sepa/NVDA` is a sepa_symbol, not a symbol, and only the order of
+ * these entries keeps it that way. The popout window shows the same symbol page in its own frame,
+ * so it counts as the same screen rather than a thirteenth one the Worker would reject.
+ */
+const PREFIX_SCREENS: readonly (readonly [string, AnalyticsScreen])[] = [
+  ['/symbol/sepa/', 'sepa_symbol'],
+  ['/popout/symbol/', 'symbol'],
+  ['/symbol/', 'symbol'],
+  ['/charts/', 'chart'],
+  ['/training/stats', 'training_stats'],
+];
+
+const EXACT_SCREENS: Readonly<Record<string, AnalyticsScreen>> = {
+  '/': 'home',
+  '/overview': 'overview',
+  '/charts': 'charts',
+  '/research': 'research',
+  '/chat': 'assistant',
+  '/settings': 'settings',
+  '/about': 'about',
+  '/logs': 'logs',
+};
+
+export function analyticsScreenOf(pathname: string): AnalyticsScreen {
+  const path = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  const exact = EXACT_SCREENS[path];
+  if (exact) return exact;
+  for (const [prefix, screen] of PREFIX_SCREENS) {
+    if (path.startsWith(prefix)) return screen;
+  }
+  return 'other';
+}

--- a/apps/web/src/lib/useScreenAnalytics.ts
+++ b/apps/web/src/lib/useScreenAnalytics.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { trackFeatureUsed, trackScreenViewed } from './analytics';
+import { analyticsScreenOf } from './analyticsScreen';
+import { routePathname, useRoute } from './router';
+
+/**
+ * One event per screen the trader lands on, not per navigation: several routes collapse onto the
+ * same screen (every `/charts/:id` is `chart`), and paging through them is one visit to that
+ * screen rather than a dozen. Deduping here rather than in the Worker keeps the daily event count
+ * proportional to what someone actually looked at.
+ */
+export function useScreenAnalytics(): void {
+  const route = useRoute();
+  const screen = analyticsScreenOf(routePathname(route));
+  const sent = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (sent.current === screen) return;
+    sent.current = screen;
+    trackScreenViewed(screen);
+  }, [screen]);
+}
+
+/**
+ * Fires once per launch that lands on the gate, so the pair with `completed` reads as a funnel:
+ * how many first runs reached setup against how many got through it. Gated on a ref rather than
+ * on mount because the gate re-renders as each credential check resolves.
+ */
+export function useOnboardingAnalytics(shown: boolean): void {
+  const sent = useRef(false);
+
+  useEffect(() => {
+    if (!shown || sent.current) return;
+    sent.current = true;
+    trackFeatureUsed('onboarding', { stage: 'started' });
+  }, [shown]);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,11 +1,15 @@
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { trackAppOpened } from './lib/analytics';
 import { persistOptions, queryClient } from './lib/queryClient';
 import { installRouter } from './lib/router';
 import './styles.css';
 
 installRouter();
+// At module scope rather than in an effect: this counts page loads, and React would double-fire
+// it in development's strict mode.
+trackAppOpened('main');
 createRoot(document.getElementById('root')!).render(
   <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
     <App />

--- a/apps/web/src/train-entry.tsx
+++ b/apps/web/src/train-entry.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { TrainerLauncher } from './features/training/TrainerLauncher';
+import { trackAppOpened } from './lib/analytics';
 import './styles.css';
 
+trackAppOpened('trainer');
 createRoot(document.getElementById('root')!).render(<TrainerLauncher />);


### PR DESCRIPTION
`e.kansoku.trade` 这个 Worker 从 7/29 就活着，后面挂着一个 D1 库 —— 而 **events 表是空的**。仓里没有任何代码给它发过东西，`VITE_ANALYTICS_ENDPOINT` 这个仓变量既没有任何 workflow 引用、也没有任何源码读取。dashboard 一直是一条跑在零行数据上的正确查询。

本 PR 把客户端补上。

## 契约为什么写成联合类型而不是字符串

Worker 的校验很严：每个维度都是闭合枚举，出现任何白名单外的 key 直接整条拒绝，而且三个枚举按 event_name 条件必填（`app_opened` 要 `entry`、`screen_viewed` 要 `screen`、`feature_used` 要 `feature`）。

投递是**故意静默**的，所以单方面放宽这边的类型只会换来一个没人看得见的 400。把契约钉成类型，让这种错在 typecheck 就炸。

## 静默是设计，不是偷懒

模块里没有任何 throw、await 或上报路径；端点没配就整体惰性 —— 开发构建、fork、自托管构建拿到的都是这个状态。埋点绝不该让用户的操作失败。

## 只有正式发版接端点

分支构建和 nightly **故意不接**：schema 里没有区分构建渠道的维度，测试流量混进 dau/mau 之后再也分不出来。

变量放在 workflow 顶层 env 而不是 build 步骤上 —— 这个 job 会构建两次 web（显式一次，`pnpm package` 经 apps/desktop 的 prepackage 钩子再一次），按步骤给的话第二次构建会把它悄悄剥掉。

## crypto.randomUUID 的兜底

它需要安全上下文。桌面端是有的（`app://` 注册了 `secure: true`，已核对）。但一个 fire-and-forget 的模块赌输了就是「什么都不报也什么都不说」，所以 id 生成器自带 v4 兜底而不是依赖这个前提。

## 埋在哪

每处都取最窄的共享点，而不是逐个 UI 组件：

| 事件 | 位置 | 说明 |
| --- | --- | --- |
| `app_opened` | `main.tsx` / `train-entry.tsx` | 模块作用域，一次页面加载一次；放 effect 里会被 StrictMode 打两次 |
| `screen_viewed` | `useScreenAnalytics` | 按 screen 去重，不是按导航 —— 翻十个 `/charts/:id` 是一次 `chart` |
| `ai_chat` | `useConversationSession` | 它的 `ConversationKind` 恰好就是 `surface` 枚举，一处覆盖 chart/research/assistant |
| `chart_drawing` | `setActiveTool` | 工具栏和快捷键都走这里；`measure` 在 ingest 枚举里没有 variant，因此只报 feature 不报 variant |
| `deep_research` | `useDeepDive` | started / completed 成对，两个数一比就知道多少次跑没跑到报告 |
| `market_analysis` | `useReassessSymbol` + `SymbolActions` | 这两个是仓里仅有的两个 reassess 调用点 |
| `research_create` | `CreateResearchDialog` | `kind` 直接就是 variant（stock/journal） |
| `training_session` | `TrainerLauncher` | 开局成功才记 |
| `onboarding` | `useCredentialsGate` + `useOnboardingAnalytics` | started/completed 成对，可以当漏斗读 |

## 验证

- 25 个新单测；`apps/web` 全量 166 文件 / 1220 测试通过；typecheck 干净；改动文件 eslint 无 error
- **对生产 Worker 实打了客户端会发的全部 7 种形态，全部 202**，包括 `measure` 那个不带 variant 的
- D1 里确认 7 行落库，字段与预期完全一致，**随后已全部删除**；删完 `SELECT COUNT(*)` 为 0 —— 这同时坐实了此前那张表确实一行都没有