### PR TITLE
feat(desktop): 连续增量更新和下载进度

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -353,11 +353,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: sign, generate appcast, and publish GitHub Release (electron-sparkle-updater)
-        uses: Innei/electron-sparkle-updater/action@v1
+        uses: Innei/electron-sparkle-updater/action@v0.4.0
         with:
           tag: ${{ steps.version.outputs.tag }}
           repo: ${{ env.REPO_SLUG }}
           tag-prefix: 'desktop-v'
+          delta-bases: '2'
+          delta-history: '6'
           archive-dir: ${{ steps.archive.outputs.dir }}
           ed-private-key: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
           publish: 'true'

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -47,6 +47,7 @@ files:
   - '!**/node_modules/electron-sparkle-updater/native/scripts/**'
   - '!**/node_modules/electron-sparkle-updater/native/src/**'
   - '!**/node_modules/electron-sparkle-updater/native/vendor/**'
+  - '!**/node_modules/electron-sparkle-updater/native/sparkle-chain.tar.xz'
 extraResources:
   - from: ../web/dist
     to: web-dist
@@ -116,6 +117,7 @@ mac:
     SUPublicEDKey: SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER
     SUEnableInstallerLauncherService: false
     SUScheduledCheckInterval: 3600
+    SUDeltaChainHistory: 6
     CFBundleURLTypes:
       - CFBundleURLName: dev.innei.kansoku
         CFBundleURLSchemes:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
   "main": "dist-main/main.mjs",
   "scripts": {
     "build": "vite build -c vite.main.config.ts --configLoader runner && vite build -c vite.preload.config.ts",
-    "build:native": "npx electron-sparkle-updater rebuild --electron-version 43.1.0 --arch arm64",
+    "build:native": "npx electron-sparkle-updater rebuild --arch arm64",
     "predev": "node scripts/ensureDevNative.mjs",
     "dev": "node scripts/dev.mjs",
     "generate-icon": "bash scripts/generate-icon.sh",
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "electron-sparkle-updater": "^0.3.0",
+    "electron-sparkle-updater": "^0.4.0",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/apps/desktop/src/shell/updater/status.ts
+++ b/apps/desktop/src/shell/updater/status.ts
@@ -1,7 +1,13 @@
 export type UpdaterUiStatus =
   | { kind: 'unknown' }
   | { kind: 'up-to-date'; current: string; latest: string }
-  | { kind: 'available'; version: string; htmlUrl: string }
+  | {
+      kind: 'available';
+      version: string;
+      htmlUrl: string;
+      phase?: 'downloading' | 'preparing' | 'ready';
+      percent?: number;
+    }
   | { kind: 'error'; message: string };
 
 export type CheckResultForStatus =
@@ -15,6 +21,8 @@ export function applyCheckResult(
   prev: UpdaterUiStatus,
   result: CheckResultForStatus,
 ): UpdaterUiStatus {
+  // A background GitHub check must not replace an in-progress native update.
+  if (prev.kind === 'available' && prev.phase) return prev;
   switch (result.kind) {
     case 'available': {
       return {
@@ -87,7 +95,13 @@ function sameStatus(a: UpdaterUiStatus, b: UpdaterUiStatus): boolean {
       return b.kind === 'up-to-date' && a.current === b.current && a.latest === b.latest;
     }
     case 'available': {
-      return b.kind === 'available' && a.version === b.version && a.htmlUrl === b.htmlUrl;
+      return (
+        b.kind === 'available' &&
+        a.version === b.version &&
+        a.htmlUrl === b.htmlUrl &&
+        a.phase === b.phase &&
+        a.percent === b.percent
+      );
     }
     case 'error': {
       return b.kind === 'error' && a.message === b.message;

--- a/apps/desktop/src/shell/updater/updater.ts
+++ b/apps/desktop/src/shell/updater/updater.ts
@@ -104,6 +104,52 @@ export function createUpdaterHandle(options: {
       });
     });
 
+  if (options.mode === 'sparkle' && options.sparkleBridge) {
+    options.sparkleBridge.setEventHandler((event) => {
+      const current = statusStore.get();
+      switch (event.type) {
+        case 'update-available':
+        case 'update-downloaded': {
+          const version =
+            event.version ?? (current.kind === 'available' ? current.version : undefined);
+          if (!version) break;
+          statusStore.set({
+            kind: 'available',
+            version,
+            htmlUrl:
+              current.kind === 'available' && current.version === version
+                ? current.htmlUrl
+                : `https://github.com/${OWNER_REPO}/releases/tag/${TAG_PREFIX}${encodeURIComponent(version)}`,
+            ...(event.type === 'update-downloaded' ? { phase: 'ready' as const } : {}),
+          });
+          break;
+        }
+        case 'download-progress': {
+          if (current.kind !== 'available') break;
+          const percent =
+            typeof event.percent === 'number' && Number.isFinite(event.percent)
+              ? Math.min(100, Math.max(0, event.percent))
+              : undefined;
+          statusStore.set({
+            ...current,
+            phase: percent === 100 ? 'preparing' : 'downloading',
+            percent,
+          });
+          break;
+        }
+        case 'update-not-available': {
+          statusStore.set({ kind: 'unknown' });
+          break;
+        }
+        case 'error': {
+          statusStore.set({ kind: 'error', message: event.message ?? '更新失败' });
+          log(`sparkle update failed: ${event.message ?? 'unknown error'}`);
+          break;
+        }
+      }
+    });
+  }
+
   let silentCheckInFlight = false;
 
   const applyResult = (result: CheckForUpdateResult) => {
@@ -213,6 +259,12 @@ export function createUpdaterHandle(options: {
       }
 
       if (options.mode === 'sparkle' && options.sparkleBridge) {
+        const current = statusStore.get();
+        if (
+          current.kind === 'available' &&
+          (current.phase === 'downloading' || current.phase === 'preparing')
+        )
+          return;
         try {
           options.sparkleBridge.installUpdateNow();
         } catch (err) {

--- a/apps/desktop/test/updater/updater.test.ts
+++ b/apps/desktop/test/updater/updater.test.ts
@@ -55,6 +55,50 @@ describe('startUpdater', () => {
 });
 
 describe('createUpdaterHandle', () => {
+  it('tracks the final target through native preparation without a GitHub check replacing it', async () => {
+    const bridge = mockBridge();
+    const store = createUpdaterStatusStore();
+    const handle = createUpdaterHandle({
+      mode: 'sparkle',
+      sparkleBridge: bridge,
+      statusStore: store,
+      showMessage: vi.fn(),
+      runWeakCheck: vi
+        .fn()
+        .mockResolvedValue({
+          kind: 'available',
+          release: { version: '0.43.0', htmlUrl: 'https://example.com/new' },
+        }),
+    });
+    const emit = vi.mocked(bridge.setEventHandler).mock.calls[0]![0];
+    emit({ type: 'update-available', version: '0.42.0' });
+    emit({ type: 'download-progress', percent: 40 });
+    expect(handle.getStatus()).toMatchObject({
+      kind: 'available',
+      version: '0.42.0',
+      phase: 'downloading',
+      percent: 40,
+    });
+    handle.installNow();
+    expect(bridge.installUpdateNow).not.toHaveBeenCalled();
+    handle.silentCheckOnActivate();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handle.getStatus()).toMatchObject({ version: '0.42.0', phase: 'downloading' });
+    emit({ type: 'download-progress', percent: 100 });
+    expect(handle.getStatus()).toMatchObject({ phase: 'preparing' });
+    // A full-download fallback starts a fresh progress range for the same target.
+    emit({ type: 'download-progress', percent: 3 });
+    expect(handle.getStatus()).toMatchObject({
+      version: '0.42.0',
+      phase: 'downloading',
+      percent: 3,
+    });
+    emit({ type: 'update-downloaded', version: '0.42.0' });
+    expect(handle.getStatus()).toMatchObject({ version: '0.42.0', phase: 'ready' });
+    handle.installNow();
+    expect(bridge.installUpdateNow).toHaveBeenCalledOnce();
+  });
+
   it('shows a dev dialog and does not touch sparkle or weak check', () => {
     const showMessage = vi.fn();
     const bridge = mockBridge();

--- a/apps/web/src/features/desktop/DesktopTitlebar.tsx
+++ b/apps/web/src/features/desktop/DesktopTitlebar.tsx
@@ -4,6 +4,7 @@ import * as stylex from '@stylexjs/stylex';
 import {
   ArrowUpCircle,
   Circle,
+  Download,
   LayoutDashboard,
   Library,
   MessageCircle,
@@ -457,6 +458,16 @@ export function DesktopTitlebar({ controller }: { controller: TabsController }) 
   } = controller;
   const updaterStatus = useUpdaterStatus();
   const showUpdateBadge = isAvailableStatus(updaterStatus);
+  const update = updaterStatus?.kind === 'available' ? updaterStatus : null;
+  const updateBusy = update?.phase === 'downloading' || update?.phase === 'preparing';
+  const updateLabel =
+    update?.phase === 'downloading'
+      ? `正在下载更新${update.percent === undefined ? '' : ` ${Math.floor(update.percent)}%`}`
+      : update?.phase === 'preparing'
+        ? '正在准备更新'
+        : update?.phase === 'ready'
+          ? '重启并安装更新'
+          : '有更新可用';
   const activeSymbol = symbolFromRoute(controller.activeTab.route);
   const { pro, licensed } = useCapabilities();
   const trainerBridge = getOpenTrainerBridge();
@@ -561,13 +572,15 @@ export function DesktopTitlebar({ controller }: { controller: TabsController }) 
           <button
             className={classNames('desktop-update-badge', styles.updateBadge)}
             type="button"
-            aria-label="有更新可用"
-            title="有更新可用"
+            aria-label={updateLabel}
+            title={updateLabel}
+            disabled={updateBusy}
+            aria-busy={updateBusy}
             onClick={() => {
               void getDesktopUpdaterBridge()?.installNow();
             }}
           >
-            <ArrowUpCircle size={16} />
+            {updateBusy ? <Download size={16} /> : <ArrowUpCircle size={16} />}
           </button>
         )}
         {activeSymbol && <PopoutTitlebarButton symbol={activeSymbol} />}

--- a/apps/web/src/features/desktop/desktopUpdater.ts
+++ b/apps/web/src/features/desktop/desktopUpdater.ts
@@ -3,7 +3,13 @@ import { getShellRpc } from './shellRpc';
 export type UpdaterUiStatus =
   | { kind: 'unknown' }
   | { kind: 'up-to-date'; current: string; latest: string }
-  | { kind: 'available'; version: string; htmlUrl: string }
+  | {
+      kind: 'available';
+      version: string;
+      htmlUrl: string;
+      phase?: 'downloading' | 'preparing' | 'ready';
+      percent?: number;
+    }
   | { kind: 'error'; message: string };
 
 export interface DesktopUpdaterBridge {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@lobehub/eslint-config": "^2.1.5",
     "@lobehub/prettier-config": "^2.1.5",
     "concurrently": "^10.0.5",
-    "electron-sparkle-updater": "0.3.0",
+    "electron-sparkle-updater": "0.4.0",
     "eslint": "^10.10.0",
     "prettier": "^3.9.6",
     "prettier-plugin-packagejson": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^10.0.5
         version: 10.0.5
       electron-sparkle-updater:
-        specifier: 0.3.0
-        version: 0.3.0(electron@44.2.0)
+        specifier: 0.4.0
+        version: 0.4.0(electron@44.2.0)
       eslint:
         specifier: ^10.10.0
         version: 10.10.0(jiti@2.7.0)
@@ -54,8 +54,8 @@ importers:
   apps/desktop:
     dependencies:
       electron-sparkle-updater:
-        specifier: ^0.3.0
-        version: 0.3.0(electron@44.2.0)
+        specifier: ^0.4.0
+        version: 0.4.0(electron@44.2.0)
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -4728,8 +4728,8 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
-  electron-sparkle-updater@0.3.0:
-    resolution: {integrity: sha512-4wR351ieXCN8gPHqf50r5v7yYVofy1nd7fDQv72N19zyR2A76enJW7US5upERLSlexnbxhVXe/cXXqXeakNS/A==}
+  electron-sparkle-updater@0.4.0:
+    resolution: {integrity: sha512-8QSlL7tkejD2LtAh1XtydzQ04dLc/KGYVIZP2t3pbtTR12eQ5mTiEe6rGCukq8ZdcHQ+5BNmj3lPBKWscJpneg==}
     engines: {node: '>=20.19'}
     hasBin: true
     peerDependencies:
@@ -12287,7 +12287,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-sparkle-updater@0.3.0(electron@44.2.0):
+  electron-sparkle-updater@0.4.0(electron@44.2.0):
     dependencies:
       node-addon-api: 8.9.2
       node-gyp: 13.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ minimumReleaseAgeExclude:
   - '@earendil-works/pi-agent-core@0.80.6 || 0.84.1'
   - '@innei/message-engine@0.2.0 || 0.4.0 || 0.4.1'
   - tsdown@0.22.5
-  - electron-sparkle-updater@0.1.0
+  - electron-sparkle-updater@0.1.0 || 0.4.0
   - astro@7.1.3
   - marked@18.0.7
   - '@vibeloft/telemetry-electron@0.1.0'


### PR DESCRIPTION
更新下载现在显示累计进度，准备完成后才能重启安装，后台版本检查不会覆盖正在更新的状态。接入 electron-sparkle-updater 0.4.0：每次发布只生成两个直接差分包，保留最近六个版本的历史链接，客户端连续打补丁后只安装一次，异常时回退完整包。

Action 固定到 v0.4.0，原生桥接按实际安装的 Electron 版本编译。正式 npm 包安装和原生编译、18 项更新测试及桌面/Web 类型检查通过。

本 PR 保持桌面版本 0.42.0，发版版本和更新日志另行提交。
