### PR TITLE
feat(chat): resizable ai chat sidebar with stable collapse layout

### DIFF
--- a/apps/web/src/features/assistant/AssistantChatPage.tsx
+++ b/apps/web/src/features/assistant/AssistantChatPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ResearchDocumentMeta } from '@kansoku/core/contract/index';
 import { canvasSlugFromResearchPath } from '@kansoku/core/contract/index';
 import * as stylex from '@stylexjs/stylex';
@@ -23,14 +23,13 @@ import {
 import type { MentionCandidate } from './atMention.js';
 import { resolveActiveSessionId } from './assistantPageState.js';
 import { useAssistantSessions } from './useAssistantSessions';
-import { colors, radii, sizes } from '../../theme/tokens.stylex';
+import { colors, radii } from '../../theme/tokens.stylex';
 
 const styles = stylex.create({
   page: {
     'backgroundColor': colors.backgroundCanvas,
     'color': colors.textPrimary,
     'display': 'grid',
-    'gridTemplateColumns': `${sizes.sidebarWidth} 1fr`,
     'height': '100cqh',
     'minHeight': 0,
     'overflow': 'hidden',
@@ -39,14 +38,50 @@ const styles = stylex.create({
       transition: 'none',
     },
   },
-  pageCollapsed: {
-    gridTemplateColumns: '0px 1fr',
+  pageResizing: {
+    transition: 'none',
+    userSelect: 'none',
   },
   sidebarSlot: {
     display: 'flex',
     minHeight: 0,
     minWidth: 0,
     overflow: 'hidden',
+  },
+  sidebarStable: {
+    display: 'flex',
+    flex: '0 0 auto',
+    minHeight: 0,
+  },
+  resizeHandle: {
+    'bottom': 0,
+    'cursor': 'col-resize',
+    'left': '-3px',
+    'position': 'absolute',
+    'top': 0,
+    'touchAction': 'none',
+    'width': '6px',
+    'zIndex': 2,
+    '::after': {
+      backgroundColor: colors.borderStrong,
+      bottom: 0,
+      content: '""',
+      left: '2px',
+      opacity: 0,
+      position: 'absolute',
+      top: 0,
+      transition: 'opacity 0.12s ease',
+      width: '2px',
+    },
+    ':hover::after': {
+      opacity: 1,
+    },
+  },
+  resizeHandleActive: {
+    '::after': {
+      backgroundColor: colors.accent,
+      opacity: 1,
+    },
   },
   emptyToggle: {
     left: '8px',
@@ -75,6 +110,31 @@ const styles = stylex.create({
 });
 
 const SIDEBAR_COLLAPSED_KEY = 'assistant.sidebar-collapsed';
+const SIDEBAR_WIDTH_KEY = 'assistant.sidebar-width';
+const SIDEBAR_WIDTH_DEFAULT = 340;
+const SIDEBAR_WIDTH_MIN = 240;
+const SIDEBAR_WIDTH_MAX = 520;
+
+function clampSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_WIDTH_MAX, Math.max(SIDEBAR_WIDTH_MIN, Math.round(width)));
+}
+
+function readSidebarWidth(): number {
+  try {
+    const stored = Number(window.localStorage.getItem(SIDEBAR_WIDTH_KEY));
+    return Number.isFinite(stored) && stored > 0 ? clampSidebarWidth(stored) : SIDEBAR_WIDTH_DEFAULT;
+  } catch {
+    return SIDEBAR_WIDTH_DEFAULT;
+  }
+}
+
+function writeSidebarWidth(width: number): void {
+  try {
+    window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  } catch {
+    /* storage unavailable */
+  }
+}
 
 function readSidebarCollapsed(): boolean {
   try {
@@ -119,6 +179,39 @@ export function AssistantChatPage() {
   const [modelError, setModelError] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
   const [composerFocusRequest, setComposerFocusRequest] = useState(0);
+  const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
+  const [resizing, setResizing] = useState(false);
+  const pageRef = useRef<HTMLDivElement>(null);
+
+  const startResize = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const handle = event.currentTarget;
+    const pageLeft = pageRef.current?.getBoundingClientRect().left ?? 0;
+    handle.setPointerCapture(event.pointerId);
+    setResizing(true);
+    const onMove = (moveEvent: PointerEvent) => {
+      setSidebarWidth(clampSidebarWidth(moveEvent.clientX - pageLeft));
+    };
+    const onUp = () => {
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', onUp);
+      handle.removeEventListener('pointercancel', onUp);
+      setResizing(false);
+      setSidebarWidth((current) => {
+        writeSidebarWidth(current);
+        return current;
+      });
+    };
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onUp);
+  }, []);
+
+  const resetSidebarWidth = useCallback(() => {
+    setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
+    writeSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
+  }, []);
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed((current) => {
       writeSidebarCollapsed(!current);
@@ -209,9 +302,12 @@ export function AssistantChatPage() {
 
   return (
     <div
-      className={`fullpage ${stylex.props(styles.page, desktopShell && styles.pageDesktop, sidebarCollapsed && styles.pageCollapsed).className}`}
+      ref={pageRef}
+      className={`fullpage ${stylex.props(styles.page, desktopShell && styles.pageDesktop, resizing && styles.pageResizing).className}`}
+      style={{ gridTemplateColumns: `${sidebarCollapsed ? 0 : sidebarWidth}px 1fr` }}
     >
       <div {...stylex.props(styles.sidebarSlot)} aria-hidden={sidebarCollapsed} inert={sidebarCollapsed}>
+        <div {...stylex.props(styles.sidebarStable)} style={{ width: `${sidebarWidth}px` }}>
         <AssistantSessionList
           sessions={sessions}
           activeId={activeId}
@@ -223,8 +319,19 @@ export function AssistantChatPage() {
           onDelete={(id) => void handleDelete(id)}
           onCollapse={toggleSidebar}
         />
+        </div>
       </div>
       <div {...stylex.props(styles.main)}>
+        {sidebarCollapsed ? null : (
+          <div
+            {...stylex.props(styles.resizeHandle, resizing && styles.resizeHandleActive)}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="调整侧边栏宽度"
+            onPointerDown={startResize}
+            onDoubleClick={resetSidebarWidth}
+          />
+        )}
         {activeId ? (
           <AssistantConversation
             key={activeId}

--- a/apps/web/src/features/assistant/AssistantSessionList.tsx
+++ b/apps/web/src/features/assistant/AssistantSessionList.tsx
@@ -14,7 +14,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     minHeight: 0,
     overflow: 'hidden',
-    width: sizes.sidebarWidth,
+    width: '100%',
   },
   head: {
     alignItems: 'center',


### PR DESCRIPTION
AI 对话页左侧会话栏现在可以拖拽调宽（240–520px，双击复位 340），宽度存 localStorage。

折叠改成 lobe-ui 那种 stable layout：外层 overflow hidden + 内层固定宽度，折叠时整块滑出，内容不再被挤扁。

验证：`pnpm --filter @kansoku/web typecheck` 通过，改动文件 eslint 无 error。

https://claude.ai/code/session_015fPmJu5o3LXmuKWDBLG85M